### PR TITLE
[Ubuntu] Replace bindgen to bindgen-cli

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -20,9 +20,9 @@ source $CARGO_HOME/env
 rustup component add rustfmt clippy
 
 if isUbuntu22; then
-    cargo install bindgen cbindgen cargo-audit cargo-outdated
+    cargo install bindgen-cli cbindgen cargo-audit cargo-outdated
 else
-    cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+    cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
 fi
 
 # Cleanup Cargo cache


### PR DESCRIPTION
# Description
https://github.com/rust-lang/cargo/issues/11249 - we should use `cargo install bindgen-cli`.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4478

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
