### PR TITLE
[macOS] Add Xcode 14 beta 6 in macOS 12 toolset

### DIFF
--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -3,6 +3,7 @@
         "default": "13.4.1",
         "versions": [
             { "link": "14.0", "version": "14.0.0" },
+            { "link": "14.0_beta", "version": "14 beta 6", "skip-symlink": "true"},
             { "link": "13.4.1", "version": "13.4.1" },
             { "link": "13.4", "version": "13.4.0" },
             { "link": "13.3.1", "version": "13.3.1", "symlinks": ["13.3"] },


### PR DESCRIPTION
# Description
For development with the macOS Ventura SDK users need to continue to use Xcode 14 beta 6 so we need to have both beta and stable versions preinstalled until Ventura is out of beta (October 2022).

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4311

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
