### PR TITLE
Update codeowners to the right team for PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @actions/runner-images-owners
+* @actions/runner-images-team


### PR DESCRIPTION
Update to point to the right team for PR reviews: https://github.com/orgs/actions/teams/runner-images-team/members
<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->
