### PR TITLE
[Ubuntu] Hardcode android cmd-tools on 18.04

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -43,26 +43,33 @@ echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" | tee -a /etc/environment
 # Create android sdk directory
 mkdir -p ${ANDROID_SDK_ROOT}
 
-# Download the latest command line tools so that we can accept all of the licenses.
-# See https://developer.android.com/studio/#command-tools
-cmdlineToolsVersion=$(get_toolset_value '.android."cmdline-tools"')
-if [[ $cmdlineToolsVersion == "latest" ]]; then
-    repositoryXmlUrl="https://dl.google.com/android/repository/repository2-1.xml"
-    download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
-    cmdlineToolsVersion=$(
-      yq -p=xml \
-      '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
-      /tmp/repository2-1.xml
-    )
+cmdlineTools="android-cmdline-tools.zip"
 
-    if [[ -z $cmdlineToolsVersion ]]; then
-        echo "Failed to parse latest command-line tools version"
-        exit 1
-    fi
+if isUbuntu18; then
+    # Newer command-line-tools require Java 11 which is not default on ubuntu-18.04
+    download_with_retries "https://dl.google.com/android/repository/commandlinetools-linux-9123335_latest.zip" "." $cmdlineTools
+else
+    # Download the latest command line tools so that we can accept all of the licenses.
+    # See https://developer.android.com/studio/#command-tools
+    cmdlineToolsVersion=$(get_toolset_value '.android."cmdline-tools"')
+    if [[ $cmdlineToolsVersion == "latest" ]]; then
+        repositoryXmlUrl="https://dl.google.com/android/repository/repository2-1.xml"
+        download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
+        cmdlineToolsVersion=$(
+        yq -p=xml \
+        '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
+        /tmp/repository2-1.xml
+        )
+
+        if [[ -z $cmdlineToolsVersion ]]; then
+            echo "Failed to parse latest command-line tools version"
+            exit 1
+        fi
 fi
 
-cmdlineTools="android-cmdline-tools.zip"
 download_with_retries "https://dl.google.com/android/repository/${cmdlineToolsVersion}" "." $cmdlineTools
+fi
+
 unzip -qq $cmdlineTools -d ${ANDROID_SDK_ROOT}/cmdline-tools
 # Command line tools need to be placed in ${ANDROID_SDK_ROOT}/sdk/cmdline-tools/latest to determine SDK root
 mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -87,7 +87,6 @@
         "maven": "3.8.7"
     },
     "android": {
-        "cmdline-tools": "latest",
         "platform_min_version": "23",
         "build_tools_min_version": "23.0.1",
         "extra_list": [


### PR DESCRIPTION
# Description

Newer cmd-tools require Java 11 which is not default on 18.04

#### Related issue: n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
