### PR TITLE
[Ubuntu] Update Maven to 3.8.8, new download link

### DIFF
--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -138,7 +138,7 @@ echo "ANT_HOME=/usr/share/ant" | tee -a /etc/environment
 
 # Install Maven
 mavenVersion=$(get_toolset_value '.java.maven')
-mavenDownloadUrl="https://www-eu.apache.org/dist/maven/maven-3/${mavenVersion}/binaries/apache-maven-${mavenVersion}-bin.zip"
+mavenDownloadUrl="https://dlcdn.apache.org/maven/maven-3/${mavenVersion}/binaries/apache-maven-${mavenVersion}-bin.zip"
 download_with_retries ${mavenDownloadUrl} "/tmp" "maven.zip"
 unzip -qq -d /usr/share /tmp/maven.zip
 ln -s /usr/share/apache-maven-${mavenVersion}/bin/mvn /usr/bin/mvn

--- a/images/linux/toolsets/toolset-1804.json
+++ b/images/linux/toolsets/toolset-1804.json
@@ -84,7 +84,7 @@
                 "versions": [ "8", "11", "12" ]
             }
         ],
-        "maven": "3.8.7"
+        "maven": "3.8.8"
     },
     "android": {
         "platform_min_version": "23",

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -86,7 +86,7 @@
                 "versions": [ "8", "11" ]
             }
         ],
-        "maven": "3.8.7"
+        "maven": "3.8.8"
     },
     "android": {
         "cmdline-tools": "latest",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -74,7 +74,7 @@
                 "versions": [ "8", "11", "17" ]
             }
         ],
-        "maven": "3.8.7"
+        "maven": "3.8.8"
     },
     "android": {
         "cmdline-tools": "latest",


### PR DESCRIPTION
# Description
Maven 3.8.7 available only as archived version, download links were updated.
More info here: https://maven.apache.org/download.cgi

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
