### PR TITLE
Allow to use existing resource group for pipelines generating Linux and Windows image variants

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -40,6 +40,8 @@ jobs:
   pool: ${{ parameters.agent_pool }}
   variables:
   - group: ${{ parameters.variable_group_name }}
+  - name: 'BUILD_RESOURCE_GROUP_NAME_RUNTIME'
+    value: $[variables.BUILD_RESOURCE_GROUP_NAME]
 
   steps:
   - checkout: ${{ parameters.repository_ref }}
@@ -84,8 +86,9 @@ jobs:
                         -Location $(AZURE_LOCATION) `
                         -VirtualNetworkName $(BUILD_AGENT_VNET_NAME) `
                         -VirtualNetworkRG $(BUILD_AGENT_VNET_RESOURCE_GROUP) `
-                        -VirtualNetworkSubnet $(BUILD_AGENT_SUBNET_NAME)
-
+                        -VirtualNetworkSubnet $(BUILD_AGENT_SUBNET_NAME) `
+                        -BuildResourceGroupName "$(BUILD_RESOURCE_GROUP_NAME_RUNTIME)"
+                        
     env:
       PACKER_LOG: 1
       PACKER_LOG_PATH: $(Build.ArtifactStagingDirectory)/packer-log.txt

--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -10,7 +10,8 @@ param(
     [String] [Parameter (Mandatory=$true)] $TenantId,
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkName,
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkRG,
-    [String] [Parameter (Mandatory=$false)] $VirtualNetworkSubnet
+    [String] [Parameter (Mandatory=$false)] $VirtualNetworkSubnet,
+    [String] [Parameter (Mandatory=$false)] $BuildResourceGroupName
 )
 
 if (-not (Test-Path $TemplatePath))
@@ -21,6 +22,13 @@ if (-not (Test-Path $TemplatePath))
 
 $Image = [io.path]::GetFileName($TemplatePath).Split(".")[0]
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
+
+if (-not [string]::IsNullOrEmpty($BuildResourceGroupName))
+{
+    $TempResourceGroupName = [string]::Empty
+    $Location = [string]::Empty
+}
+
 $InstallPassword = [System.GUID]::NewGuid().ToString().ToUpper()
 
 packer validate -syntax-only $TemplatePath
@@ -48,6 +56,7 @@ packer build    -var "capture_name_prefix=$ResourcesNamePrefix" `
                 -var "storage_account=$StorageAccount" `
                 -var "subscription_id=$SubscriptionId" `
                 -var "temp_resource_group_name=$TempResourceGroupName" `
+                -var "build_resource_group_name=$BuildResourceGroupName" `
                 -var "tenant_id=$TenantId" `
                 -var "virtual_network_name=$VirtualNetworkName" `
                 -var "virtual_network_resource_group_name=$VirtualNetworkRG" `


### PR DESCRIPTION
# Description

Enhancements in the pipeline (`image-generation.yml`) and in the `build-image.ps1` script to allow using a static resource group as an option to the temporary resource group.

This change allows generating an image in situations when given service principal does not have enough permissions to create resource groups in Azure.

According to the [Packer AzureRM documentation](https://developer.hashicorp.com/packer/plugins/builders/azure/arm):

> By default a temporary resource group will be created and destroyed as part of the build. If you do not have permissions to do so, use `build_resource_group_name` to specify an existing resource group to run the build in.

> Providing `temp_resource_group_name` or `location` in combination with `build_resource_group_name` is not allowed.

> The Azure builder works under the assumption that it creates everything it needs to execute a build. When the build has completed it simply deletes the resource group to cleanup any runtime resources. 

This change was tested and is backward compatible with existing variable groups. The `BUILD_RESOURCE_GROUP_NAME` is a new variable which existence in variable group is optional.

***REMARK** When using an existing resource group the cleanup process needs to be covered by custom cleaning logic which is not part of this repository.*

Example pipeline design showing where the custom cleanup logic could be created:

```yaml
resources:
  repositories:
    - repository: RunnerImagesGitHub
      type: github
      name: actions/runner-images
      endpoint: ***
      ref: releases/ubuntu22/20221212

...
  - stage: 'Build'
    dependsOn: []
    displayName: 'Build'
    jobs:
      - template: images.CI/linux-and-win/azure-pipelines/image-generation.yml@RunnerImagesGitHub
        parameters:
          job_id: 'GenerateVHD'
          image_type: 'ubuntu2204'
          image_readme_name: 'Ubuntu2204-Readme.md'
          agent_pool:
            name: 'ci-agent-pool'
          variable_group_name: 'Image Generation Variables'
          create_release: false
          repository_ref: 'RunnerImagesGitHub'

      - job: 'Cleanup'
        dependsOn:
          - 'GenerateVHD'
        condition: always()
        displayName: 'Cleanup Packer Resources'
        pool:
          vmImage: 'ubuntu-latest'
        steps:
          - checkout: none

          - task: AzureCLI@2
            displayName: 'Cleanup all resources'
            inputs:
              azureSubscription: '***'
              scriptType: 'pscore'
              scriptLocation: inlineScript
              inlineScript: |
                # Custom cleanup logic here. 
                Write-Host "Cleanup completed."
              powerShellErrorActionPreference: stop
```

*Hint: All resources created by packer in case of `runner-images` repository will have names starting from `$(Build.BuildId)` pipeline variable.*

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
