### PR TITLE
[Windows] AWS CLI session manager plugin test fix

### DIFF
--- a/images/win/scripts/Tests/CLI.Tools.Tests.ps1
+++ b/images/win/scripts/Tests/CLI.Tools.Tests.ps1
@@ -24,7 +24,7 @@ Describe "AWS" {
     }
 
     It "Session Manager Plugin for the AWS CLI" {
-        session-manager-plugin 2>&1 | Out-String | Should -Match "plugin was installed successfully"
+        @(session-manager-plugin) -Match '\S' | Out-String | Should -Match "plugin was installed successfully"
     }
 
     It "AWS SAM CLI" {

--- a/images/win/scripts/Tests/CLI.Tools.Tests.ps1
+++ b/images/win/scripts/Tests/CLI.Tools.Tests.ps1
@@ -24,7 +24,7 @@ Describe "AWS" {
     }
 
     It "Session Manager Plugin for the AWS CLI" {
-        session-manager-plugin | Out-String | Should -BeLike "* plugin was installed successfully. *"
+        session-manager-plugin 2>&1 | Out-String | Should -Match "plugin was installed successfully"
     }
 
     It "AWS SAM CLI" {

--- a/images/win/scripts/Tests/CLI.Tools.Tests.ps1
+++ b/images/win/scripts/Tests/CLI.Tools.Tests.ps1
@@ -24,7 +24,7 @@ Describe "AWS" {
     }
 
     It "Session Manager Plugin for the AWS CLI" {
-        session-manager-plugin | Out-String | Should -Match "plugin was installed successfully"
+        session-manager-plugin | Out-String | Should -BeLike "* plugin was installed successfully. *"
     }
 
     It "AWS SAM CLI" {


### PR DESCRIPTION
# Description
AWS session manager plugin 1.2.458.0 has introduced breaking change causing automatic test failure

#### Related issue:
https://github.com/actions/runner-images/issues/7284
## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
