### PR TITLE
[Windows] Add Component.Xamarin for Visual Studio 2022

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -185,6 +185,7 @@
             "Component.Linux.CMake",
             "Component.UnityEngine.x64",
             "Component.Unreal.Android",
+            "Component.Xamarin",
             "Microsoft.Component.VC.Runtime.UCRTSDK",
             "Microsoft.Net.Component.4.7.TargetingPack",
             "Microsoft.Net.Component.4.7.2.TargetingPack",


### PR DESCRIPTION
# Description
Component.Xamarin VS component is optional by default for Visual Studio 2022 since version 17.3. We should add it back.

#### Related issue:
https://github.com/actions/runner-images/issues/6082

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
