### PR TITLE
Don't install stack install hook

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -9,6 +9,7 @@ source $HELPER_SCRIPTS/etc-environment.sh
 
 # Any nonzero value for noninteractive installation
 export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+export BOOTSTRAP_HASKELL_INSTALL_NO_STACK_HOOK=1
 export GHCUP_INSTALL_BASE_PREFIX=/usr/local
 export BOOTSTRAP_HASKELL_GHC_VERSION=0
 ghcup_bin=$GHCUP_INSTALL_BASE_PREFIX/.ghcup/bin

--- a/images/linux/scripts/tests/Haskell.Tests.ps1
+++ b/images/linux/scripts/tests/Haskell.Tests.ps1
@@ -31,4 +31,8 @@ Describe "Haskell" {
     It "Stack" {
         "stack --version" | Should -ReturnZeroExitCode
     }
+
+    It "Stack hook is not installed" {
+        "$HOME/.stack/hooks/ghc-install.sh" | Should -Not -Exist
+    }
 }


### PR DESCRIPTION
See https://github.com/commercialhaskell/stack/issues/5895

Stack feature is documented here:
  https://docs.haskellstack.org/en/stable/yaml_configuration/#ghc-installation-customisation

It's recommended, but probably too unexpected for CI. It means stack will not install GHC on its own, but through GHCup.

@al-cheb @mpilgrem