### PR TITLE
[macOS] fix yq invocation on android repo xml

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -41,7 +41,7 @@ if [[ $cmdlineToolsVersion == "latest" ]]; then
     download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
     cmdlineToolsVersion=$(
       yq -p=xml \
-      '.sdk-repository.remotePackage[] | select(."+path" == "cmdline-tools;latest").archives.archive[].complete.url | select(contains("commandlinetools-mac"))' \
+      '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest").archives.archive[].complete.url | select(contains("commandlinetools-mac"))' \
       /tmp/repository2-1.xml
     )
 


### PR DESCRIPTION
# Description
The default xml-attribute-prefix has changed in the v4.30 to `+@` to avoid naming conflicts with the default content name.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
