### PR TITLE
[Ubuntu] fix ghcup version in software report

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -241,7 +241,7 @@ function Get-GHCVersion {
 }
 
 function Get-GHCupVersion {
-    $(ghcup --version) -match "version v(?<version>\d+(\.\d+){2,})" | Out-Null
+    $(ghcup --version) -match "version (?<version>\d+(\.\d+){2,})" | Out-Null
     return $Matches.version
 }
 


### PR DESCRIPTION
Regex returns empty string.