### PR TITLE
[actions] Updated github/codeql-action used version from v1 to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,8 +25,10 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
+      # only required for workflows in private repositories
       actions: read
       contents: read
+      # required for all workflows
       security-events: write
 
     strategy:
@@ -42,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
# Description
Workflow update.

CodeQL actions release/v1 would be deprecated in December of this year:
https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

Usage of CodeQL actions release/v2 is same:
https://github.com/github/codeql-action/blob/main/README.md

#### Related issue:
N/A

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
