### PR TITLE
[Haskell] Make sure GHCUP_INSTALL_BASE_PREFIX is set

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -14,6 +14,7 @@ export GHCUP_INSTALL_BASE_PREFIX=/usr/local
 export BOOTSTRAP_HASKELL_GHC_VERSION=0
 ghcup_bin=$GHCUP_INSTALL_BASE_PREFIX/.ghcup/bin
 setEtcEnvironmentVariable "BOOTSTRAP_HASKELL_NONINTERACTIVE" $BOOTSTRAP_HASKELL_NONINTERACTIVE
+setEtcEnvironmentVariable "GHCUP_INSTALL_BASE_PREFIX" $GHCUP_INSTALL_BASE_PREFIX
 
 # Install GHCup
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh > /dev/null 2>&1 || true


### PR DESCRIPTION
We use it during installation and add it to PATH, but then don't instruct ghcup to actually use this directory at runtime.

This leads to:

1. ghcup is in /usr/local/.ghcup/bin/
2. `ghcup install cabal latest` will actually install into ~/.ghcup/bin/
3. since ~/.ghcup/bin/ is not in PATH, but /usr/local/.ghcup/bin/ is, the new binary is not visible to the user

This issues does not exist on darwin, because there we use ~/.ghcup/bin/.

----

An alternative approach is matching the macOS install way and use the default `~/.ghcup`. Why was `/usr/local/.ghcup` chosen for linux?