### PR TITLE
install only the latest patch version of .net core

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -18,8 +18,9 @@ function Get-SDKVersionsToInstall (
     $releaseJson = "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/${DotnetVersion}/releases.json"
     $releasesJsonPath = Start-DownloadWithRetry -Url $releaseJson -Name "releases-${DotnetVersion}.json"
     $currentReleases = Get-Content -Path $releasesJsonPath | ConvertFrom-Json
-    # filtering out the preview/rc releases
-    $currentReleases = $currentReleases.'releases' | Where-Object { !$_.'release-version'.Contains('-') }
+    # filtering the latest patch
+    $latestReleaseVersion = $currentReleases.'latest-release'
+    $currentReleases = $currentReleases.'releases' | Where-Object { $_.'release-version' -eq  $latestReleaseVersion}
 
     $sdks = @()
     ForEach ($release in $currentReleases)


### PR DESCRIPTION
To comply with the guidelines https://github.com/gonchalo620/virtual-environments/blob/main/README.md#software-guidelines, the Install-DotnetSDK.ps1 script was modified so that it only installs the latest patch version of each major.minor version of .net core

# Description
Improvement

To comply with the guidelines https://github.com/gonchalo620/virtual-environments/blob/main/README.md#software-guidelines in which it is mentioned that only the latest version of each major.secondary version will be installed. Therefore, the Install-DotnetSDK.ps1 script was modified so that it only installs the latest patch version of each major.minor version of .net core.

![image](https://user-images.githubusercontent.com/12538951/217026520-4366923d-90e7-43d1-8013-4cf71cb673b7.png)


Currently the script is scheduled to install all patch versions other than preview/rc releases. Therefore it installs older versions, which contain uncorrected detected vulnerabilities.