### PR TITLE
[Ubuntu] Add Firefox for 22.04 from PPA source

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Browsers.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Browsers.psm1
@@ -10,7 +10,8 @@ function Get-ChromeDriverVersion {
 
 function Get-FirefoxVersion {
     $firefoxVersion = firefox --version
-    return $firefoxVersion
+    $aptSourceRepo = Get-AptSourceRepository -PackageName "mozillateam"
+    return "$firefoxVersion (apt source repository: $aptSourceRepo)"
 }
 
 function Get-GeckodriverVersion {

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -246,15 +246,10 @@ $browsersAndDriversList = @(
     (Get-ChromiumVersion),
     (Get-EdgeVersion),
     (Get-EdgeDriverVersion),
-    (Get-SeleniumVersion)
+    (Get-SeleniumVersion),
+    (Get-FirefoxVersion),
+    (Get-GeckodriverVersion)
 )
-
-if ((Test-IsUbuntu18) -or (Test-IsUbuntu20)) {
-    $browsersAndDriversList += @(
-        (Get-FirefoxVersion),
-        (Get-GeckodriverVersion)
-    )
-}
 
 $markdown += New-MDList -Style Unordered -Lines $browsersAndDriversList
 $markdown += New-MDHeader "Environment variables" -Level 4

--- a/images/linux/scripts/installers/firefox.sh
+++ b/images/linux/scripts/installers/firefox.sh
@@ -7,8 +7,18 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
+FIREFOX_REPO="ppa:mozillateam/ppa"
+
 # Install Firefox
-apt-get install -y firefox
+add-apt-repository $FIREFOX_REPO -y
+apt-get update
+apt-get install --target-release 'o=LP-PPA-mozillateam' -y firefox
+
+# Remove source repo's
+add-apt-repository --remove $FIREFOX_REPO
+
+# Document apt source repo's
+echo "mozillateam $FIREFOX_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
 
 # add to gloabl system preferences for firefox locale en_US, because other browsers have en_US local.
 # Default firefox local is en_GB

--- a/images/linux/scripts/tests/Browsers.Tests.ps1
+++ b/images/linux/scripts/tests/Browsers.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Firefox" -Skip:(Test-IsUbuntu22) {
+Describe "Firefox" {
     It "Firefox" {
         "sudo -i firefox --version" | Should -ReturnZeroExitCode
     }

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -287,6 +287,7 @@ build {
                         "${path.root}/scripts/installers/codeql-bundle.sh",
                         "${path.root}/scripts/installers/containers.sh",
                         "${path.root}/scripts/installers/dotnetcore-sdk.sh",
+                        "${path.root}/scripts/installers/firefox.sh",
                         "${path.root}/scripts/installers/microsoft-edge.sh",
                         "${path.root}/scripts/installers/gcc.sh",
                         "${path.root}/scripts/installers/gfortran.sh",


### PR DESCRIPTION
# Description
- Add Firefox browser to ubuntu 22.04 from PPA source.
- Update browsers test to be able to validate Firefox installation on Ubuntu 22.04
- Include Firefox on Ubuntu 22.04 in the Software Report

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4573

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
