### PR TITLE
[macOS] Stop versioned postgresql service instead of the general one

### DIFF
--- a/images/macos/provision/core/postgresql.sh
+++ b/images/macos/provision/core/postgresql.sh
@@ -8,7 +8,8 @@ toolsetVersion=$(get_toolset_value '.postgresql.version')
 brew_smart_install postgresql@$toolsetVersion
 
 # Service PostgreSQL should be started before use
-brew services start postgresql
+postgreService=$(brew services list | grep -oe "postgresql\S*")
+brew services start $postgreService
 
 # Verify PostgreSQL is ready for accept incoming connections
 echo "Check PostgreSQL service is running"
@@ -27,7 +28,6 @@ while [ $i -gt 0 ]; do
 done
 
 # Stop PostgreSQL
-postgreService=$(brew services list | grep -oe "postgresql\S*")
 brew services stop $postgreService
 
 invoke_tests "Databases" "PostgreSQL"

--- a/images/macos/provision/core/postgresql.sh
+++ b/images/macos/provision/core/postgresql.sh
@@ -27,6 +27,7 @@ while [ $i -gt 0 ]; do
 done
 
 # Stop PostgreSQL
-brew services stop postgresql
+postgreService=$(brew services list | grep -oe "postgresql\S*")
+brew services stop $postgreService
 
 invoke_tests "Databases" "PostgreSQL"


### PR DESCRIPTION
# Description
Postgresql formula has been updated to version 15 and as we are still installing version 14 we have to stop the versioned formula instead of the main one to avoid such a warning — `Warning: Use postgresql@14 instead of deprecated postgresql`
![image](https://user-images.githubusercontent.com/48208649/187387384-9076db09-c6e1-424e-b8a4-ce94c085da4a.png)

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4243

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
