### PR TITLE
[Windows] Add VCPKG_ROOT variable

### DIFF
--- a/images/win/scripts/Installers/Install-Vcpkg.ps1
+++ b/images/win/scripts/Installers/Install-Vcpkg.ps1
@@ -17,5 +17,6 @@ Invoke-Expression "$InstallDir\$VcpkgExecPath integrate install"
 Add-MachinePathItem $InstallDir
 $env:Path = Get-MachinePath
 setx VCPKG_INSTALLATION_ROOT $InstallDir /M
+setx VCPKG_ROOT $InstallDir /M
 
 Invoke-PesterTests -TestFile "Tools" -TestName "Vcpkg"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -349,6 +349,12 @@ function Build-PackageManagementEnvironmentTable {
             "Value" = $env:VCPKG_INSTALLATION_ROOT
         }
     )
+    $envVariables += @(
+        @{
+            "Name" = "VCPKG_ROOT"
+            "Value" = $env:VCPKG_ROOT
+        }
+    )
     if (Test-IsWin19) {
         $envVariables += @(
             @{

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -347,9 +347,7 @@ function Build-PackageManagementEnvironmentTable {
         @{
             "Name" = "VCPKG_INSTALLATION_ROOT"
             "Value" = $env:VCPKG_INSTALLATION_ROOT
-        }
-    )
-    $envVariables += @(
+        },
         @{
             "Name" = "VCPKG_ROOT"
             "Value" = $env:VCPKG_ROOT

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -147,15 +147,23 @@ Describe "Stack" {
 
 Describe "Vcpkg" {
     It "vcpkg" {
-      "vcpkg version" | Should -ReturnZeroExitCode
+        "vcpkg version" | Should -ReturnZeroExitCode
     }
 
     It "env variable VCPKG_INSTALLATION_ROOT is set" {
-      $env:VCPKG_INSTALLATION_ROOT | Should -Not -BeNullOrEmpty
+        $env:VCPKG_INSTALLATION_ROOT | Should -Not -BeNullOrEmpty
     }
 
     It "VCPKG_INSTALLATION_ROOT directory" {
         $env:VCPKG_INSTALLATION_ROOT | Should -Exist
+    }
+
+    It "env variable VCPKG_ROOT is set" {
+        $env:VCPKG_ROOT | Should -Not -BeNullOrEmpty
+    }
+  
+    It "VCPKG_ROOT directory" {
+        $env:VCPKG_ROOT | Should -Exist
     }
 }
 

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -154,10 +154,6 @@ Describe "Vcpkg" {
         $env:VCPKG_INSTALLATION_ROOT | Should -Not -BeNullOrEmpty
     }
 
-    It "VCPKG_INSTALLATION_ROOT directory" {
-        $env:VCPKG_INSTALLATION_ROOT | Should -Exist
-    }
-
     It "env variable VCPKG_ROOT is set" {
         $env:VCPKG_ROOT | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
# Description
Add VCPKG_ROOT variable in additional to VCPKG_INSTALLATION_ROOT + simple style fix

#### Related issue:
[#4241](https://github.com/actions/runner-images-internal/issues/4241)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
