### PR TITLE
[macOS] always return True on gfortran check

### DIFF
--- a/images/macos/provision/core/gcc.sh
+++ b/images/macos/provision/core/gcc.sh
@@ -8,7 +8,7 @@ for gccVersion in $gccVersions; do
 done
 
 # Delete default gfortran link if it exists https://github.com/actions/runner-images/issues/1280
-gfortranPath=$(which gfortran)
+gfortranPath=$(which gfortran) || true
 if [ $gfortranPath ]; then
     rm $gfortranPath
 fi


### PR DESCRIPTION
# Description

Not always the binary under the `/usr/bin/gfortran` exists which makes the script fall.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
