### PR TITLE
[macOS] Use json to parse libraries version

### DIFF
--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -524,22 +524,22 @@ function Get-JazzyVersion {
 }
 
 function Get-ZlibVersion {
-	$zlibVersion = (brew info zlib)[0] | Take-Part -Part 2
+	$zlibVersion = brew info --json zlib | jq -r '.[].installed[].version'
 	return "Zlib $zlibVersion"
 }
 
 function Get-LibXftVersion {
-    $libXftVersion = (brew info libxft)[0] | Take-Part -Part 2
+    $libXftVersion = brew info --json libxft | jq -r '.[].installed[].version'
     return "libXft $libXftVersion"
 }
 
 function Get-LibXextVersion {
-    $libXextVersion = (brew info libxext)[0] | Take-Part -Part 2
+    $libXextVersion = brew info --json libxext | jq -r '.[].installed[].version'
     return "libXext $libXextVersion"
 }
 
 function Get-TclTkVersion {
-    $tcltkVersion = (brew info tcl-tk)[0] | Take-Part -Part 2
+    $tcltkVersion = brew info --json tcl-tk | jq -r '.[].installed[].version'
     return "Tcl/Tk $tcltkVersion"
 }
 


### PR DESCRIPTION
# Description

Brew outputs json as well so we can use jq rather than rely on our cut supply helper.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
