### PR TITLE
[macOS] Set Xcode 14.0.1 as the default version

### DIFF
--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "13.4.1",
+        "default": "14.0.1",
         "versions": [
             { "link": "14.1", "version": "14.1.0"},
             { "link": "14.0.1", "version": "14.0.1" },


### PR DESCRIPTION
# Description
We would like to provide images with the latest stable updates as default ones.

#### Related issue:
https://github.com/actions/runner-images/issues/6225

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
