### PR TITLE
[Ubuntu] remove gfortran symlink from brew

### DIFF
--- a/images/linux/scripts/installers/homebrew.sh
+++ b/images/linux/scripts/installers/homebrew.sh
@@ -43,4 +43,10 @@ for package in $brew_packages; do
     fi
 done
 
+gfortran=$(brew --prefix)/bin/gfortran
+# Remove gfortran symlink, not to conflict with system gfortran
+if [[ -e $gfortran ]]; then
+    rm $gfortran
+fi
+
 invoke_tests "Tools" "Homebrew"


### PR DESCRIPTION
# Description

Homebrew installs both `gfortran-12` and `gfortran`. `gfortran` itself is a symlink and can be removed as we already are doing it on macOS.

#### Related issue: https://github.com/actions/runner-images/issues/6274

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
