### PR TITLE
[Windows] Upgrade openssl from light version to full

### DIFF
--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -455,10 +455,7 @@
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
-            {
-                "name": "openssl.light",
-                "args": [ "--version=1.1.1.20181020" ]
-            },
+            { "name": "openssl"},
             { "name": "packer" },
             { "name": "strawberryperl" },
             { "name": "pulumi" },

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -366,10 +366,7 @@
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
-            {
-                "name": "openssl.light",
-                "args": [ "--version=1.1.1.20181020" ]
-            },
+            { "name": "openssl" },
             { "name": "packer" },
             { "name": "strawberryperl" },
             { "name": "pulumi" },


### PR DESCRIPTION
# Description
Install full version of Win64 OpenSSL instead of just the most commonly used essentials. This is to include into the image extra development libraries that may be needed during a CI workflow.

Also the package containing light version of OpenSSL doesn't provide the latest patch for version 1.1.1 while the full one does.

#### Related issue: https://github.com/actions/runner-images/issues/7283

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
