### PR TITLE
style: use the interval value in retry function

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -33,7 +33,7 @@ download_with_retries() {
             return 0
         else
             echo "Error — Either HTTP response code for '$URL' is wrong - '$http_code' or exit code is not 0 - '$exit_code'. Waiting $interval seconds before the next attempt, $retries attempts left"
-            sleep 30
+            sleep "$interval"
         fi
         # Enable exit on error back
         set -e


### PR DESCRIPTION
# Description
Improvement. This request is to use the value from the `interval` variable for the sleep when retrying the downloads according to the message in https://github.com/actions/runner-images/blob/macOS-12/20230219.1/images/linux/scripts/helpers/install.sh#L35.
This allows the message to be logic to be aligned with the message.

## Related issue:

## Check list
- [ ] Related issue / work item is attached
  + _n/a_
- [ ] Tests are written (if applicable)
  + _I haven't written a test, is there any test for the download_with_retries function, that I can take a look and update?_
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
