### PR TITLE
[Ubuntu] Add one more missing file for vcpkg

### DIFF
--- a/images/linux/scripts/installers/vcpkg.sh
+++ b/images/linux/scripts/installers/vcpkg.sh
@@ -15,13 +15,13 @@ $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 
 # workaround https://github.com/microsoft/vcpkg/issues/27786
 
-mkdir -p /root/.vcpkg/
-touch /root/.vcpkg/vcpkg.path.txt
+mkdir -p /root/.vcpkg/ $HOME/.vcpkg
+touch /root/.vcpkg/vcpkg.path.txt $HOME/.vcpkg/vcpkg.path.txt
 
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 chmod 0777 -R $VCPKG_INSTALLATION_ROOT
 ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
 
-rm -rf /root/.vcpkg
+rm -rf /root/.vcpkg $HOME/.vcpkg
 
 invoke_tests "Tools" "Vcpkg"


### PR DESCRIPTION
# Description

File for ubuntu18 is also missed for ubuntu

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
