### PR TITLE
Revert "[Windows] Update OpenSSL version to 3.x (#6837)"

### DIFF
--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -448,7 +448,10 @@
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
-            { "name": "openssl.light" },
+            {
+                "name": "openssl.light",
+                "args": [ "--version=1.1.1.20181020" ]
+            },
             { "name": "packer" },
             { "name": "strawberryperl" },
             { "name": "pulumi" },

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -357,7 +357,10 @@
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
-            { "name": "openssl.light" },
+            {
+                "name": "openssl.light",
+                "args": [ "--version=1.1.1.20181020" ]
+            },
             { "name": "packer" },
             { "name": "strawberryperl" },
             { "name": "pulumi" },


### PR DESCRIPTION
This reverts commit 9753e7301e19e29b89b0622b811bbb9b3891d02e.

# Description

Openssl-3.x breaks some azdo tasks which use openssl directly so we have to revert it.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
