### PR TITLE
[Ubuntu] Fix chromium revision parsing

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -17,7 +17,7 @@ function GetChromiumRevision {
     # Some Google Chrome versions are based on Chromium revisions for which a (usually very old) Chromium release with the same number exist. So far this has heppened with 4 digits long Chromium revisions (1060, 1086).
     # Use the previous Chromium release when this happens to avoid downloading and installing very old Chromium releases that would break image build because of incompatibilities.
     # First reported with: https://github.com/actions/runner-images/issues/5256
-    if [ ${#REVISION} -eq 4 ]; then
+    if [ ${#REVISION} -le 4 ]; then
       CURRENT_REVISIONS=$(curl -s "https://omahaproxy.appspot.com/all.json?os=linux&channel=stable")
       PREVIOUS_VERSION=$(echo "$CURRENT_REVISIONS" | jq -r '.[].versions[].previous_version')
       URL="https://omahaproxy.appspot.com/deps.json?version=${PREVIOUS_VERSION}"


### PR DESCRIPTION
# Description
https://omahaproxy.appspot.com/deps.json?version=105.0.5195.102 - returns very old chromium version

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4273

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
