### PR TITLE
[Windows] Add .NET 6.0 as LTS

### DIFF
--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -429,7 +429,8 @@
     "dotnet": {
         "versions": [
             "3.1",
-            "5.0"
+            "5.0",
+            "6.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -340,7 +340,8 @@
     "dotnet": {
         "versions": [
             "3.1",
-            "5.0"
+            "5.0",
+            "6.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }


### PR DESCRIPTION
# Description
With the release of .NET 7.0, the content of our images has changed from our software support policy. Let's add .NET 6.0 as a permanent component of the build.

#### Related issue:
#6577

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
