### PR TITLE
[macOS] Update templates to fix issue with node 19

### DIFF
--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -5,7 +5,7 @@ defaultVersion=$(get_toolset_value '.node.default')
 
 echo "Installing Node.js $defaultVersion"
 brew_smart_install "node@$defaultVersion"
-brew link node@$defaultVersion --force
+brew link node@$defaultVersion --force --overwrite
 
 echo Installing yarn...
 curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/images/macos/templates/macOS-11.anka.pkr.hcl
+++ b/images/macos/templates/macOS-11.anka.pkr.hcl
@@ -172,6 +172,7 @@ build {
       "./provision/core/ruby.sh",
       "./provision/core/rubygem.sh",
       "./provision/core/git.sh",
+      "./provision/core/mongodb.sh",
       "./provision/core/node.sh",
       "./provision/core/commonutils.sh",
     ]
@@ -214,7 +215,6 @@ build {
       "./provision/core/apache.sh",
       "./provision/core/nginx.sh",
       "./provision/core/postgresql.sh",
-      "./provision/core/mongodb.sh",
       "./provision/core/audiodevice.sh",
       "./provision/core/vcpkg.sh",
       "./provision/core/miniconda.sh",

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -157,6 +157,7 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
+                "./provision/core/mongodb.sh",
                 "./provision/core/node.sh"
             ],
             "environment_vars": [
@@ -201,7 +202,6 @@
                 "./provision/core/apache.sh",
                 "./provision/core/nginx.sh",
                 "./provision/core/postgresql.sh",
-                "./provision/core/mongodb.sh",
                 "./provision/core/audiodevice.sh",
                 "./provision/core/vcpkg.sh",
                 "./provision/core/miniconda.sh",

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -173,6 +173,7 @@ build {
       "./provision/core/ruby.sh",
       "./provision/core/rubygem.sh",
       "./provision/core/git.sh",
+      "./provision/core/mongodb.sh",
       "./provision/core/node.sh",
       "./provision/core/commonutils.sh"
     ]
@@ -215,7 +216,6 @@ build {
       "./provision/core/apache.sh",
       "./provision/core/nginx.sh",
       "./provision/core/postgresql.sh",
-      "./provision/core/mongodb.sh",
       "./provision/core/audiodevice.sh",
       "./provision/core/vcpkg.sh",
       "./provision/core/miniconda.sh",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -157,6 +157,7 @@
                 "./provision/core/ruby.sh",
                 "./provision/core/rubygem.sh",
                 "./provision/core/git.sh",
+                "./provision/core/mongodb.sh",
                 "./provision/core/node.sh",
                 "./provision/core/commonutils.sh"
             ],
@@ -202,7 +203,6 @@
                 "./provision/core/apache.sh",
                 "./provision/core/nginx.sh",
                 "./provision/core/postgresql.sh",
-                "./provision/core/mongodb.sh",
                 "./provision/core/audiodevice.sh",
                 "./provision/core/vcpkg.sh",
                 "./provision/core/miniconda.sh",


### PR DESCRIPTION
# Description
The latest build failed with the test error:
```
version should correspond to the version in the toolset 67ms (66ms|2ms)
Expected like wildcard 'v16*' to match 'v19.6.0', but it did not match.
```
The root cause of installing node.js v19.6.0 was "mongosh" which uses this app as a dependency.

This is the first try to unblock the build

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
