### PR TITLE
Revert "[Ubuntu] workaround libodbc installation (#7117)"

### DIFF
--- a/images/linux/scripts/installers/mssql-cmd-tools.sh
+++ b/images/linux/scripts/installers/mssql-cmd-tools.sh
@@ -7,9 +7,7 @@
 export ACCEPT_EULA=Y
 
 apt-get update
-# both libodbc1 nd libodbc2 install libodbc.so.2.0.0, temporary workaround
-# https://github.com/microsoft/linux-package-repositories/issues/39
-apt-get install -o Dpkg::Options::="--force-overwrite" -y mssql-tools unixodbc-dev
+apt-get install -y mssql-tools unixodbc-dev
 apt-get -f install
 ln -s /opt/mssql-tools/bin/* /usr/local/bin/
 


### PR DESCRIPTION
This reverts commit c89bab7e421dbab8edddb75d8f5b3ad93a898aa5.

As it seems to be fixed