### PR TITLE
Windows 2022 Readme (Updated AZ Module version)

### DIFF
--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -559,7 +559,7 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 #### Azure Powershell Modules
 | Module  | Version                                                                         | Path                           |
 | ------- | ------------------------------------------------------------------------------- | ------------------------------ |
-| Az      | 6.6.0.zip<br>7.5.0                                                              | C:\Modules\az_\<version\>      |
+| Az      | 7.5.0.zip<br>9.0.1                                                             | C:\Modules\az_\<version\>      |
 | Azure   | 2.1.0 [Installed]<br>3.8.0.zip<br>4.2.1.zip<br>5.1.1.zip<br>5.3.0               | C:\Modules\azure_\<version\>   |
 | AzureRM | 2.1.0 [Installed]<br>3.8.0.zip<br>4.2.1.zip<br>5.1.1.zip<br>6.7.0.zip<br>6.13.1 | C:\Modules\azurerm_\<version\> |
 ```


### PR DESCRIPTION
# Description
It looks like we have merged a change to update the Azure PowerShell Modules from 7.5.0 to 9.0.1 but this readme was not updated with the changes merged in this PR. 

https://github.com/actions/runner-images/pull/6664/files

Related PR for Windows 2019: https://github.com/actions/runner-images/pull/6732

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

![image](https://user-images.githubusercontent.com/2100093/206596510-a329c9bc-fbf9-4eb6-ba84-56cf932c4794.png)

Had issues before merging our PR as per below:

![image](https://user-images.githubusercontent.com/2100093/206598110-d40e8db3-ed74-40ca-86c9-b5c0f8982820.png)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
