### PR TITLE
[Windows] set TLS12 for toolset

### DIFF
--- a/images/win/scripts/Installers/Install-Toolset.ps1
+++ b/images/win/scripts/Installers/Install-Toolset.ps1
@@ -4,6 +4,8 @@
 ##  Desc:  Install toolset
 ################################################################################
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls13
+
 Function Install-Asset {
     param(
         [Parameter(Mandatory=$true)]
@@ -32,7 +34,7 @@ Function Install-Asset {
 # Get toolcache content from toolset
 $ToolsToInstall = @("Python", "Node", "Boost", "Go")
 
-$tools = Get-ToolsetContent | Select-Object -ExpandProperty toolcache | Where {$ToolsToInstall -contains $_.Name}
+$tools = Get-ToolsetContent | Select-Object -ExpandProperty toolcache | Where-Object {$ToolsToInstall -contains $_.Name}
 
 foreach ($tool in $tools) {
     # Get versions manifest for current tool


### PR DESCRIPTION
# Description

It requires tls1.2 forcibly

#### Related issue: https://github.com/actions/runner-images/issues/6990

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
