### PR TITLE
[Ubuntu] install gcc@11 from brew

### DIFF
--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -257,16 +257,22 @@ Describe "HHVM" -Skip:(Test-IsUbuntu22) {
 }
 
 Describe "Homebrew" {
+    $brewToolset = (Get-ToolsetContent).brew
+    $testCases = $brewToolset | ForEach-Object { @{brewName = $_.name; brewCommand = $_.command} }
+
     It "homebrew" {
         "brew --version" | Should -ReturnZeroExitCode
     }
 
-    Context "Packages" {
-        $testCases = (Get-ToolsetContent).brew | ForEach-Object { @{ ToolName = $_.name } }
+    It "zstd has /usr/local/bin symlink" {
+        "/usr/local/bin/zstd" | Should -Exist
+    }
 
-        It "<ToolName>" -TestCases $testCases {
-           "$ToolName --version" | Should -Not -BeNullOrEmpty
-        }
+    It "homebrew package <brewName>" -TestCases $testCases {
+        $brewPrefix = brew --prefix $brewName
+        $brewPackage = Join-Path $brewPrefix "bin" $brewCommand
+
+        "$brewPackage --version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -217,7 +217,14 @@
         ]
     },
     "brew": [
-        {"name": "zstd"}
+        {
+            "name": "gcc@11",
+            "command": "gcc-11"
+        },
+        {
+            "name": "zstd",
+            "command": "zstd"
+        }
     ],
     "docker": {
         "images": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -217,7 +217,14 @@
         ]
     },
     "brew": [
-        {"name": "zstd"}
+        {
+            "name": "gcc@11",
+            "command": "gcc-11"
+        },
+        {
+            "name": "zstd",
+            "command": "zstd"
+        }
     ],
     "docker": {
         "images": [

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -201,7 +201,10 @@
         ]
     },
     "brew": [
-        {"name": "zstd"}
+        {
+            "name": "zstd",
+            "command": "zstd"
+        }
     ],
     "docker": {
         "images": [


### PR DESCRIPTION
# Description

Since homebrew-3.6.0 gcc@11 and glibc have become mandatory dependencies for any package, While we are installing zstd, it surely does not pull gcc, because zstd itself is required for GCC's LTO support, so there would be a circular dependency loop, as a result zstd's linkage is broken because it requires toolchain libs to present.

Also fixed a broken pester test.

<img width="797" alt="image" src="https://user-images.githubusercontent.com/88318005/189152249-84bb7d11-2054-4d41-a690-518eb654ecc2.png">



#### Related issue: https://github.com/actions/runner-images/issues/6200

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
