### PR TITLE
[Ubuntu] Allow image_sku to be passed in as variable

### DIFF
--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -70,6 +70,11 @@ variable "image_version" {
   default = "dev"
 }
 
+variable "image_sku" {
+  type    = string
+  default = "22_04-lts"
+}
+
 variable "imagedata_file" {
   type    = string
   default = "/imagegeneration/imagedata.json"
@@ -155,7 +160,7 @@ source "azure-arm" "build_vhd" {
   client_cert_path                       = "${var.client_cert_path}"
   image_offer                            = "0001-com-ubuntu-server-jammy"
   image_publisher                        = "canonical"
-  image_sku                              = "22_04-lts"
+  image_sku                              = "${var.image_sku}"
   location                               = "${var.location}"
   os_disk_size_gb                        = "86"
   os_type                                = "Linux"


### PR DESCRIPTION
# Description
This Pull Request seeks to modify the latest Ubuntu 22.04 Packer template to allow an override of the hard-coded image_sku. This change introduces a new variable, and contains the hard-coded value as its default. 
The reason I desire to perform this override is to allow the deployment of a Generation 2 VM while consuming the packer template. I only targeted the images/linux/ubuntu2204.pkr.hcl file, because I didn't want to introduce a new variable dependency. I anticipate that this change will not impact current users of this packer template. 

#### Additional Information:
[Gen 2 VM Details](https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
