### PR TITLE
[Ubuntu] Use variable instead of hard coded value

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -33,7 +33,7 @@ download_with_retries() {
             return 0
         else
             echo "Error — Either HTTP response code for '$URL' is wrong - '$http_code' or exit code is not 0 - '$exit_code'. Waiting $interval seconds before the next attempt, $retries attempts left"
-            sleep 30
+            sleep $interval
         fi
         # Enable exit on error back
         set -e


### PR DESCRIPTION
# Description
Use the interval value in retry function 
#### Related issue:
https://github.com/actions/runner-images/issues/7208
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
