### PR TITLE
Minor fixes for Calculate-ImagesDifference.ps1

### DIFF
--- a/helpers/software-report-base/Calculate-ImagesDifference.ps1
+++ b/helpers/software-report-base/Calculate-ImagesDifference.ps1
@@ -60,4 +60,7 @@ if ($ReleaseBranch -and $ReadmePath) {
     $diff += "`n`n`nFor comprehensive list of software installed on this image please click [here]($ImageDocsUrl)."
 }
 
+$parentDirectory = Split-Path $OutputFile -Parent
+if (-not (Test-Path $parentDirectory)) { New-Item -Path $parentDirectory -ItemType Directory | Out-Null }
+
 $diff | Out-File -Path $OutputFile -Encoding utf8NoBOM

--- a/helpers/software-report-base/Calculate-ImagesDifference.ps1
+++ b/helpers/software-report-base/Calculate-ImagesDifference.ps1
@@ -54,7 +54,7 @@ $comparer = [SoftwareReportDifferenceCalculator]::new($previousReport, $currentR
 $comparer.CompareReports()
 $diff = $comparer.GetMarkdownReport()
 
-if ($ReleaseBranch -and $ReadmePath) {
+if ($ReleaseBranchName -and $ReadmePath) {
     # https://github.com/actions/runner-images/blob/releases/macOS-12/20221215/images/macos/macos-12-Readme.md
     $ImageDocsUrl = "https://github.com/actions/runner-images/blob/${ReleaseBranchName}/${ReadmePath}"
     $diff += "`n`n`nFor comprehensive list of software installed on this image please click [here]($ImageDocsUrl)."


### PR DESCRIPTION
# Description

Included changes:
- Create output folder if it doesn't exist yet
- Fix typo `ReleaseBranch` -> `ReleaseBranchName`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
