### PR TITLE
[Windows] Clean Install_user Temp directory

### DIFF
--- a/images/win/scripts/Installers/Finalize-VM.ps1
+++ b/images/win/scripts/Installers/Finalize-VM.ps1
@@ -19,6 +19,7 @@ Write-Host "Clean up various directories"
     "$env:SystemRoot\logs",
     "$env:SystemRoot\winsxs\manifestcache",
     "$env:SystemRoot\Temp",
+    "$env:SystemDrive\Users\$env:INSTALL_USER\AppData\Local\Temp",
     "$env:TEMP"
 ) | ForEach-Object {
     if (Test-Path $_) {

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -314,6 +314,9 @@
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Run-NGen.ps1",
                 "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1"
+            ],
+            "environment_vars": [
+                "INSTALL_USER={{user `install_user`}}"
             ]
         },
         {

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -318,6 +318,9 @@
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Run-NGen.ps1",
                 "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1"
+            ],
+            "environment_vars": [
+                "INSTALL_USER={{user `install_user`}}"
             ]
         },
         {


### PR DESCRIPTION
# Description

The `install_user` Temp directory is never cleaned.
This user is used for Visual Studio, Kubernetes tools, and other installation. The Temp directory contains several resources, that are not useful at runtime (installer profile should not be used any time...)

I've checked here, it's appr. 7Gb we can reclaim:
https://github.com/asbiin/windows-test/actions/runs/3419158662/jobs/5692324619

Another option would be deleting the `install_user` profile entirely, which might have other consequences...

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
