### PR TITLE
Revert "[Ubuntu] install gcc@11 from brew (#6202)"

### DIFF
--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -257,22 +257,16 @@ Describe "HHVM" -Skip:(Test-IsUbuntu22) {
 }
 
 Describe "Homebrew" {
-    $brewToolset = (Get-ToolsetContent).brew
-    $testCases = $brewToolset | ForEach-Object { @{brewName = $_.name; brewCommand = $_.command} }
-
     It "homebrew" {
         "brew --version" | Should -ReturnZeroExitCode
     }
 
-    It "zstd has /usr/local/bin symlink" {
-        "/usr/local/bin/zstd" | Should -Exist
-    }
+    Context "Packages" {
+        $testCases = (Get-ToolsetContent).brew | ForEach-Object { @{ ToolName = $_.name } }
 
-    It "homebrew package <brewName>" -TestCases $testCases {
-        $brewPrefix = brew --prefix $brewName
-        $brewPackage = Join-Path $brewPrefix "bin" $brewCommand
-
-        "$brewPackage --version" | Should -ReturnZeroExitCode
+        It "<ToolName>" -TestCases $testCases {
+           "$ToolName --version" | Should -Not -BeNullOrEmpty
+        }
     }
 }
 

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -217,14 +217,7 @@
         ]
     },
     "brew": [
-        {
-            "name": "gcc@11",
-            "command": "gcc-11"
-        },
-        {
-            "name": "zstd",
-            "command": "zstd"
-        }
+        {"name": "zstd"}
     ],
     "docker": {
         "images": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -217,14 +217,7 @@
         ]
     },
     "brew": [
-        {
-            "name": "gcc@11",
-            "command": "gcc-11"
-        },
-        {
-            "name": "zstd",
-            "command": "zstd"
-        }
+        {"name": "zstd"}
     ],
     "docker": {
         "images": [

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -201,10 +201,7 @@
         ]
     },
     "brew": [
-        {
-            "name": "zstd",
-            "command": "zstd"
-        }
+        {"name": "zstd"}
     ],
     "docker": {
         "images": [


### PR DESCRIPTION
This reverts commit d2c84c9d4c30a469ab32e88d9118914a9380a53f.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/88318005/189946899-46136d7f-d085-4813-8353-642d93ae126f.png">

Every single linux binary relies on glibc from brew now, in the screenshot `ldd /bin/ls`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
