### PR TITLE
Revert "[Ubuntu] Update Maven to 3.9.0 (#7060)"

### DIFF
--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -84,7 +84,7 @@
                 "versions": [ "8", "11", "12" ]
             }
         ],
-        "maven": "3.9.0"
+        "maven": "3.8.7"
     },
     "android": {
         "platform_min_version": "23",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -86,7 +86,7 @@
                 "versions": [ "8", "11" ]
             }
         ],
-        "maven": "3.9.0"
+        "maven": "3.8.7"
     },
     "android": {
         "cmdline-tools": "latest",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -74,7 +74,7 @@
                 "versions": [ "8", "11", "17" ]
             }
         ],
-        "maven": "3.9.0"
+        "maven": "3.8.7"
     },
     "android": {
         "cmdline-tools": "latest",


### PR DESCRIPTION
This reverts commit 7e014ba67ba4fccf5280394ff77663a65eb0ca84.

# Description
The latest stable maven release broke deployments to/incompatible with GitHub Packages.
Talking with support the root cause seems to be this commit.
