### PR TITLE
[Windows] Pin PowerShell version 7.2.7

### DIFF
--- a/images/win/scripts/Installers/Install-PowershellCore.ps1
+++ b/images/win/scripts/Installers/Install-PowershellCore.ps1
@@ -3,7 +3,35 @@
 ##  Desc:  Install PowerShell Core
 ################################################################################
 
-Invoke-Expression "& { $(Invoke-RestMethod https://aka.ms/install-powershell.ps1) } -UseMSI -Quiet"
+$ErrorActionPreference = "Stop"
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+$null = New-Item -ItemType Directory -Path $tempDir -Force -ErrorAction SilentlyContinue
+try {
+    $originalValue = [Net.ServicePointManager]::SecurityProtocol
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+    $metadata = Invoke-RestMethod https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json
+    $release = $metadata.LTSReleaseTag[0] -replace '^v'
+    $packageName = "PowerShell-${release}-win-x64.msi"
+
+    $downloadURL = "https://github.com/PowerShell/PowerShell/releases/download/v${release}/${packageName}"
+    Write-Verbose "About to download package from '$downloadURL'" -Verbose
+
+    $packagePath = Join-Path -Path $tempDir -ChildPath $packageName
+    Invoke-WebRequest -Uri $downloadURL -OutFile $packagePath
+
+    Write-Verbose "Performing quiet install"
+    $ArgumentList=@("/i", $packagePath, "/quiet")
+    $process = Start-Process msiexec -ArgumentList $ArgumentList -Wait -PassThru
+    if ($process.exitcode -ne 0) {
+        throw "Quiet install failed, please rerun install without -Quiet switch or ensure you have administrator rights"
+    }
+} finally {
+    # Restore original value
+    [Net.ServicePointManager]::SecurityProtocol = $originalValue
+    Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 # about_update_notifications
 # While the update check happens during the first session in a given 24-hour period, for performance reasons,


### PR DESCRIPTION
# Description
The PowerShell v7.3.0 has compatibility issues and it is not an LTS version.  
The latest version of PowerShell will be changed to v7.2.7 
Example breaking change:
https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#psnativecommandargumentpassing

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4615

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
