### PR TITLE
[Ubuntu] Update  inotify resource limits

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -32,6 +32,10 @@ chmod -R 777 $AGENT_TOOLSDIRECTORY
 # https://www.suse.com/support/kb/doc/?id=000016692
 echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf
 
+# https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
+echo 'fs.inotify.max_user_watches=655360' | tee -a /etc/sysctl.conf
+echo 'fs.inotify.max_user_instances=1280' | tee -a /etc/sysctl.conf
+
 # Create symlink for tests running
 chmod +x $HELPER_SCRIPTS/invoke-tests.sh
 ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests


### PR DESCRIPTION
# Description
Pod errors due to "too many open files":
This may be caused by running out of [inotify](https://linux.die.net/man/7/inotify) resources. Resource limits are defined by fs.inotify.max_user_watches and fs.inotify.max_user_instances system variables. For example, in Ubuntu these default to 8192 and 128 respectively, which is not enough to create a cluster with many nodes.

#### Related issue:
https://github.com/actions/runner-images/issues/268#issuecomment-1222405650

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
