### PR TITLE
[macOS] Close System Preferences window

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -45,6 +45,10 @@ fi
 
 # Validate "Parallels International GmbH" kext
 if is_Monterey; then
+    echo "Closing System Preferences window if it is still opened"
+    killall "System Preferences" || true
+
+    echo "Checking parallels kexts"
     dbName="/var/db/SystemPolicyConfiguration/KextPolicy"
     dbQuery="SELECT * FROM kext_policy WHERE bundle_id LIKE 'com.parallels.kext.%';"
     kext=$(sudo sqlite3 $dbName "$dbQuery")


### PR DESCRIPTION
# Description
Sometimes `Expected $null or empty, but got window Security & Privacy of application process System Preferences.` window is still opened after reboot. As a fix we should kill System Preferences process.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
