### PR TITLE
[Ubuntu] Remove Node 12 from toolcache

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -32,7 +32,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "12.*",
                 "14.*",
                 "16.*",
                 "18.*"
@@ -241,11 +240,9 @@
             "debian:10",
             "debian:11",
             "moby/buildkit:latest",
-            "node:12",
             "node:14",
             "node:16",
             "node:18",
-            "node:12-alpine",
             "node:14-alpine",
             "node:16-alpine",
             "node:18-alpine",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -34,7 +34,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "12.*",
                 "14.*",
                 "16.*",
                 "18.*"
@@ -241,11 +240,9 @@
             "debian:10",
             "debian:11",
             "moby/buildkit:latest",
-            "node:12",
             "node:14",
             "node:16",
             "node:18",
-            "node:12-alpine",
             "node:14-alpine",
             "node:16-alpine",
             "node:18-alpine",


### PR DESCRIPTION
# Description
Remove Nodejs 12.x in order to leave the three latest versions of Nodejs for Ubuntu

#### Related issue:
#6482 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
