### PR TITLE
[Ubuntu] Add new alpine Docker images

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -231,6 +231,8 @@
             "alpine:3.12",
             "alpine:3.13",
             "alpine:3.14",
+            "alpine:3.15",
+            "alpine:3.16",
             "buildpack-deps:stretch",
             "buildpack-deps:buster",
             "buildpack-deps:bullseye",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -210,6 +210,7 @@
         "images": [
             "alpine:3.14",
             "alpine:3.15",
+            "alpine:3.16",
             "buildpack-deps:buster",
             "buildpack-deps:bullseye",
             "debian:10",


### PR DESCRIPTION
# Description
Add new Docker images with Alpine OS

For Ubuntu 20.04:
alpine:3.15
alpine:3.16

For Ubuntu 22.04:
alpine:3.16

#### Related issue:
#6315
[#4381](https://github.com/actions/runner-images-internal/issues/4381)

## Runner Images affected
- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [x] Ubuntu 22.04

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
