### PR TITLE
[Ubuntu] hardcode chromium revision for 110.x

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -14,6 +14,12 @@ function GetChromiumRevision {
     URL="https://omahaproxy.appspot.com/deps.json?version=${CHROME_VERSION}"
     REVISION=$(curl -s $URL | jq -r '.chromium_base_position')
 
+    # both 110.0.5481.100 and 110.0.5481.96 return old incorrect revision
+    # nothing to compare with, hardcode temporarily.
+    if [ $REVISION -eq "839" ]; then
+       REVISION="1084008"
+    fi
+
     # Some Google Chrome versions are based on Chromium revisions for which a (usually very old) Chromium release with the same number exist. So far this has heppened with 4 digits long Chromium revisions (1060, 1086).
     # Use the previous Chromium release when this happens to avoid downloading and installing very old Chromium releases that would break image build because of incompatibilities.
     # First reported with: https://github.com/actions/runner-images/issues/5256


### PR DESCRIPTION
# Description
To unblock image generation we have to temporarily hardcode the chromium revision.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
