### PR TITLE
Eksctl installation

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -182,6 +182,7 @@ $markdown += New-MDList -Style Unordered -Lines (@(
     (Get-OCCliVersion),
     (Get-ORASCliVersion),
     (Get-VerselCliversion)
+    (Get-EksctlVersion)
     ) | Sort-Object
 )
 

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -306,3 +306,8 @@ function Get-YqVersion {
     $yqVersion = ($(yq -V) -Split " ")[-1]
     return "yq $yqVersion"
 }
+
+function Get-EksctlVersion {
+    $eksctlversion = eksctl version
+    return $eksctlversion
+}

--- a/images/linux/scripts/installers/eksctl-cli.sh
+++ b/images/linux/scripts/installers/eksctl-cli.sh
@@ -1,0 +1,6 @@
+# Source the helpers for use with the script
+    source $HELPER_SCRIPTS/install.sh
+
+    # Install Eksctl CLI  
+    downloadUrl="https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+    mv /tmp/eksctl /usr/local/bin

--- a/images/macos/provision/core/eksctl.sh
+++ b/images/macos/provision/core/eksctl.sh
@@ -1,0 +1,1 @@
+brew install weaveworks/tap/eksctl

--- a/images/macos/software-report/SoftwareReport.Common.psm1
+++ b/images/macos/software-report/SoftwareReport.Common.psm1
@@ -597,3 +597,7 @@ function Get-CodeQLBundleVersion {
     $CodeQLVersion = & $CodeQLPath version --quiet
     return "CodeQL Action Bundle $CodeQLVersion"
 }
+function Get-EksctlVersion {
+    $eksctlversion = Run-Command "eksctl version"
+    return "eksctl version $eksctlversion"
+}

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -160,6 +160,7 @@ $toolsList = @(
     (Get-AWSCLIVersion),
     (Get-AWSSAMCLIVersion),
     (Get-AWSSessionManagerCLIVersion)
+    (Get-EksctlVersion)
 )
 
 if (-not $os.IsCatalina) {

--- a/images/win/scripts/Installers/Install-Eksctl.ps1
+++ b/images/win/scripts/Installers/Install-Eksctl.ps1
@@ -1,0 +1,2 @@
+$installDir = "C:\eksctl"
+Choco-Install -PackageName eksctl -ArgumentList "/installLocation:$installDir"

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -139,6 +139,7 @@ $cliTools = @(
     (Get-AzureDevopsExtVersion),
     (Get-GHVersion),
     (Get-HubVersion)
+    (Get-EksctlVersion)
 )
 if (Test-IsWin19) {
     $cliTools += @(

--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -307,3 +307,7 @@ function Get-SwigVersion {
     $swigVersion = $Matches.Version
     return "Swig $swigVersion"
 }
+function Get-EksctlVersion {
+    $eksctlversion = eksctl version
+    return $eksctlversion
+}


### PR DESCRIPTION
# Description
eksctl installed for windows, ubuntu and macos images
version tests ran to make sure the software available is of the latest version
updated readme files for Windows, Ubuntu and MacOS

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- Installed eksctl on Windows
- Created and Ran Test for software version on Windows
- Using the output for the software version test. Updated the readme file for Windows
- Installed eksctl on Ubuntu
- Created and Ran Test for software version on Ubuntu
- Using the output for the software version test. Updated the readme file for Ubuntu
 - Installed eksctl on MacOS
- Created and Ran Test for software version on MacOS
- Using the output for the software version test. Updated the readme file for MacOS