### PR TITLE
[Windows] remove vcredist_2010_x64 duplicate test

### DIFF
--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -160,11 +160,10 @@ Describe "Vcpkg" {
 }
 
 Describe "VCRedist" -Skip:(Test-IsWin22) {
-    It "vcredist_2010_x64" {
-        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
-        "C:\Windows\System32\msvcr100.dll" | Should -Exist
+    It "vcredist_140" -Skip:(Test-IsWin19) {
+        "C:\Windows\System32\vcruntime140.dll" | Should -Exist
     }
-
+    
     It "vcredist_2010_x64" {
         "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
         "C:\Windows\System32\msvcr100.dll" | Should -Exist

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -160,10 +160,6 @@ Describe "Vcpkg" {
 }
 
 Describe "VCRedist" -Skip:(Test-IsWin22) {
-    It "vcredist_140" -Skip:(Test-IsWin19) {
-        "C:\Windows\System32\vcruntime140.dll" | Should -Exist
-    }
-    
     It "vcredist_2010_x64" {
         "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
         "C:\Windows\System32\msvcr100.dll" | Should -Exist


### PR DESCRIPTION
# Description
Remove `vcredist_2010_x64` duplication - I would have expect a `vcredist_2010_x86` test, but it does just not exist.


#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
