### PR TITLE
[macOS] point Xcode 13.4 to 13.4.1

### DIFF
--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -5,8 +5,7 @@
             {"link": "14.2", "version": "14.2.0"},
             { "link": "14.1", "version": "14.1.0"},
             { "link": "14.0.1", "version": "14.0.1", "symlinks": ["14.0"] },
-            { "link": "13.4.1", "version": "13.4.1" },
-            { "link": "13.4", "version": "13.4.0" },
+            { "link": "13.4.1", "version": "13.4.1", "symlinks": ["13.4"] },
             { "link": "13.3.1", "version": "13.3.1", "symlinks": ["13.3"] },
             { "link": "13.2.1", "version": "13.2.1", "symlinks": ["13.2"] },
             { "link": "13.1", "version": "13.1.0" }


### PR DESCRIPTION
# Description
Announcement(issue-7127): Xcode 13.4 will be pointing to Xcode 13.4.1 and Xcode 13.4 removed.

#### Related issue:
https://github.com/actions/runner-images/issues/7127

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
