### PR TITLE
[Windows] Remove pester test for kotlinc-js

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -13,20 +13,13 @@ $VersionsList = $LatestMajorMinor | ForEach-Object { $_.Group | Select-Object -F
 # The latest version will be installed as a default
 ForEach ($version in $VersionsList)
 {
-     # 9.4.3 has failed choco builds, replace with 9.4.2 for the time being
-     # 9.2.5 has failed choco builds, replace with 9.2.4 for the time being
-    if ($version -eq "9.4.3"){ [version]$version = "9.4.2" }
-    if ($version -eq "9.2.5"){ [version]$version = "9.2.4" }
     Write-Host "Installing ghc $version..."
     Choco-Install -PackageName ghc -ArgumentList '--version', $version, '-m'
 }
 
 # Add default version of GHC to path, because choco formula updates path on user level
 $DefaultGhcVersion = $VersionsList | Select-Object -Last 1
-# temporary hardcode -------------
-#$DefaultGhcShortVersion = ([version]$DefaultGhcVersion).ToString(3)
-$DefaultGhcShortVersion = "9.4.2"
-#--------------------------------
+$DefaultGhcShortVersion = ([version]$DefaultGhcVersion).ToString(3)
 $DefaultGhcPath = Join-Path $env:ChocolateyInstall "lib\ghc.$DefaultGhcVersion\tools\ghc-$DefaultGhcShortVersion\bin"
 # Starting from version 9 haskell installation directory is $env:ChocolateyToolsLocation instead of $env:ChocolateyInstall\lib
 if ($DefaultGhcShortVersion -notmatch '^[0-8]\.\d+.*')

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -183,7 +183,7 @@ Describe "Pipx" {
 }
 
 Describe "Kotlin" {
-    $kotlinPackages =  @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-js", "kotlinc-jvm")
+    $kotlinPackages =  @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-jvm")
 
     It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } })  {
         "$toolName -version" | Should -ReturnZeroExitCode


### PR DESCRIPTION
# Description
We have to remove pester test for "kotlinc-js" since the check throws an error and locks image generation.

Revert commit (https://github.com/actions/runner-images/commit/b101b56) included in this PR to unblock two parallel issues (ghc and kotlin)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
