### PR TITLE
Don't clean up haddock and profiling libs on MacOS

### DIFF
--- a/images/macos/provision/core/haskell.sh
+++ b/images/macos/provision/core/haskell.sh
@@ -14,13 +14,6 @@ for majorMinorVersion in $minorMajorVersions; do
     echo "install ghc version $fullVersion..."
     ghcup install $fullVersion
     ghcup set $fullVersion
-
-    # remove docs and profiling libs
-    ghc_dir="$(ghcup whereis basedir)/ghc/$fullVersion"
-    [ -e "${ghc_dir}" ] || exit 1
-    find "${ghc_dir}" \( -name "*_p.a" -o -name "*.p_hi" \) -type f -delete
-    rm -r "${ghc_dir}"/share/*
-    unset ghc_bin_dir ghc_dir
 done
 
 echo "install cabal..."


### PR DESCRIPTION
This was initially meant to save space in docker containers, but breaks several use cases and runner images shouldn't have space constraints.

