### PR TITLE
[Ubuntu] Delete old Alpine Docker images

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -228,8 +228,6 @@
     ],
     "docker": {
         "images": [
-            "alpine:3.12",
-            "alpine:3.13",
             "alpine:3.14",
             "alpine:3.15",
             "alpine:3.16",


### PR DESCRIPTION
# Description
Delete old Docker images with Alpine OS for Ubuntu 20.04:
alpine:3.12
alpine:3.13

#### Related issue:
[#4381](https://github.com/actions/runner-images-internal/issues/4381)

# Runner Images affected
- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Ubuntu 22.04

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
