### PR TITLE
[Ubuntu] Test Chrome and Chrome Driver major versions are the same

### DIFF
--- a/images/linux/scripts/tests/Browsers.Tests.ps1
+++ b/images/linux/scripts/tests/Browsers.Tests.ps1
@@ -16,6 +16,12 @@ Describe "Chrome" {
     It "Chrome Driver" {
         "chromedriver --version" | Should -ReturnZeroExitCode
     }
+
+    It "Chrome and Chrome Driver major versions are the same" {
+        $chromeMajor = (google-chrome --version).Trim("Google Chrome ").Split(".")[0]
+        $chromeDriverMajor = (chromedriver --version).Trim("ChromeDriver ").Split(".")[0]
+        $chromeMajor | Should -BeExactly $chromeDriverMajor
+    }
 }
 
 Describe "Edge" {


### PR DESCRIPTION
# Description
Sometimes we have a situation when Chrome is already updated to a new major version but chromedriver isn't.
We need to fail a build in such cases rather than find it out only during the deployment.
This PR adds a Pester test that will fail the build in case of a version mismatch.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4392

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
