### PR TITLE
[macOS] Use variable instead of hard coded value

### DIFF
--- a/images/macos/helpers/Common.Helpers.psm1
+++ b/images/macos/helpers/Common.Helpers.psm1
@@ -131,7 +131,7 @@ function Start-DownloadWithRetry {
                 exit 1
             }
 
-            Write-Host "Waiting '$Interval' seconds before retrying. Retries left: $Retries"
+            Write-Host "Waiting $Interval seconds before retrying. Retries left: $Retries"
             Start-Sleep -Seconds $Interval
         }
     }

--- a/images/macos/helpers/Common.Helpers.psm1
+++ b/images/macos/helpers/Common.Helpers.psm1
@@ -101,7 +101,8 @@ function Start-DownloadWithRetry {
         [string] $Url,
         [string] $Name,
         [string] $DownloadPath = "${env:Temp}",
-        [int] $Retries = 20
+        [int] $Retries = 20,
+        [int] $Interval = 30
     )
 
     if ([String]::IsNullOrEmpty($Name)) {
@@ -130,8 +131,8 @@ function Start-DownloadWithRetry {
                 exit 1
             }
 
-            Write-Host "Waiting 30 seconds before retrying. Retries left: $Retries"
-            Start-Sleep -Seconds 30
+            Write-Host "Waiting '$Interval' seconds before retrying. Retries left: $Retries"
+            Start-Sleep -Seconds $Interval
         }
     }
 


### PR DESCRIPTION
# Description
Use the interval value in retry function
#### Related issue:
https://github.com/actions/runner-images/issues/7208
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
