### PR TITLE
select-datastore: make cluster parameter mandatory

### DIFF
--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -36,9 +36,11 @@ param(
     [ValidateNotNullOrEmpty()]
     [string]$VIPassword,
 
-    [string]$TagCategory = "Busy",
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Cluster,
 
-    [string]$Cluster
+    [string]$TagCategory = "Busy"
 )
 
 # Import helpers module


### PR DESCRIPTION
# Description

Otherwise it fails in interactive mode with

<img width="647" alt="image" src="https://user-images.githubusercontent.com/88318005/185612448-d13adce9-b432-4098-bc54-b6ae1ddc2e44.png">


#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
