### PR TITLE
[macOS] Remove bats formula installation

### DIFF
--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -204,7 +204,6 @@
             "ant",
             "aria2",
             "azure-cli",
-            "bats",
             "bazelisk",
             "carthage",
             "cmake",


### PR DESCRIPTION
# Description

bats was [disabled](https://formulae.brew.sh/formula/bats)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
