### PR TITLE
[macOS] remove go-1.16.x

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -280,7 +280,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.16.*",
                 "1.17.*",
                 "1.18.*",
                 "1.19.*"

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -213,7 +213,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.16.*",
                 "1.17.*",
                 "1.18.*",
                 "1.19.*"


### PR DESCRIPTION
# Description

According to our [Software and image guidelines](https://github.com/actions/virtual-environments/blob/main/docs/software-and-images-guidelines.md)
we support [3 latest minor versions of Go],
(https://endoflife.date/go) which are 1.17, 1.18 & 1.19 at the moment.

#### Related issue: https://github.com/actions/runner-images/issues/6024

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
