### PR TITLE
[Windows] Set Windows Server 2022 image_version

### DIFF
--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -59,6 +59,7 @@
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",
             "image_sku": "2022-Datacenter",
+            "image_version": "20348.1129.221007",
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",


### PR DESCRIPTION
# Description
The latest Azure marketplace image version is broken:

```
Publisher               : MicrosoftWindowsServer
Offer                   : WindowsServer
Sku                     : 2022-datacenter
Version                 : latest
ExactVersion            : 20348.1131.221014

    vhd: Activating Windows Feature 'NET-Framework-Features'...
==> vhd: Install-WindowsFeature : The request to add or remove features on the specified server failed.
==> vhd: Installation of one or more roles, role services, or features failed. Error: 0x800f0950
```
#### Related issue:
https://github.com/actions/runner-images/issues/6431

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
