### PR TITLE
Add sccache

### DIFF
--- a/images/linux/Ubuntu1804-Readme.md
+++ b/images/linux/Ubuntu1804-Readme.md
@@ -149,6 +149,7 @@
 - Rust 1.62.1
 - Rustdoc 1.62.1
 - Rustup 1.25.1
+- Sccache 0.3.0
 
 #### Packages
 - Bindgen 0.60.1

--- a/images/linux/Ubuntu2004-Readme.md
+++ b/images/linux/Ubuntu2004-Readme.md
@@ -151,6 +151,7 @@
 - Rust 1.63.0
 - Rustdoc 1.63.0
 - Rustup 1.25.1
+- Sccache 0.3.0
 
 #### Packages
 - Bindgen 0.60.1

--- a/images/linux/Ubuntu2204-Readme.md
+++ b/images/linux/Ubuntu2204-Readme.md
@@ -142,6 +142,7 @@
 - Rust 1.63.0
 - Rustdoc 1.63.0
 - Rustup 1.25.1
+- Sccache 0.3.0
 
 #### Packages
 - Bindgen 0.60.1

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -222,7 +222,8 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-CargoOutdatedVersion),
     (Get-CargoClippyVersion),
     (Get-CbindgenVersion),
-    (Get-RustfmtVersion)
+    (Get-RustfmtVersion),
+    (Get-SccacheVersion)
     ) | Sort-Object
 )
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Rust.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Rust.psm1
@@ -54,3 +54,8 @@ function Get-RustfmtVersion {
     $rustfmtVersion = $(rustfmt --version) | Take-OutputPart -Part 1 | Take-OutputPart -Part 0 -Delimiter "-"
     return "Rustfmt $rustfmtVersion"
 }
+
+function Get-SccacheVersion {
+    $sccacheVersion = sccache --version | Take-OutputPart -Part 1
+    return "Sccache $sccacheVersion"
+}

--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -20,9 +20,9 @@ source $CARGO_HOME/env
 rustup component add rustfmt clippy
 
 if isUbuntu22; then
-    cargo install bindgen cbindgen cargo-audit cargo-outdated
+    cargo install bindgen cbindgen cargo-audit cargo-outdated sccache
 else
-    cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+    cargo install --locked bindgen cbindgen cargo-audit cargo-outdated sccache
 fi
 
 # Cleanup Cargo cache

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -62,6 +62,10 @@ Describe "Rust" {
             "cargo outdated --version" | Should -ReturnZeroExitCode
         }
     }
+
+    It "Sccache is installed" {
+        "sccache --version" | Should -ReturnZeroExitCode
+    }
 }
 Describe "Docker" {
     It "docker" {

--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -12,7 +12,7 @@ CARGO_HOME=$HOME/.cargo
 
 echo Install common tools...
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated sccache
 
 echo Cleanup Cargo registry cached data...
 rm -rf $CARGO_HOME/registry/*

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -73,6 +73,11 @@ function Get-RustupVersion {
     return "Rustup ${rustupVersion}"
 }
 
+function Get-SccacheVersion {
+    $sccacheVersion = Run-Command "sccache --version" | Take-Part -Part 1
+    return "Sccache $sccacheVersion"
+}
+
 function Get-VcpkgVersion {
     $vcpkgVersion = Run-Command "vcpkg version" | Select-Object -First 1 | Take-Part -Part 5 | Take-Part -Part 0 -Delimiter "-"
     $commitId = git -C "/usr/local/share/vcpkg" rev-parse --short HEAD

--- a/images/macos/tests/Rust.Tests.ps1
+++ b/images/macos/tests/Rust.Tests.ps1
@@ -34,4 +34,10 @@ Describe "Rust" {
             "cargo outdated --version" | Should -ReturnZeroExitCode
         }
     }
+
+    Context "Sccache" {
+        It "Sccache is installed" {
+            "sccache --version" | Should -ReturnZeroExitCode
+        }
+    }
 }

--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -24,7 +24,7 @@ rustup target add i686-pc-windows-msvc
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen cbindgen cargo-audit cargo-outdated sccache
 
 # Cleanup Cargo crates cache
 Remove-Item "${env:CARGO_HOME}\registry\*" -Recurse -Force

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -67,6 +67,10 @@ function Get-CargoOutdatedVersion {
     return cargo outdated --version
 }
 
+function Get-SccacheVersion {
+    return sccache --version
+}
+
 function Get-PythonVersion {
     return & python --version
 }

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -163,8 +163,8 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-CargoOutdatedVersion),
     (Get-CbindgenVersion),
     "Rustfmt $(Get-RustfmtVersion)",
-    "Clippy $(Get-RustClippyVersion)"
-    (Get-SccacheVersion),
+    "Clippy $(Get-RustClippyVersion)",
+    (Get-SccacheVersion)
     ) | Sort-Object
 )
 

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -164,6 +164,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-CbindgenVersion),
     "Rustfmt $(Get-RustfmtVersion)",
     "Clippy $(Get-RustClippyVersion)"
+    (Get-SccacheVersion),
     ) | Sort-Object
 )
 

--- a/images/win/scripts/Tests/Rust.Tests.ps1
+++ b/images/win/scripts/Tests/Rust.Tests.ps1
@@ -11,6 +11,7 @@ Describe "Rust" {
         @{ToolName = "cargo"; binPath = "C:\Users\Default\.cargo\bin\cargo.exe"}
         @{ToolName = "cargo audit"; binPath = "C:\Users\Default\.cargo\bin\cargo-audit.exe"}
         @{ToolName = "cargo outdated"; binPath = "C:\Users\Default\.cargo\bin\cargo-outdated.exe"}
+        @{ToolName = "sccache"; binPath = "C:\Users\Default\.cargo\bin\sccache.exe"}
     )
 
     $rustEnvNotExists = @(


### PR DESCRIPTION
# Description

Add the sccache tool to all images.

sccache is about 12MB once installed on my own system, but it depends on the operating system. It takes about 28 seconds to install.

#### Related issue:

Close https://github.com/actions/runner-images/issues/6209

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
