### PR TITLE
[macOS] Add VCPKG_ROOT variable

### DIFF
--- a/images/macos/provision/core/vcpkg.sh
+++ b/images/macos/provision/core/vcpkg.sh
@@ -1,15 +1,16 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-# Set env variable for vcpkg
-VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
-echo "export VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a ~/.bashrc
+# Set env variables for vcpkg
+VCPKG_ROOT=/usr/local/share/vcpkg
+echo "export VCPKG_INSTALLATION_ROOT=${VCPKG_ROOT}" | tee -a ~/.bashrc
+echo "export VCPKG_ROOT=${VCPKG_ROOT}" | tee -a ~/.bashrc
 
 # Install vcpkg
-git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
-$VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
-$VCPKG_INSTALLATION_ROOT/vcpkg integrate install
-chmod -R 0777 $VCPKG_INSTALLATION_ROOT
-ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
+git clone https://github.com/Microsoft/vcpkg $VCPKG_ROOT
+$VCPKG_ROOT/bootstrap-vcpkg.sh
+$VCPKG_ROOT/vcpkg integrate install
+chmod -R 0777 $VCPKG_ROOT
+ln -sf $VCPKG_ROOT/vcpkg /usr/local/bin
 
 invoke_tests "Common" "vcpkg"

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -562,6 +562,10 @@ function Build-PackageManagementEnvironmentTable {
         @{
             "Name" = "VCPKG_INSTALLATION_ROOT"
             "Value" = $env:VCPKG_INSTALLATION_ROOT
+        },
+        @{
+            "Name" = "VCPKG_ROOT"
+            "Value" = $env:VCPKG_ROOT
         }
     ) | ForEach-Object {
         [PSCustomObject] @{


### PR DESCRIPTION
# Description
Add VCPKG_ROOT variable in additional to VCPKG_INSTALLATION_ROOT

#### Related issue:
[#4241](https://github.com/actions/runner-images-internal/issues/4241)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
