### PR TITLE
[macOS] Add Colima exclusion to fix macOS-10.15 image

### DIFF
--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -151,7 +151,7 @@ Describe "CodeQL" -Skip:($os.IsCatalina) {
     }
 }
 
-Describe "Colima" {
+Describe "Colima" -Skip:($os.IsCatalina) {
     It "Colima" {
         "colima version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
Colima tool excluded from Pester tests for macOS 10.15 image,

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
[#4393](https://github.com/actions/runner-images-internal/issues/4393)

## Virtual environments affected
- [x] macOS 10.15
- [ ] macOS 11
- [ ] macOS 12

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
