### PR TITLE
Update PowerShell Az Modules to 9.0.1

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -121,13 +121,15 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "7.5.0"
+                "9.0.1"
             ],
             "zip_versions": [
                 "3.1.0",
                 "4.4.0",
                 "5.9.0",
-                "6.6.0"
+                "6.6.0",
+                "7.5.0"
+
             ]
         }
     ],

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -109,9 +109,10 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "7.5.0"
+                "9.0.1"
             ],
             "zip_versions": [
+                "7.5.0"
             ]
         }
     ],

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -127,7 +127,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "7.5.0"
+                "9.0.1"
             ],
             "zip_versions": [
                 "1.0.0",
@@ -142,7 +142,8 @@
                 "4.7.0",
                 "5.5.0",
                 "5.9.0",
-                "6.6.0"
+                "6.6.0",
+                "7.5.0"
             ]
         }
     ],

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -119,10 +119,11 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "7.5.0"
+                "9.0.1"
             ],
             "zip_versions": [
-                "6.6.0"
+                "6.6.0",
+                "7.5.0"
             ]
         }
     ],


### PR DESCRIPTION
# Description
Update installed Powershell Az Module, from 7.5.0 to 9.0.1. 
The 7.5.0 is seven months old, and version 9.x is out (1 month ago).
At the moment 9.1.1 is available, but because it's less than 1 day old (at the moment of writing) I prefer to pin to 9.0.1 which has been released one month ago.
