### PR TITLE
Update GitHub actions/checkout package to v3

### DIFF
--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create release for ${{ github.event.client_payload.ReleaseBranchName }}
       uses: actions/create-release@v1.1.1

--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/update_github_release.yml
+++ b/.github/workflows/update_github_release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Update release for ${{ github.event.client_payload.ReleaseBranchName }}
       uses: actions/github-script@v2


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

# Description
Update actions/checkout from v2 to v3 to migrate off Node 12

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
