### PR TITLE
fix issue 6251

### DIFF
--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -34,7 +34,7 @@
     "builders": [
         {
             "name": "vhd",
-            "type": "azure-arm",
+            "type": "azure-arm","azure_tags": { "ExcludeMdeAutoProvisioning": "True" },
             "client_id": "{{user `client_id`}}",
             "client_secret": "{{user `client_secret`}}",
             "client_cert_path": "{{user `client_cert_path`}}",
@@ -345,3 +345,4 @@
         }
     ]
 }
+

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -34,7 +34,7 @@
     "builders": [
         {
             "name": "vhd",
-            "type": "azure-arm",
+            "type": "azure-arm","azure_tags": { "ExcludeMdeAutoProvisioning": "True" },
             "client_id": "{{user `client_id`}}",
             "client_secret": "{{user `client_secret`}}",
             "client_cert_path": "{{user `client_cert_path`}}",
@@ -348,3 +348,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
# Description
Bug fixing:
When Microsoft Defender for Endpoint is active in an Azure Subscription, it can cause interference when sysprep is run at the end of the VM Build causing the **IIMAGE_STATE_UNDEPLOYABLE** error. To avoid interference the parameter "azure_tags": { "ExcludeMdeAutoProvisioning": "True"  has been added to the builder type parameter., 

Related issue: [https://github.com/actions/runner-images/discussions/6251](https://github.com/actions/runner-images/discussions/6251)

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
