### PR TITLE
[Ubuntu] Remove pester test for kotlinc-js

### DIFF
--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -416,10 +416,6 @@ Describe "Kotlin" {
         "kotlinc -version"| Should -ReturnZeroExitCode
     }
 
-    It "kotlinc-js" {
-        "kotlinc-js -version"| Should -ReturnZeroExitCode
-    }
-
     It "kotlinc-jvm" {
         "kotlinc-jvm -version"| Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
We have to remove pester test for "kotlinc-js" since the check throws an error and locks image generation.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
