### PR TITLE
Rust: add support for mingw-w64 toolchains

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -22,6 +22,9 @@ $env:Path += ";$env:CARGO_HOME\bin"
 # Add i686 target for building 32-bit binaries
 rustup target add i686-pc-windows-msvc
 
+# Add target for building mingw-w64 binaries
+rustup target add x86_64-pc-windows-gnu
+
 # Install common tools
 rustup component add rustfmt clippy
 cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated


### PR DESCRIPTION
# Description

The R project (and probably other OSS projects) are using mingw-w64 based compilers, that require the `x86_64-pc-windows-gnu` target for rust code. It would be great if we can preinstall this on the image.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
