### PR TITLE
[macos] ignore "vmkdump" folder in VISphere

### DIFF
--- a/images.CI/macos/select-datastore.ps1
+++ b/images.CI/macos/select-datastore.ps1
@@ -67,7 +67,7 @@ function Select-DataStore {
     $availableDatastores = $availableClusterDatastores `
     | Where-Object { $_.FreeSpaceGB -ge $thresholdInGb } `
     | Where-Object {
-        $vmOnDatastore = @((Get-ChildItem -Path $_.DatastoreBrowserPath).Name -notmatch "^\.").Count
+        $vmOnDatastore = @((Get-ChildItem -Path $_.DatastoreBrowserPath).Name -notmatch '(^\.|vmkdump)').Count
         $vmOnDatastore -lt $vmCount } `
     | Group-Object -Property { $vmOnDatastore }
 


### PR DESCRIPTION

# Description

Small improvement for MacOS image generation. We need to ignore "vmkdump" because it is not VM folder

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
