### PR TITLE
[Windows] Fix Google CloudSDK version output

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -258,7 +258,7 @@ function Get-StackVersion {
 }
 
 function Get-GoogleCloudSDKVersion {
-    (gcloud --version) -match "Google Cloud SDK"
+    (cmd /c "gcloud --version") -match "Google Cloud SDK"
 }
 
 function Get-ServiceFabricSDKVersion {


### PR DESCRIPTION
# Description

 Google CloudSDK version is missing due to PowerShell Core update:
```
==> vhd: C:\Program Files (x86)\Google\Cloud SDK\google-cloud-sdk\platform\bundledpython\python.exe: can't find '__main__' module in ''
```

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4591

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
