### PR TITLE
[macOS] Remove \ escape

### DIFF
--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -49,7 +49,7 @@ Describe "Screen Resolution" {
 
 Describe "Open windows" {
     It "Opened windows not found" {
-        $cmd = "osascript -e 'tell application \""System Events\"" to get every window of (every process whose class of windows contains window)'"
+        $cmd = "osascript -e 'tell application ""System Events"" to get every window of (every process whose class of windows contains window)'"
         $openWindows = bash -c $cmd
         $openWindows.Split(",").Trim() | Where-Object { $_ -notmatch "NotificationCenter" } | Should -BeNullOrEmpty
     }


### PR DESCRIPTION
# Description
`vsphere-clone: 17:18: syntax error: Expected expression, property or key form, etc. but found unknown token. (-2741)`

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4589

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
