### PR TITLE
Fix GHCup wrt #7061

### DIFF
--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -43,6 +43,7 @@ echo "install cabal..."
 ghcup install cabal
 
 chmod -R 777 $GHCUP_INSTALL_BASE_PREFIX/.ghcup
+chown -R runner $GHCUP_INSTALL_BASE_PREFIX/.ghcup
 ln -s $GHCUP_INSTALL_BASE_PREFIX/.ghcup /etc/skel/.ghcup
 
 # Install the latest stable release of haskell stack

--- a/images/linux/scripts/installers/haskell.sh
+++ b/images/linux/scripts/installers/haskell.sh
@@ -43,7 +43,7 @@ echo "install cabal..."
 ghcup install cabal
 
 chmod -R 777 $GHCUP_INSTALL_BASE_PREFIX/.ghcup
-chown -R runner $GHCUP_INSTALL_BASE_PREFIX/.ghcup
+chown -R 1001 $GHCUP_INSTALL_BASE_PREFIX/.ghcup
 ln -s $GHCUP_INSTALL_BASE_PREFIX/.ghcup /etc/skel/.ghcup
 
 # Install the latest stable release of haskell stack

--- a/images/linux/scripts/tests/Haskell.Tests.ps1
+++ b/images/linux/scripts/tests/Haskell.Tests.ps1
@@ -1,4 +1,5 @@
 Describe "Haskell" {
+    $GHCupCommonPath = "/usr/local/.ghcup"
     $GHCCommonPath = "/usr/local/.ghcup/ghc"
     $GHCVersions = Get-ChildItem -Path $GHCCommonPath | Where-Object { $_.Name -match "\d+\.\d+" }
 
@@ -30,6 +31,10 @@ Describe "Haskell" {
 
     It "Stack" {
         "stack --version" | Should -ReturnZeroExitCode
+    }
+
+    It "GHCup dir has correct user permissions" {
+        "stat --format '%U' $GHCupCommonPath" | Should -Be "runner"
     }
 
     It "Stack hook is not installed" {


### PR DESCRIPTION
# Description

Unbreak the permission on `/usr/local/.ghcup` that cause most new Haskell CIs (non-container envs) to fail at the moment.

#### Related issue: https://github.com/actions/runner-images/issues/7061

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
