### PR TITLE
[Ubuntu] Set max_retries to 3

### DIFF
--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -321,8 +321,12 @@
         },
         {
             "type": "shell",
+            "max_retries": 3,
+            "start_retry_timeout": "2m",
             "inline": [
+                "pwsh -Command Write-Host Running SoftwareReport.Generator.ps1 script",
                 "pwsh -File {{user `image_folder`}}/SoftwareReport/SoftwareReport.Generator.ps1 -OutputDirectory {{user `image_folder`}}",
+                "pwsh -Command Write-Host Running RunAll-Tests.ps1 script",
                 "pwsh -File {{user `image_folder`}}/tests/RunAll-Tests.ps1 -OutputDirectory {{user `image_folder`}}"
             ],
             "environment_vars": [


### PR DESCRIPTION
# Description
Time to time we get the error `Script disconnected unexpectedly` during packer provisioner stage on Ubuntu Server 20.04 - https://github.visualstudio.com/virtual-environments/_build/results?buildId=128407&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043

```
==> azure-arm: Provisioning with shell script: C:\agent\_work\18\s\images\linux/scripts/base/apt-mock-remove.sh
==> azure-arm: Provisioning with shell script: C:\Windows\SERVIC~2\NETWOR~1\AppData\Local\Temp\packer-shell4207490466
==> azure-arm: Provisioning step had errors: Running the cleanup provisioner, if present...
==> azure-arm: 
==> azure-arm: Deleting individual resources ...
Build 'azure-arm' errored after 1 hour 24 minutes: Script disconnected unexpectedly. If you expected your script to disconnect, i.e. from a restart, you can try adding `"expect_disconnect": true` or `"valid_exit_codes": [0, 2300218]` to the shell provisioner parameters.
```

We could add `max_retries` option - https://github.visualstudio.com/virtual-environments/_build/results?buildId=128423&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043

```
==> azure-arm: Provisioning with shell script: C:\agent\_work\22\s\images\linux/scripts/base/apt-mock-remove.sh
==> azure-arm: Provisioning with shell script: C:\Windows\SERVIC~2\NETWOR~1\AppData\Local\Temp\packer-shell3572216467
    azure-arm: Running SoftwareReport.Generator.ps1 script
==> azure-arm: Provisioner failed with "Script disconnected unexpectedly. If you expected your script to disconnect, i.e. from a restart, you can try adding `\"expect_disconnect\": true` or `\"valid_exit_codes\": [0, 2300218]` to the shell provisioner parameters.", retrying with 3 trie(s) left
==> azure-arm: Provisioning with shell script: C:\Windows\SERVIC~2\NETWOR~1\AppData\Local\Temp\packer-shell885850339
    azure-arm: Running SoftwareReport.Generator.ps1 script
```