### PR TITLE
Ensure VS MEF is also initialized in the VS experimental

### DIFF
--- a/images/win/post-generation/VSConfiguration.ps1
+++ b/images/win/post-generation/VSConfiguration.ps1
@@ -5,6 +5,5 @@ $devEnvPath = "$vsInstallRoot\Common7\IDE\devenv.exe"
 # The Out-Null cmdlet is required to ensure PowerShell waits until the '/ResetSettings' command fully completes.
 # The temp/empty C# file is required to ensure VS MEF is fully initialized
 Set-Content -Path "$env:TEMP\temp.cs" -Value "//"
-& "$devEnvPath" "$env:TEMP\temp.cs" /RootSuffix Exp /NoSplash /ResetSettings General.vssettings /Command File.Exit | Out-Null
 
-cmd.exe /c "`"$devEnvPath`" /updateconfiguration"
+& "$devEnvPath" "$env:TEMP\temp.cs" /RootSuffix Exp /NoSplash /ResetSettings General.vssettings /Command File.Exit | Out-Null

--- a/images/win/post-generation/VSConfiguration.ps1
+++ b/images/win/post-generation/VSConfiguration.ps1
@@ -3,6 +3,8 @@ $devEnvPath = "$vsInstallRoot\Common7\IDE\devenv.exe"
 
 # Initialize Visual Studio Experimental Instance
 # The Out-Null cmdlet is required to ensure PowerShell waits until the '/ResetSettings' command fully completes.
-& "$devEnvPath" /RootSuffix Exp /ResetSettings General.vssettings /Command File.Exit | Out-Null
+# The temp/empty C# file is required to ensure VS MEF is fully initialized
+Set-Content -Path "$env:TEMP\temp.cs" -Value "//"
+& "$devEnvPath" "$env:TEMP\temp.cs" /RootSuffix Exp /NoSplash /ResetSettings General.vssettings /Command File.Exit | Out-Null
 
 cmd.exe /c "`"$devEnvPath`" /updateconfiguration"


### PR DESCRIPTION
MEF initialization is very costly and can take up to 15' on first run of VS.

MEF is only initialized when some action in the IDE requires resolving a MEF  export in VS. The heaviest consumer of MEF in VS is the core editor itself, and  the existing initialization code was not causing the editor to open at all, leaving  MEF uninitialized. 

By opening even a (mostly) empty C# file, we cause most key components in 
MEF to be properly initialized once: editor and project system.

# Description

Performance issue bug fixing for VS experimental (for VS extension authoring 
integration testing).
