### PR TITLE
[Windows] Hardcode command line tools

### DIFF
--- a/images/win/scripts/Installers/Install-AndroidSDK.ps1
+++ b/images/win/scripts/Installers/Install-AndroidSDK.ps1
@@ -5,22 +5,9 @@
 
 # get packages to install from the toolset
 $androidToolset = (Get-ToolsetContent).android
-
-# install latest command-line tools
-$cmdlineToolsVersion = $androidToolset."cmdline-tools"
-if ($cmdlineToolsVersion -eq "latest") {
-    $googlePkgs = Invoke-RestMethod "https://dl.google.com/android/repository/repository2-1.xml"
-    $cmdlineToolsVersion = $googlePkgs.SelectSingleNode(
-        "//remotePackage[@path='cmdline-tools;latest']/archives/archive/complete/url[starts-with(text(), 'commandlinetools-win-')]"
-    ).'#text'
-
-    if (-not $cmdlineToolsVersion) {
-        Write-Host "Failed to parse latest command-line tools version"
-        exit 1
-    }
-}
-
-$cmdlineToolsUrl = "https://dl.google.com/android/repository/${cmdlineToolsVersion}"
+# Newer version(s) require Java 11 by default
+# See https://github.com/actions/runner-images/issues/6960
+$cmdlineToolsUrl = "https://dl.google.com/android/repository/commandlinetools-win-9123335_latest.zip"
 $cmdlineToolsArchPath = Start-DownloadWithRetry -Url $cmdlineToolsUrl -Name "cmdline-tools.zip"
 $sdkInstallRoot = "C:\Program Files (x86)\Android\android-sdk"
 $sdkRoot = "C:\Android\android-sdk"

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -162,7 +162,6 @@
         ]
     },
     "android": {
-        "cmdline-tools": "latest",
         "platform_min_version": "19",
         "build_tools_min_version": "19.1.0",
         "extra_list": [

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -141,7 +141,6 @@
         ]
     },
     "android": {
-        "cmdline-tools": "latest",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra_list": [


### PR DESCRIPTION
# Description
Newer version require Java 11 which we can't switch to default yet.

#### Related issue: https://github.com/actions/runner-images/issues/6960

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
