### PR TITLE
[Windows] Reengineer the way of getting the installer for PostgreSQL

### DIFF
--- a/images/win/scripts/Installers/Install-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Install-PostgreSQL.ps1
@@ -28,7 +28,7 @@ $TargetMinorVersions = ($MinorVersions | Sort-Object)[-1]
 $ErrorActionOldValue = $ErrorActionPreference
 $ErrorActionPreference = 'SilentlyContinue'
 # Starting from number 9 and going down, check if the installer is available. If yes, break the loop.
-# If an installer with $TargetMinorVersions does not to be found, the $TargetMinorVersions will be decreased by 1
+# If an installer with $TargetMinorVersions is not to be found, the $TargetMinorVersions will be decreased by 1
 $increment = 9
 do {
     $url = "https://get.enterprisedb.com/postgresql/postgresql-$toolsetVersion.$TargetMinorVersions-$increment-windows-x64.exe"

--- a/images/win/scripts/Installers/Install-PostgreSQL.ps1
+++ b/images/win/scripts/Installers/Install-PostgreSQL.ps1
@@ -28,16 +28,22 @@ $TargetMinorVersions = ($MinorVersions | Sort-Object)[-1]
 $ErrorActionOldValue = $ErrorActionPreference
 $ErrorActionPreference = 'SilentlyContinue'
 # Starting from number 9 and going down, check if the installer is available. If yes, break the loop.
-foreach ($increment in 9..0) {
+# If an installer with $TargetMinorVersions does not to be found, the $TargetMinorVersions will be decreased by 1
+$increment = 9
+do {
     $url = "https://get.enterprisedb.com/postgresql/postgresql-$toolsetVersion.$TargetMinorVersions-$increment-windows-x64.exe"
     $checkaccess = [System.Net.WebRequest]::Create($url)
     $response = $null
     $response = $checkaccess.GetResponse()
     if ($response) {
         $InstallerUrl = $response.ResponseUri.OriginalString
-        break
+    } elseif (!$response -and ($increment -eq 0)) {
+        $increment = 9
+        $TargetMinorVersions--
+    } else {
+        $increment--
     }
-}
+} while (!$response)
 # Return the previous value of ErrorAction and invoke Install-Binary function
 $ErrorActionPreference = $ErrorActionOldValue
 $InstallerName = $InstallerUrl.Split('/')[-1]


### PR DESCRIPTION
# Description
We faced the issue where a new release tag for PostgreSQL was published, but the installer was not uploaded. To mitigate this issue the way to get the installer was updated.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
