### PR TITLE
[ubuntu] fix cmdline-tools parser

### DIFF
--- a/images/linux/scripts/installers/android.sh
+++ b/images/linux/scripts/installers/android.sh
@@ -57,7 +57,7 @@ else
         download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
         cmdlineToolsVersion=$(
         yq -p=xml \
-        '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
+        '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
         /tmp/repository2-1.xml
         )
 


### PR DESCRIPTION
# Description

Format got changed

#### Related issue: https://github.com/actions/runner-images/issues/7226

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
