### PR TITLE
Revert "Remove libssl dependency (#7166)"

### DIFF
--- a/images/linux/scripts/installers/sqlpackage.sh
+++ b/images/linux/scripts/installers/sqlpackage.sh
@@ -8,6 +8,12 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
+# Install libssl1.1 dependency
+if isUbuntu22; then
+    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb" "/tmp"
+    dpkg -i /tmp/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
+fi
+
 # Install SqlPackage
 download_with_retries "https://aka.ms/sqlpackage-linux" "." "sqlpackage.zip"
 


### PR DESCRIPTION
This reverts commit 7fa12b880649ddd0a00fed00b79a5bd4aed462ab.

As it breaks the provision process with the 

```
Feb 27 19:49:31 fv-az165-537 provisioner[1599]: No usable version of libssl was found
```