### PR TITLE
[Ubuntu] Add GFortran 12 for Ubuntu 22.04

### DIFF
--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -271,7 +271,8 @@
     "gfortran": {
         "versions": [
             "gfortran-9",
-            "gfortran-10"
+            "gfortran-10",
+            "gfortran-12"
         ]
     },
     "php": {


### PR DESCRIPTION
# Description
GFortran 12 is available for Ubuntu in PPA.

#### Related issue:
#6724

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
