### PR TITLE
[macOS] Tight VirtualBox version to 6.1.38

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -13,7 +13,16 @@ done
 cask_packages=$(get_toolset_value '.brew.cask_packages[]')
 for package in $cask_packages; do
     echo "Installing $package..."
-    brew install --cask $package
+    if [[ $package == "virtualbox" ]]; then
+        # VirtualBox 7 crashes
+        # macOS host: Dropped all kernel extensions. VirtualBox relies fully on the hypervisor and vmnet frameworks provided by Apple now.
+        vbcask_url="https://raw.githubusercontent.com/Homebrew/homebrew-cask/aa3c55951fc9d687acce43e5c0338f42c1ddff7b/Casks/virtualbox.rb"
+        download_with_retries $vbcask_url
+        brew install ./virtualbox.rb
+        rm ./virtualbox.rb
+    else
+        brew install --cask $package
+    fi
 done
 
 # Load "Parallels International GmbH"


### PR DESCRIPTION
# Description
VMs suddenly crash on VirtualBox 7 due to new hypervisor(macOS host: Dropped all kernel extensions. [VirtualBox](https://www.virtualbox.org/wiki/VirtualBox) relies fully on the hypervisor and vmnet frameworks provided by Apple now. At the moment the implementation lacks "Internal Networking" functionality. This will be provided at a later date. - https://www.virtualbox.org/wiki/Changelog-7.0). We should downgrade VirtualBox to the previous version.

![image](https://user-images.githubusercontent.com/47745270/195289359-f7e84901-3fa7-4540-ad8d-94cd8b7e2090.png)

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4449

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
