### PR TITLE
[Windows] Add Windows11SDK.22621 to Win19

### DIFF
--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -44,10 +44,10 @@ if (Test-IsWin19) {
 	Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
 
 	# Install Windows 11 SDK version 10.0.22621.0
-    $sdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2196241"
-    $sdkFileName = "sdksetup22621.exe"
-    $argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64")
-    Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
+        $sdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2196241"
+        $sdkFileName = "sdksetup22621.exe"
+        $argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64")
+        Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
 }
 
 if (Test-IsWin22) {

--- a/images/win/scripts/Installers/Install-VS.ps1
+++ b/images/win/scripts/Installers/Install-VS.ps1
@@ -42,6 +42,12 @@ if (Test-IsWin19) {
 	$sdkFileName = "sdksetup14393.exe"
 	$argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit")
 	Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
+
+	# Install Windows 11 SDK version 10.0.22621.0
+    $sdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2196241"
+    $sdkFileName = "sdksetup22621.exe"
+    $argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64")
+    Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList
 }
 
 if (Test-IsWin22) {

--- a/images/win/scripts/Tests/VisualStudio.Tests.ps1
+++ b/images/win/scripts/Tests/VisualStudio.Tests.ps1
@@ -29,3 +29,9 @@ Describe "Windows 10 SDK" {
         "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.17763.0\UAP.props" | Should -Exist
     }
 }
+
+Describe "Windows 11 SDK" {
+    It "Verifies 22621 SDK is installed" -Skip:(Test-IsWin22) {
+        "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.22621.0\UAP.props" | Should -Exist
+    }
+}


### PR DESCRIPTION
# Description
Windows SDK 10.0.22621 added to Windows Server 2019.

#### Related issue:
#6137

## Virtual environments affected
- [x] Windows 2019
- [ ] Windows 2022
-
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
