### PR TITLE
[Windows] Update PostgreSQL way to install

### DIFF
--- a/images/win/scripts/Installers/Install-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Install-PostgreSQL.ps1
@@ -8,10 +8,41 @@ Set-SystemVariable -SystemVariable PGPASSWORD -Value $pgPwd
 
 # Define latest available version to install based on version specified in the toolset
 $toolsetVersion = (Get-ToolsetContent).postgresql.version
-$latestChocoPackage = Get-LatestChocoPackageVersion -TargetVersion $toolsetVersion -PackageName "postgresql"
+$getPostgreReleases =  Invoke-WebRequest -Uri "https://git.postgresql.org/gitweb/?p=postgresql.git;a=tags" -UseBasicParsing
+# Getting all links matched to the pattern (e.g.a=log;h=refs/tags/REL_14)
+$TargetReleases = $getPostgreReleases.Links.href | Where-Object {$_ -match "a=log;h=refs/tags/REL_$toolsetVersion"}
+[Int32]$OutNumber = $null
+$MinorVersions = @()
+foreach ($release in $TargetReleases) {
+  $version = $release.split('/')[-1]
+  # Checking if the latest symbol of the release version is actually a number. If yes, add to $MinorVersions array
+  if ([Int32]::TryParse($($version.Split('_')[-1]),[ref]$OutNumber)){
+    $MinorVersions += $OutNumber
+  }
+}
+# Sorting and getting the last one
+$TargetMinorVersions = ($MinorVersions | Sort-Object)[-1]
 
 # Install latest PostgreSQL
-Choco-Install -PackageName postgresql -ArgumentList "--params", "'/Password:$pgPwd /NoPath'", "--params-global", "--version=$latestChocoPackage"
+# In order to get rid of error messages (we know we will have them), force ErrorAction to SilentlyContinue
+$ErrorActionOldValue = $ErrorActionPreference
+$ErrorActionPreference = 'SilentlyContinue'
+# Starting from number 9 and going down, check if the installer is available. If yes, break the loop.
+foreach ($increment in 9..0) {
+    $url = "https://get.enterprisedb.com/postgresql/postgresql-$toolsetVersion.$TargetMinorVersions-$increment-windows-x64.exe"
+    $checkaccess = [System.Net.WebRequest]::Create($url)
+    $response = $null
+    $response = $checkaccess.GetResponse()
+    if ($response) {
+        $InstallerUrl = $response.ResponseUri.OriginalString
+        break
+    }
+}
+# Return the previous value of ErrorAction and invoke Install-Binary function
+$ErrorActionPreference = $ErrorActionOldValue
+$InstallerName = $InstallerUrl.Split('/')[-1]
+$ArgumentList = ("--install_runtimes 0","--superpassword root","--enable_acledit 1","--unattendedmodeui none","--mode unattended")
+Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList
 
 # Get Path to pg_ctl.exe
 $pgPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName


### PR DESCRIPTION
# Description
Since the installation of the latest version of PostgreSQL 14 from the choco is broken, was decided to change the way of installation.
The current way parse the latest minor version from the git.postgresql.org site and download ".exe" file from a well-known source.
The installation itself happens in unattended mode.

#### Related issue:
#6802

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
