### PR TITLE
Replaced download url  due to certificate issues

### DIFF
--- a/images/win/scripts/Installers/Install-Rust.ps1
+++ b/images/win/scripts/Installers/Install-Rust.ps1
@@ -9,7 +9,7 @@ $env:CARGO_HOME = "C:\Users\Default\.cargo"
 
 # Download the latest rustup-init.exe for Windows x64
 # See https://rustup.rs/#
-$rustupPath = Start-DownloadWithRetry -Url "https://win.rustup.rs/x86_64" -Name "rustup-init.exe"
+$rustupPath = Start-DownloadWithRetry -Url "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe" -Name "rustup-init.exe"
 
 # Install Rust by running rustup-init.exe (disabling the confirmation prompt with -y)
 & $rustupPath -y --default-toolchain=stable --profile=minimal


### PR DESCRIPTION
# Description
Bug fixing:
Replaced download url "https://win.rustup.rs/x86_64" to "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe". The "https://win.rustup.rs/x86_64" has download issues due to certificate problem (in corporate environments).

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
