### PR TITLE
[macOS] Install the latest Swiftlint only for macOS 12

### DIFF
--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -2,7 +2,14 @@
 source ~/utils/utils.sh
 
 echo "Install SwiftLint"
-swiftlintUrl=$(get_github_package_download_url "realm/SwiftLint" "contains(\"portable_swiftlint.zip\")" "latest" "$API_PAT")
+# SwiftLint now requires Swift 5.6 or higher to build, and macOS 12 or higher to run https://github.com/realm/SwiftLint/releases/tag/0.49.0
+if is_Less_Monterey; then
+    version="0.48.0"
+else
+    version="latest"
+fi
+
+swiftlintUrl=$(get_github_package_download_url "realm/SwiftLint" "contains(\"portable_swiftlint.zip\")" "$version" "$API_PAT")
 download_with_retries $swiftlintUrl "/tmp" "portable_swiftlint.zip"
 unzip -q "/tmp/portable_swiftlint.zip" -d /usr/local/bin
 # Remove the LICENSE file that comes along with the binary and the downloaded archive


### PR DESCRIPTION
# Description
Swiftling 0.49 introduces a breaking change — SwiftLint now requires Swift 5.6 or higher to build, and macOS 12
or higher to run.
https://github.com/realm/SwiftLint/releases/tag/0.49.0

#### Related issue:
https://github.com/realm/SwiftLint/issues/4131

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
