### PR TITLE
Check WSL is on path on Windows Server 2022

### DIFF
--- a/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
+++ b/images/win/scripts/Tests/WindowsFeatures.Tests.ps1
@@ -10,7 +10,7 @@ Describe "WindowsFeatures" {
         }
     }
 
-    it "Check WSL is on path" -Skip:(-not (Test-IsWin19)) {
+    it "Check WSL is on path" {
         (Get-Command -Name 'wsl') | Should -BeTrue
     }
 }


### PR DESCRIPTION
# Description
The test was added when there was only Win16 and Win19 (see [f934134](https://github.com/actions/runner-images/commit/f93413492e47983bafbc29ab84cb697aeeb41f7b#diff-c127bdee181991b257462eb3b7256f1fb22533615ee574ceb6f48421efa2ef99))
Now it makes more sense to test if WSL is on path all the time.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
