### PR TITLE
[macOS] Replace bindgen to bindgen-cli

### DIFF
--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -12,7 +12,7 @@ CARGO_HOME=$HOME/.cargo
 
 echo Install common tools...
 rustup component add rustfmt clippy
-cargo install --locked bindgen cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
 
 echo Cleanup Cargo registry cached data...
 rm -rf $CARGO_HOME/registry/*


### PR DESCRIPTION
# Description
https://github.com/rust-lang/cargo/issues/11249 - we should use `cargo install bindgen-cli`.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4478

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
