### PR TITLE
[all OSs] Change title in workflow log

### DIFF
--- a/images/linux/scripts/installers/preimagedata.sh
+++ b/images/linux/scripts/installers/preimagedata.sh
@@ -19,7 +19,7 @@ cat <<EOF > $imagedata_file
     "detail": "${os_name}"
   },
   {
-    "group": "Runner Image",
+    "group": "Image",
     "detail": "Label: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
   }
 ]

--- a/images/linux/scripts/installers/preimagedata.sh
+++ b/images/linux/scripts/installers/preimagedata.sh
@@ -19,8 +19,8 @@ cat <<EOF > $imagedata_file
     "detail": "${os_name}"
   },
   {
-    "group": "Image",
-    "detail": "Label: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
+    "group": "Runner Image",
+    "detail": "Image: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
   }
 ]
 EOF

--- a/images/linux/scripts/installers/preimagedata.sh
+++ b/images/linux/scripts/installers/preimagedata.sh
@@ -19,7 +19,7 @@ cat <<EOF > $imagedata_file
     "detail": "${os_name}"
   },
   {
-    "group": "Virtual Environment",
+    "group": "Runner Image",
     "detail": "Environment: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
   }
 ]

--- a/images/linux/scripts/installers/preimagedata.sh
+++ b/images/linux/scripts/installers/preimagedata.sh
@@ -20,7 +20,7 @@ cat <<EOF > $imagedata_file
   },
   {
     "group": "Runner Image",
-    "detail": "Environment: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
+    "detail": "Label: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
   }
 ]
 EOF

--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -25,8 +25,8 @@ cat <<EOF > $imagedata_file
         "detail": "${os_name}\n${os_version}\n${os_build}"
       },
       {
-        "group": "Runner Image",
-        "detail": "Environment: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
+        "group": "Image",
+        "detail": "Label: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
       }
     ]
 EOF

--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -25,7 +25,7 @@ cat <<EOF > $imagedata_file
         "detail": "${os_name}\n${os_version}\n${os_build}"
       },
       {
-        "group": "Virtual Environment",
+        "group": "Runner Image",
         "detail": "Environment: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
       }
     ]

--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -25,8 +25,8 @@ cat <<EOF > $imagedata_file
         "detail": "${os_name}\n${os_version}\n${os_build}"
       },
       {
-        "group": "Image",
-        "detail": "Label: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
+        "group": "Runner Image",
+        "detail": "Image: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
       }
     ]
 EOF

--- a/images/win/scripts/Installers/Update-ImageData.ps1
+++ b/images/win/scripts/Installers/Update-ImageData.ps1
@@ -26,8 +26,8 @@ $json = @"
     "detail": "${osName}\n${osVersion}\n${osEdition}"
   },
   {
-    "group": "Image",
-    "detail": "Label: ${imageLabel}\nVersion: ${imageVersion}\nIncluded Software: ${softwareUrl}\nImage Release: ${releaseUrl}"
+    "group": "Runner Image",
+    "detail": "Image: ${imageLabel}\nVersion: ${imageVersion}\nIncluded Software: ${softwareUrl}\nImage Release: ${releaseUrl}"
   }
 ]
 "@

--- a/images/win/scripts/Installers/Update-ImageData.ps1
+++ b/images/win/scripts/Installers/Update-ImageData.ps1
@@ -26,8 +26,8 @@ $json = @"
     "detail": "${osName}\n${osVersion}\n${osEdition}"
   },
   {
-    "group": "Runner Image",
-    "detail": "Environment: ${imageLabel}\nVersion: ${imageVersion}\nIncluded Software: ${softwareUrl}\nImage Release: ${releaseUrl}"
+    "group": "Image",
+    "detail": "Label: ${imageLabel}\nVersion: ${imageVersion}\nIncluded Software: ${softwareUrl}\nImage Release: ${releaseUrl}"
   }
 ]
 "@

--- a/images/win/scripts/Installers/Update-ImageData.ps1
+++ b/images/win/scripts/Installers/Update-ImageData.ps1
@@ -26,7 +26,7 @@ $json = @"
     "detail": "${osName}\n${osVersion}\n${osEdition}"
   },
   {
-    "group": "Virtual Environment",
+    "group": "Runner Image",
     "detail": "Environment: ${imageLabel}\nVersion: ${imageVersion}\nIncluded Software: ${softwareUrl}\nImage Release: ${releaseUrl}"
   }
 ]


### PR DESCRIPTION
# Description
Recently we changed name of our repo to 'runner-images'. This PR changes group title 'Virtual Environment' in workflow logs to 'Runner Image' to be consistent with new repo name.

#### Related issue:
https://github.com/actions/runner-images/pull/6006
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
