### PR TITLE
[Ubuntu] Add sqlcmd on Ubuntu Server 22.04

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -273,9 +273,7 @@ $markdown += New-MDList -Style Unordered -Lines ( $databaseLists | Sort-Object )
 
 $markdown += Build-PostgreSqlSection
 $markdown += Build-MySQLSection
-if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
-    $markdown += Build-MSSQLToolsSection
-}
+$markdown += Build-MSSQLToolsSection
 
 $markdown += New-MDHeader "Cached Tools" -Level 3
 $markdown += Build-CachedToolsSection

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -182,7 +182,7 @@ Describe "Mono" {
     }
 }
 
-Describe "MSSQLCommandLineTools" -Skip:(Test-IsUbuntu22) {
+Describe "MSSQLCommandLineTools" {
     It "sqlcmd" {
         "sqlcmd -?" | Should -ReturnZeroExitCode
     }

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -303,6 +303,7 @@ build {
                         "${path.root}/scripts/installers/mono.sh",
                         "${path.root}/scripts/installers/kotlin.sh",
                         "${path.root}/scripts/installers/mysql.sh",
+                        "${path.root}/scripts/installers/mssql-cmd-tools.sh",
                         "${path.root}/scripts/installers/sqlpackage.sh",
                         "${path.root}/scripts/installers/nginx.sh",
                         "${path.root}/scripts/installers/nvm.sh",


### PR DESCRIPTION
# Description
Add sqlcmd tool on Ubuntu Server 22.04.

#### Related issue:
https://github.com/actions/runner-images/issues/6126

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
