### PR TITLE
[macOS] Pin PowerShell version 7.2.7

### DIFF
--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -2,7 +2,9 @@
 source ~/utils/utils.sh
 
 echo Installing PowerShell...
-psDownloadUrl=$(get_github_package_download_url "PowerShell/PowerShell" "contains(\"osx-x64.pkg\")" "latest" "$API_PAT")
+psmetadata=$(curl "https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json" -s)
+psver=$(echo $psmetadata | jq -r '.LTSReleaseTag[0]')
+psDownloadUrl=$(get_github_package_download_url "PowerShell/PowerShell" "contains(\"osx-x64.pkg\")" "$psver" "$API_PAT")
 download_with_retries $psDownloadUrl "/tmp" "powershell.pkg"
 
 # Work around the issue on macOS Big Sur 11.5 or higher for possible error message ("can't be opened because Apple cannot check it for malicious software") when installing the package


### PR DESCRIPTION
# Description
The PowerShell v7.3.0 has compatibility issues and it is not an LTS version.
The latest version of PowerShell will be changed to v7.2.7
Example breaking change:
https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#psnativecommandargumentpassing

#### Related issue:
https://github.com/actions/runner-images-internal/issues/4615

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
