### PR TITLE
Add 'Larger Runners' option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,8 @@ body:
       label: Platforms affected
       options:
         - label: Azure DevOps
-        - label: GitHub Actions
+        - label: GitHub Actions - Standard Runners
+        - label: GitHub Actions - Larger Runners
   - type: checkboxes
     attributes:
       label: Runner images affected


### PR DESCRIPTION
# Description
We are deploying our images not only to Standard GitHub runners, but also to Larger Github Runners. This PR updates options in bug report template to reflect this change
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
