### PR TITLE
[macOS] do not install tcl/tk symlinks on BigSur

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -84,7 +84,7 @@ az extension add -n azure-devops
 
 # Workaround https://github.com/actions/runner-images/issues/4931
 # by making Tcl/Tk paths the same on macOS 10.15 and macOS 11
-if is_BigSur || is_Monterey; then
+if is_Monterey; then
     version=$(brew info tcl-tk --json | jq -r '.[].installed[].version')
     ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtcl8.6.dylib /usr/local/lib/libtcl8.6.dylib
     ln -s /usr/local/Cellar/tcl-tk/$version/lib/libtk8.6.dylib /usr/local/lib/libtk8.6.dylib


### PR DESCRIPTION
They already exist in before.