### PR TITLE
Revert "[Windows] Set Windows Server 2022 image_version"

### DIFF
--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -59,7 +59,6 @@
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",
             "image_sku": "2022-Datacenter",
-            "image_version": "20348.1129.221007",
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",


### PR DESCRIPTION
Reverts actions/runner-images#6447

The issues has been fixed in `20348.1249.221105` version:
```
Publisher               : MicrosoftWindowsServer
Offer                   : WindowsServer
Sku                     : 2022-Datacenter
Version                 : latest
ExactVersion            : 20348.1249.221105
```