### PR TITLE
[macOS] Remove xctool formula installation

### DIFF
--- a/images/macos/software-report/SoftwareReport.Xcode.psm1
+++ b/images/macos/software-report/SoftwareReport.Xcode.psm1
@@ -246,13 +246,6 @@ function Build-XcodeSupportToolsSection {
         )
     }
 
-    if ($os.IsCatalina) {
-        $xctool = Run-Command "xctool --version"
-        $toolList += @(
-            "xctool $xctool"
-        )
-    }
-
     $output = ""
     $output += New-MDHeader "Xcode Support Tools" -Level 4
     $output += New-MDList -Style Unordered -Lines $toolList

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -150,12 +150,6 @@ Describe "virtualbox" -Skip:($os.IsBigSur) {
     }
 }
 
-Describe "xctool" -Skip:($os.IsHigherThanCatalina) {
-    It "xctool" {
-        "xctool --version" | Should -ReturnZeroExitCode
-    }
-}
-
 Describe "R" {
     It "R" {
         "R --version" | Should -ReturnZeroExitCode

--- a/images/macos/toolsets/toolset-10.15.json
+++ b/images/macos/toolsets/toolset-10.15.json
@@ -221,7 +221,6 @@
             "subversion",
             "swiftformat",
             "swig",
-            "xctool",
             "zstd",
             "zlib",
             "libxext",


### PR DESCRIPTION
# Description

xctool formula has been [disabled](https://formulae.brew.sh/formula/xctool)


#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
