### PR TITLE
[macOS] Don't show CodeQl in Catalina's sw report

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -159,9 +159,14 @@ $toolsList = @(
     (Get-AzureDevopsVersion),
     (Get-AWSCLIVersion),
     (Get-AWSSAMCLIVersion),
-    (Get-AWSSessionManagerCLIVersion),
-    (Get-CodeQLBundleVersion)
+    (Get-AWSSessionManagerCLIVersion)
 )
+
+if (-not $os.IsCatalina) {
+    $toolsList += @(
+        (Get-CodeQLBundleVersion)
+    )
+}
 
 if ($os.IsLessThanMonterey) {
     $toolsList += @(

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -139,13 +139,13 @@ Describe "VirtualBox" -Skip:($os.IsBigSur) {
     }
 }
 
-Describe "CodeQL" {
+Describe "CodeQL" -Skip:($os.IsCatalina) {
     It "codeql" {
         $CodeQLVersionWildcard = Join-Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "CodeQL" | Join-Path -ChildPath "*"
         $CodeQLVersionPath = Get-ChildItem $CodeQLVersionWildcard | Select-Object -First 1 -Expand FullName
         $CodeQLPath = Join-Path $CodeQLVersionPath -ChildPath "x64" | Join-Path -ChildPath "codeql" | Join-Path -ChildPath "codeql"
         "$CodeQLPath version --quiet" | Should -ReturnZeroExitCode
-        
+
         $CodeQLPacksPath = Join-Path $CodeQLVersionPath -ChildPath "x64" | Join-Path -ChildPath "codeql" | Join-Path -ChildPath "qlpacks"
         $CodeQLPacksPath | Should -Exist
     }


### PR DESCRIPTION
# Description

We do not install codeql on Catalina, therefore we must not include it into the software report generator, otherwise the build fails.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
