### PR TITLE
[macOS] Update python3 to 3.10 version

### DIFF
--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -20,7 +20,7 @@ fi
 # Explicitly overwrite symlinks created by Python2 such as /usr/local/bin/2to3 since they conflict with symlinks from Python3
 # https://github.com/actions/runner-images/issues/2322
 echo "Brew Installing Python 3"
-brew_smart_install "python@3.9" || brew link --overwrite python@3.9
+brew_smart_install "python@3.10" || brew link --overwrite python@3.10
 
 echo "Installing pipx"
 export PIPX_BIN_DIR=/usr/local/opt/pipx_bin


### PR DESCRIPTION
# Description
- Update default python version from 3.9 to 3.10

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4188

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
