### PR TITLE
[Windows] Change the way of installing Service Fabric

### DIFF
--- a/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
+++ b/images/win/scripts/Installers/Install-ServiceFabricSDK.ps1
@@ -4,12 +4,22 @@
 ##         must be install after Visual Studio
 ################################################################################
 
-#Creating 'Installer' cache folder if it doesn't exist
-$temp_install_dir = 'C:\Windows\Installer'
-New-Item -Path $temp_install_dir -ItemType Directory -Force
+# Creating 'Installer' cache folder if it doesn't exist
+New-Item -Path 'C:\Windows\Installer' -ItemType Directory -Force
 
-Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+# Get Service Fabric components versions
+$serviceFabricRuntimeVersion = (Get-ToolsetContent).serviceFabric.runtime.version
+$serviceFabricSDKVersion = (Get-ToolsetContent).serviceFabric.sdk.version
 
-WebpiCmd.exe /Install /Products:MicrosoftAzure-ServiceFabric-CoreSDK /AcceptEula /XML:https://webpifeed.blob.core.windows.net/webpifeed/5.1/WebProductList.xml
+# Install Service Fabric Runtime for Windows
+$InstallerName = "MicrosoftServiceFabric.${serviceFabricRuntimeVersion}.exe"
+$InstallerUrl = "https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/${InstallerName}"
+$ArgumentList = ("/accepteula ","/quiet","/force")
+Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList
+
+# Install Service Fabric SDK
+$InstallerName = "MicrosoftServiceFabricSDK.${serviceFabricSDKVersion}.msi"
+$InstallerUrl = "https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/${InstallerName}"
+Install-Binary -Url $InstallerUrl -Name $InstallerName
 
 Invoke-PesterTests -TestFile "Tools" -TestName "ServiceFabricSDK"

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -427,6 +427,14 @@
             { "name": "node-sass" }
         ]
     },
+    "serviceFabric": {
+        "runtime": {
+            "version": "9.1.1436.9590"
+        },
+        "sdk": {
+            "version": "6.1.1436"
+        }
+    },
     "dotnet": {
         "versions": [
             "3.1",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -337,6 +337,14 @@
             { "name": "grunt-cli", "test": "grunt --version" }
         ]
     },
+    "serviceFabric": {
+        "runtime": {
+            "version": "9.1.1436.9590"
+        },
+        "sdk": {
+            "version": "6.1.1436"
+        }
+    },
     "dotnet": {
         "versions": [
             "3.1",


### PR DESCRIPTION
# Description
As detailed in the blog post https://blogs.iis.net/iisteam/web-platform-installer-end-of-support-feed, the Web Platform Installer is now officially retired.
This PR changes the way of installing Service Fabric Runtime and SDK 
The Service Fabric components versions is added to the toolset files.

#### Related issue:
#6880

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
