### PR TITLE
[windows] Fix version for docker-compose v1

### DIFF
--- a/images/win/scripts/Installers/Install-Docker.ps1
+++ b/images/win/scripts/Installers/Install-Docker.ps1
@@ -35,7 +35,8 @@ $instScriptPath = Start-DownloadWithRetry -Url $instScriptUrl -Name "install-doc
 New-Item -ItemType SymbolicLink -Path "C:\Windows\SysWOW64\docker.exe" -Target "C:\Windows\System32\docker.exe"
 
 Write-Host "Install-Package Docker-Compose v1"
-Choco-Install -PackageName docker-compose
+$versionToInstall = Get-LatestChocoPackageVersion -TargetVersion "1.29" -PackageName "docker-compose"
+Choco-Install -PackageName docker-compose -ArgumentList "--version=$versionToInstall"
 
 Write-Host "Install-Package Docker-Compose v2"
 $dockerComposev2Url = "https://github.com/docker/compose/releases/latest/download/docker-compose-windows-x86_64.exe"


### PR DESCRIPTION
# Description
Choco updated version of docker-compose to v2. Pin version v1 => 1.29.*

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
