### PR TITLE
[Windows] Test Chrome and Chrome Driver major versions are the same

### DIFF
--- a/images/win/scripts/Tests/Browsers.Tests.ps1
+++ b/images/win/scripts/Tests/Browsers.Tests.ps1
@@ -49,7 +49,7 @@ Describe "Chrome" {
         }
 
         It "Chrome and Chrome Driver major versions are the same" {
-            $chromeMajor = (Get-Item $chromePath).VersionInfo.ProductVersion.Split(".")[0]
+            $chromeMajor = (Get-Item $chromePath).VersionInfo.ProductMajorPart
             $chromeDriverMajor = (Get-Content $env:ChromeWebDriver\versioninfo.txt).Split(".")[0]
             $chromeMajor | Should -BeExactly $chromeDriverMajor
         }

--- a/images/win/scripts/Tests/Browsers.Tests.ps1
+++ b/images/win/scripts/Tests/Browsers.Tests.ps1
@@ -48,7 +48,7 @@ Describe "Chrome" {
             $chromeName | Should -BeExactly "chrome.exe"
         }
 
-        It "Chrome and Chrome Driver major versions are the same" {
+        It "Chrome and Chrome Driver major versions are the same" -TestCases @{chromePath = $chromePath} {
             $chromeMajor = (Get-Item $chromePath).VersionInfo.ProductMajorPart
             $chromeDriverMajor = (Get-Content $env:ChromeWebDriver\versioninfo.txt).Split(".")[0]
             $chromeMajor | Should -BeExactly $chromeDriverMajor

--- a/images/win/scripts/Tests/Browsers.Tests.ps1
+++ b/images/win/scripts/Tests/Browsers.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Chrome" {
 
         It "Chrome and Chrome Driver major versions are the same" {
             $chromeMajor = (Get-Item $chromePath).VersionInfo.ProductVersion.Split(".")[0]
-            $chromeDriverMajor = (& $env:ChromeWebDriver\chromedriver.exe --version).Trim("ChromeDriver ").Split(".")[0]
+            $chromeDriverMajor = (Get-Content $env:ChromeWebDriver\versioninfo.txt).Split(".")[0]
             $chromeMajor | Should -BeExactly $chromeDriverMajor
         }
     }

--- a/images/win/scripts/Tests/Browsers.Tests.ps1
+++ b/images/win/scripts/Tests/Browsers.Tests.ps1
@@ -47,6 +47,12 @@ Describe "Chrome" {
             $chromePath | Should -Exist
             $chromeName | Should -BeExactly "chrome.exe"
         }
+
+        It "Chrome and Chrome Driver major versions are the same" {
+            $chromeMajor = (Get-Item $chromePath).VersionInfo.ProductVersion.Split(".")[0]
+            $chromeDriverMajor = (& $env:ChromeWebDriver\chromedriver.exe --version).Trim("ChromeDriver ").Split(".")[0]
+            $chromeMajor | Should -BeExactly $chromeDriverMajor
+        }
     }
 }
 


### PR DESCRIPTION
# Description
Sometimes we have a situation when Chrome is already updated to a new major version but chromedriver isn't.
We need to fail a build in such cases rather than find it out only during the deployment.
This PR adds a Pester test that will fail the build in case of a version mismatch.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4392

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
