### PR TITLE
[ubuntu] aws session manager plugin 1.2.458.0 fix

### DIFF
--- a/images/linux/scripts/tests/CLI.Tools.Tests.ps1
+++ b/images/linux/scripts/tests/CLI.Tools.Tests.ps1
@@ -23,7 +23,7 @@ Describe "AWS" {
     }
 
     It "Session Manager Plugin for the AWS CLI" {
-        session-manager-plugin | Out-String | Should -Match "plugin was installed successfully"
+        session-manager-plugin 2>&1 | Out-String | Should -Match "plugin was installed successfully"
     }
 
     It "AWS SAM CLI" {


### PR DESCRIPTION
# Description

AWS session manager plugin 1.2.458.0 has introduced breaking change: output was redirected to stderr instead of stdout.
automatic test should have been updated accordingly

#### Related issue:

https://github.com/actions/runner-images/issues/7284

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
