### PR TITLE
[Windows] Replace Docker EE with Docker CE

### DIFF
--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -5,24 +5,26 @@
 ##         can continue.
 ################################################################################
 
-# Docker EE 20.10.8 has the regression
-# fatal: open C:\ProgramData\docker\panic.log: Access is denied.
-Write-Host "Install-Package Docker"
-Install-Package -Name docker -ProviderName DockerMsftProvider -RequiredVersion 20.10.7 -Force
-Start-Service docker
+Write-Host "Install Docker CE"
+$instScriptUrl = "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1"
+$instScriptPath = "$env:TEMP\install-docker-ce.ps1"
+Invoke-WebRequest -UseBasicParsing $instScriptUrl -o $instScriptPath
+& $instScriptPath
 
 Write-Host "Install-Package Docker-Compose v1"
 Choco-Install -PackageName docker-compose
 
 Write-Host "Install-Package Docker-Compose v2"
 $dockerComposev2Url = "https://github.com/docker/compose/releases/latest/download/docker-compose-windows-x86_64.exe"
-Start-DownloadWithRetry -Url $dockerComposev2Url -Name docker-compose.exe -DownloadPath "C:\Program Files\Docker\cli-plugins"
+$cliPluginsDir = "C:\ProgramData\docker\cli-plugins"
+New-Item -Path $cliPluginsDir -ItemType Directory
+Start-DownloadWithRetry -Url $dockerComposev2Url -Name docker-compose.exe -DownloadPath $cliPluginsDir
 
 Write-Host "Install docker-wincred"
 $dockerCredLatestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/docker/docker-credential-helpers/releases/latest"
 $dockerCredDownloadUrl = $dockerCredLatestRelease.assets.browser_download_url -match "docker-credential-wincred-.+\.zip" | Select-Object -First 1
 $dockerCredArchive = Start-DownloadWithRetry -Url $dockerCredDownloadUrl
-Expand-Archive -Path $dockerCredArchive -DestinationPath "C:\Program Files\Docker"
+Expand-Archive -Path $dockerCredArchive -DestinationPath "C:\Windows\System32"
 
 Write-Host "Download docker images"
 $dockerImages = (Get-ToolsetContent).docker.images

--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -7,8 +7,7 @@
 
 Write-Host "Install Docker CE"
 $instScriptUrl = "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1"
-$instScriptPath = "$env:TEMP\install-docker-ce.ps1"
-Invoke-WebRequest -UseBasicParsing $instScriptUrl -o $instScriptPath
+$instScriptPath = Start-DownloadWithRetry -Url $instScriptUrl -Name "install-docker-ce.ps1"
 & $instScriptPath
 
 Write-Host "Install-Package Docker-Compose v1"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Helpers.psm1
@@ -122,7 +122,7 @@ function Test-BlankElement {
 
     $splitByLines = $Markdown.Split("`n")
     # Validate entry without version
-    $blankVersions = $splitByLines -match "^-" -notmatch "(OS|Image) Version|WSL|Vcpkg|\d\." | Out-String
+    $blankVersions = $splitByLines -match "^-" -notmatch "(OS|Image) Version|WSL|Vcpkg|Docker|\d\." | Out-String
 
     # Validate tables with blank rows
     $blankRows = ""


### PR DESCRIPTION
# Description
Support for DockerMsftProvider ends at the end of September and will be fully transferred to Mirantis. The alternative is Docker CE / Moby.
This PR replaces installation of Docker EE in favor of Docker CE and also
- Changes docker-compose v2 installation to `C:\ProgramData\docker` as all the docker configs and libs are now placed there
- Changes `wincred` installation to the same directory as Docker CE executables (win\system32) as there is no more `C:\Program Files\Docker` in the path
- Adds Docker to the exclusion list in Software report blank version tester as the version doesn't match the general format — `master-dockerproject-2022-03-26`

#### Related issue:
https://github.com/actions/runner-images/issues/6181

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
