### PR TITLE
[Packer] Disable colored output on Ubuntu

### DIFF
--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -53,6 +53,7 @@ packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
                 -var "virtual_network_resource_group_name=$VirtualNetworkRG" `
                 -var "virtual_network_subnet_name=$VirtualNetworkSubnet" `
                 -var "run_validation_diskspace=$env:RUN_VALIDATION_FLAG" `
+                -color=false `
                 $TemplatePath `
         | Where-Object {
             #Filter sensitive data from Packer logs


### PR DESCRIPTION
# Description

It looks like we missed this flag on linux/windows ci as it is explicitly disabled on macOS, otherwise the log looks like we are
celebrating a new year (not yet), found it on Actions.

Example: 
<img width="862" alt="image" src="https://user-images.githubusercontent.com/88318005/184087798-19985b35-7af8-4aac-ac4f-8b5940c59596.png">


#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
