### PR TITLE
[Ubuntu] .NET 5.x has been removed

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -257,12 +257,10 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-3.1",
-            "dotnet-sdk-5.0",
             "dotnet-sdk-6.0"
         ],
         "versions": [
             "3.1",
-            "5.0",
             "6.0"
         ],
         "tools": [

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -258,13 +258,11 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-3.1",
-            "dotnet-sdk-5.0",
             "dotnet-sdk-6.0",
             "dotnet-sdk-7.0"
         ],
         "versions": [
             "3.1",
-            "5.0",
             "6.0",
             "7.0"
         ],


### PR DESCRIPTION
# Description
[Ubuntu] .NET 5.x has been removed from the images

#### Related issue: [6840](https://github.com/actions/runner-images/issues/6840)

## Check list
- [x] Related issue / work item is attached
- [x] Changes are tested and related VM images are successfully generated