### PR TITLE
[Ubuntu] Remove libssl dependency

### DIFF
--- a/images/linux/scripts/installers/sqlpackage.sh
+++ b/images/linux/scripts/installers/sqlpackage.sh
@@ -8,12 +8,6 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
-# Install libssl1.1 dependency
-if isUbuntu22; then
-    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb" "/tmp"
-    dpkg -i /tmp/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
-fi
-
 # Install SqlPackage
 download_with_retries "https://aka.ms/sqlpackage-linux" "." "sqlpackage.zip"
 


### PR DESCRIPTION
# Description
Remove sqlpackage fix for Ubuntu 22.04
<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
https://github.com/actions/runner-images/issues/7147
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
