### PR TITLE
[macOS] Uninstall public_suffix 5.0 gem

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -12,4 +12,7 @@ if [ -n "$gemsToInstall" ]; then
     done
 fi
 
+# Temporary uninstall public_suffix 5.0 gem as Cocoapods is not compatible with it yet https://github.com/actions/runner-images/issues/6149
+gem uninstall public_suffix -v 5.0.0
+
 invoke_tests "RubyGem"


### PR DESCRIPTION
# Description
macOS images currently have broken cocoapods due to the fact that we have two different [public_suffix](https://rubygems.org/gems/public_suffix/versions/1.5.3) gem versions — 5.0.0 & 4.0.7 while cocoapods only works with version 4
https://github.com/CocoaPods/CocoaPods/blob/f65ac1881cfcc78a6740c6e6e738933d560c2a55/Gemfile.lock#L21
The error is
```
/usr/local/lib/ruby/site_ruby/3.0.0/rubygems/specification.rb:2288:in `raise_if_conflicts': Unable to activate cocoapods-core-1.11.3, because public_suffix-5.0.0 conflicts with public_suffix (~> 4.0) (Gem::ConflictError)
```
This PR temporarily uninstalls the newest public_suffix version and can be reverted once cocoapods adds support for public_suffix 5.*

#### Related issue:
https://github.com/actions/runner-images/issues/6149
https://github.com/CocoaPods/CocoaPods/issues/11513

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
