### PR TITLE
Enhance image generation template for Linux and Windows variants

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -4,16 +4,46 @@
 # - https://github.community/t5/GitHub-Actions/GitHub-Actions-Manual-Trigger-Approvals/td-p/31504
 # - https://github.community/t5/GitHub-Actions/Protecting-github-workflows/td-p/30290
 
+parameters:
+  - name: job_id
+    type: string
+    default: 'generate_image'
+
+  - name: image_type
+    type: string
+
+  - name: image_readme_name
+    type: string
+
+  - name: agent_pool
+    type: object
+    default:
+      name: 'ci-agent-pool'
+
+  - name: variable_group_name
+    type: string
+    default: 'Image Generation Variables'
+
+  - name: create_release
+    type: boolean
+    default: true
+
+  - name: repository_ref
+    type: string
+    default: 'self'
+
 jobs:
-- job:
+- job: ${{ parameters.job_id }}
   displayName: Image Generation (${{ parameters.image_type }})
   timeoutInMinutes: 600
   cancelTimeoutInMinutes: 30
-  pool: ci-agent-pool
+  pool: ${{ parameters.agent_pool }}
   variables:
-  - group: Image Generation Variables
+  - group: ${{ parameters.variable_group_name }}
 
   steps:
+  - checkout: ${{ parameters.repository_ref }}
+
   - task: PowerShell@2
     displayName: 'Download custom repository'
     condition: and(ne(variables['CUSTOM_REPOSITORY_URL'], ''), ne(variables['CUSTOM_REPOSITORY_BRANCH'], ''))
@@ -76,17 +106,18 @@ jobs:
                         -PrefixToPathTrim "$(TemplateDirectoryPath)" `
                         -PrintTopNLongest 25
 
-  - task: PowerShell@2
-    displayName: 'Create release for VM deployment'
-    inputs:
-      targetType: filePath
-      filePath: ./images.CI/linux-and-win/create-release.ps1
-      arguments: -BuildId $(Build.BuildId) `
-                        -Organization $(RELEASE_TARGET_ORGANIZATION) `
-                        -DefinitionId $(RELEASE_TARGET_DEFINITION_ID) `
-                        -Project $(RELEASE_TARGET_PROJECT) `
-                        -ImageName ${{ parameters.image_type }} `
-                        -AccessToken $(RELEASE_TARGET_TOKEN)
+  - ${{ if eq(parameters.create_release, true) }}:
+    - task: PowerShell@2
+      displayName: 'Create release for VM deployment'
+      inputs:
+        targetType: filePath
+        filePath: ./images.CI/linux-and-win/create-release.ps1
+        arguments: -BuildId $(Build.BuildId) `
+                          -Organization $(RELEASE_TARGET_ORGANIZATION) `
+                          -DefinitionId $(RELEASE_TARGET_DEFINITION_ID) `
+                          -Project $(RELEASE_TARGET_PROJECT) `
+                          -ImageName ${{ parameters.image_type }} `
+                          -AccessToken $(RELEASE_TARGET_TOKEN)
 
   - task: PowerShell@2
     displayName: 'Clean up resources'


### PR DESCRIPTION
# Description

Enhancing Azure DevOps images generation pipeline template by exposing some new parameters to be possible to override.

These changes could simplify creation of custom images by organizations on their own Azure DevOps pipelines without a need to keep in sync a fork of this repository with custom pipeline/pipeline template.

## Use Case

In Organization specific repository on Azure DevOps could be created a pipeline which will be referring to `actions/runner-images` repository using [resources](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-repositories-repository?view=azure-pipelines) feature and will be calling `image-generation.yml` template directly.

Example pipeline:

```yaml
resources:
  repositories:
    - repository: RunnerImagesGitHub
      type: github
      name: actions/runner-images
      endpoint: github-service-connection-name
      ref: main

jobs:
  - template: images.CI/linux-and-win/azure-pipelines/image-generation.yml@RunnerImagesGitHub
    parameters:
      job_id: generate_vhd
      image_type: ubuntu2204
      image_readme_name: Ubuntu2204-Readme.md
      agent_pool:
        name: MyCustomAgentPool
      variable_group_name: MyCustomVariableGroupCouldBeKeyVaultBased
      create_release: false
      repository_ref: RunnerImagesGitHub

  - job: test
    dependsOn: generate_vhd
    displayName: 'Custom test logic'
    steps:
      - ....

  - job: publish
    dependsOn: test
    displayName: 'Publish image to Azure'
    steps:
      - ....
```

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
