### PR TITLE
[macOS] CodeQL tests correction for macOS 11 and 12

### DIFF
--- a/images/macos/provision/core/codeql-bundle.sh
+++ b/images/macos/provision/core/codeql-bundle.sh
@@ -21,3 +21,5 @@ touch "$codeqlToolcachePath/pinned-version"
 
 # Touch a file to indicate to the toolcache that setting up CodeQL is complete.
 touch "$codeqlToolcachePath.complete"
+
+invoke_tests "Common" "CodeQL"

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -139,11 +139,14 @@ Describe "VirtualBox" -Skip:($os.IsBigSur) {
     }
 }
 
-Describe "CodeQL Action Bundle" {
+Describe "CodeQL" {
     It "codeql" {
         $CodeQLVersionWildcard = Join-Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "CodeQL" | Join-Path -ChildPath "*"
         $CodeQLVersionPath = Get-ChildItem $CodeQLVersionWildcard | Select-Object -First 1 -Expand FullName
         $CodeQLPath = Join-Path $CodeQLVersionPath -ChildPath "x64" | Join-Path -ChildPath "codeql" | Join-Path -ChildPath "codeql"
         "$CodeQLPath version --quiet" | Should -ReturnZeroExitCode
+        
+        $CodeQLPacksPath = Join-Path $CodeQLVersionPath -ChildPath "x64" | Join-Path -ChildPath "codeql" | Join-Path -ChildPath "qlpacks"
+        $CodeQLPacksPath | Should -Exist
     }
 }


### PR DESCRIPTION
# Description
Corrections for test of CodeQL action bundle.

## Virtual environments affected
- [ ] macOS 10.15
- [x] macOS 11
- [x] macOS 12

#### Related issue:
Previous PR  #6068

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
