### PR TITLE
[Windows] Add cbindgen and bindgen pester test

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -24,7 +24,7 @@ rustup target add i686-pc-windows-msvc
 
 # Install common tools
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
 
 # Cleanup Cargo crates cache
 Remove-Item "${env:CARGO_HOME}\registry\*" -Recurse -Force

--- a/images/win/scripts/Tests/Rust.Tests.ps1
+++ b/images/win/scripts/Tests/Rust.Tests.ps1
@@ -6,11 +6,13 @@ Describe "Rust" {
     }
 
     $rustTools = @(
-        @{ToolName = "rustup"; binPath = "C:\Users\Default\.cargo\bin\rustup.exe"}
-        @{ToolName = "rustc"; binPath = "C:\Users\Default\.cargo\bin\rustc.exe"}
-        @{ToolName = "cargo"; binPath = "C:\Users\Default\.cargo\bin\cargo.exe"}
-        @{ToolName = "cargo audit"; binPath = "C:\Users\Default\.cargo\bin\cargo-audit.exe"}
-        @{ToolName = "cargo outdated"; binPath = "C:\Users\Default\.cargo\bin\cargo-outdated.exe"}
+        @{ToolName = "rustup"; binPath = "$env:CARGO_HOME\bin\rustup.exe"}
+        @{ToolName = "rustc"; binPath = "$env:CARGO_HOME\bin\rustc.exe"}
+        @{ToolName = "bindgen.exe"; binPath = "$env:CARGO_HOME\bin\bindgen.exe"}
+        @{ToolName = "cbindgen.exe"; binPath = "$env:CARGO_HOME\bin\cbindgen.exe"}
+        @{ToolName = "cargo"; binPath = "$env:CARGO_HOME\bin\cargo.exe"}
+        @{ToolName = "cargo audit"; binPath = "$env:CARGO_HOME\bin\cargo-audit.exe"}
+        @{ToolName = "cargo outdated"; binPath = "$env:CARGO_HOME\bin\cargo-outdated.exe"}
     )
 
     $rustEnvNotExists = @(

--- a/images/win/scripts/Tests/Rust.Tests.ps1
+++ b/images/win/scripts/Tests/Rust.Tests.ps1
@@ -6,13 +6,13 @@ Describe "Rust" {
     }
 
     $rustTools = @(
-        @{ToolName = "rustup"; binPath = "$env:CARGO_HOME\bin\rustup.exe"}
-        @{ToolName = "rustc"; binPath = "$env:CARGO_HOME\bin\rustc.exe"}
-        @{ToolName = "bindgen.exe"; binPath = "$env:CARGO_HOME\bin\bindgen.exe"}
-        @{ToolName = "cbindgen.exe"; binPath = "$env:CARGO_HOME\bin\cbindgen.exe"}
-        @{ToolName = "cargo"; binPath = "$env:CARGO_HOME\bin\cargo.exe"}
-        @{ToolName = "cargo audit"; binPath = "$env:CARGO_HOME\bin\cargo-audit.exe"}
-        @{ToolName = "cargo outdated"; binPath = "$env:CARGO_HOME\bin\cargo-outdated.exe"}
+        @{ToolName = "rustup"; binPath = "C:\Users\Default\.cargo\bin\rustup.exe"}
+        @{ToolName = "rustc"; binPath = "C:\Users\Default\.cargo\bin\rustc.exe"}
+        @{ToolName = "bindgen.exe"; binPath = "C:\Users\Default\.cargo\bin\bindgen.exe"}
+        @{ToolName = "cbindgen.exe"; binPath = "C:\Users\Default\.cargo\bin\cbindgen.exe"}
+        @{ToolName = "cargo"; binPath = "C:\Users\Default\.cargo\bin\cargo.exe"}
+        @{ToolName = "cargo audit"; binPath = "C:\Users\Default\.cargo\bin\cargo-audit.exe"}
+        @{ToolName = "cargo outdated"; binPath = "C:\Users\Default\.cargo\bin\cargo-outdated.exe"}
     )
 
     $rustEnvNotExists = @(


### PR DESCRIPTION
# Description
Add additional Pester tests for Rust:
- cbindgen
- bindgen

Replace bindgen to bindgen-cli - https://github.com/rust-lang/cargo/issues/11249

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4478

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
