### PR TITLE
[macOS] Fix PostgreSql pester test — take second split from the end

### DIFF
--- a/images/macos/tests/Databases.Tests.ps1
+++ b/images/macos/tests/Databases.Tests.ps1
@@ -12,8 +12,8 @@ Describe "PostgreSQL" {
     It "PostgreSQL version should correspond to the version in the toolset" {
         $toolsetVersion = Get-ToolsetValue 'postgresql.version'
         # Client version
-        (psql --version).split()[-1] | Should -BeLike "$toolsetVersion*"
+        (psql --version).split()[-2] | Should -BeLike "$toolsetVersion*"
         # Server version
-        (pg_config --version).split()[-1] | Should -BeLike "$toolsetVersion*"
+        (pg_config --version).split()[-2] | Should -BeLike "$toolsetVersion*"
     }
 }


### PR DESCRIPTION
# Description
The version output for postgresql has changed — we have (Homebrew) at the end of the output now so need to take not the last but the previous split part as a version in the test.
![image](https://user-images.githubusercontent.com/48208649/187138782-960b98c9-a420-4856-aa38-b8a5aa5137a9.png)

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4239

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
