### PR TITLE
[macOS] Test Chrome and Chrome Driver major versions are the same

### DIFF
--- a/images/macos/tests/Browsers.Tests.ps1
+++ b/images/macos/tests/Browsers.Tests.ps1
@@ -1,12 +1,21 @@
 Describe "Chrome" {
-    It "Chrome" {
+    BeforeAll {
         $chromeLocation = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    }
+
+    It "Chrome" {
         $chromeLocation | Should -Exist
         "'$chromeLocation' --version" | Should -ReturnZeroExitCode
     }
 
     It "Chrome Driver" {
         "chromedriver --version" | Should -ReturnZeroExitCode
+    }
+
+    It "Chrome and Chrome Driver major versions are the same" {
+        $chromeMajor = (& $chromeLocation --version).Trim("Google Chrome ").Split(".")[0]
+        $chromeDriverMajor = (chromedriver --version).Trim("ChromeDriver ").Split(".")[0]
+        $chromeMajor | Should -BeExactly $chromeDriverMajor
     }
 }
 


### PR DESCRIPTION
# Description
Sometimes we have a situation when Chrome is already updated to a new major version but chromedriver isn't (mostly related to macOS as those are different homebrew formulas and can be updated not at the same time).
We need to fail a build in such cases rather than find it out only during the deployment.
This PR adds a Pester test that will fail the build in case of a version mismatch. Execution example:
![image](https://user-images.githubusercontent.com/48208649/193034786-d111ca51-1df7-4237-ac67-9fe2954e7d76.png)

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4392

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
