### PR TITLE
[Windows] Add script for OpenSSL installation

### DIFF
--- a/images/win/scripts/Installers/Install-OpenSSL.ps1
+++ b/images/win/scripts/Installers/Install-OpenSSL.ps1
@@ -1,0 +1,37 @@
+################################################################################
+##  File:  Install-OpenSSL.ps1
+##  Desc:  Install win64-openssl.
+################################################################################
+
+$arch = "INTEL"
+$bits = "64"
+$light = "False"
+$installer = "exe"
+$version = (Get-ToolsetContent).openssl.version
+$installDir = "$Env:ProgramFiles\OpenSSL"
+
+# Fetch available installers list
+$jsonUrl = 'https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json'
+$installersAvailable = (Invoke-WebRequest $jsonUrl | ConvertFrom-Json -AsHashtable).files.values
+
+# Select appropriate installers
+$installersMatching = $installersAvailable | Where-Object {
+  ($_.basever -Eq $version -Or $_.basever -Like "$version.*") -And $_.arch -Eq $arch -And $_.bits -Eq $bits -And $_.light -Eq $light -And $_.installer -Eq $installer
+}
+
+# Get installer of the latest version
+$latestInstaller = $installersMatching |
+Sort-Object { [version]$_.basever }, subver | 
+Select-Object -Last 1
+
+# Invoke installation
+$installerUrl = $latestInstaller.url
+$installerName = "openssl-$($latestInstaller.basever)$($latestInstaller.subver)-setup.$($latestInstaller.installer)"
+$installerArgs = '/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`""
+Install-Binary -Url "$installerUrl" -Name "$installerName" -ArgumentList $installerArgs
+
+# Update PATH
+Add-MachinePathItem "$installDir\bin"
+$env:Path = Get-MachinePath
+
+Invoke-PesterTests -TestFile "Tools" -TestName "OpenSSL"

--- a/images/win/scripts/Installers/Install-OpenSSL.ps1
+++ b/images/win/scripts/Installers/Install-OpenSSL.ps1
@@ -5,14 +5,17 @@
 
 $arch = "INTEL"
 $bits = "64"
-$light = "False"
+$light = $false
 $installer = "exe"
 $version = (Get-ToolsetContent).openssl.version
 $installDir = "$Env:ProgramFiles\OpenSSL"
 
 # Fetch available installers list
 $jsonUrl = 'https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json'
-$installersAvailable = (Invoke-WebRequest $jsonUrl | ConvertFrom-Json -AsHashtable).files.values
+$installersAvailable = @()
+(Invoke-RestMethod $jsonUrl).files.PSObject.Properties |
+Where-Object MemberType -Eq NoteProperty |
+ForEach-Object { $installersAvailable += $_.Value }
 
 # Select appropriate installers
 $installersMatching = $installersAvailable | Where-Object {

--- a/images/win/scripts/Tests/ChocoPackages.Tests.ps1
+++ b/images/win/scripts/Tests/ChocoPackages.Tests.ps1
@@ -42,25 +42,25 @@ Describe "Jq" {
 
 Describe "Nuget" {
     It "Nuget" {
-        "nuget" | Should -ReturnZeroExitCode
+       "nuget" | Should -ReturnZeroExitCode
     }
 }
 
 Describe "Packer" {
     It "Packer" {
-        "packer --version" | Should -ReturnZeroExitCode
+       "packer --version" | Should -ReturnZeroExitCode
     }
 }
 
 Describe "Perl" {
     It "Perl" {
-        "perl --version" | Should -ReturnZeroExitCode
+       "perl --version" | Should -ReturnZeroExitCode
     }
 }
 
 Describe "Pulumi" {
     It "pulumi" {
-        "pulumi version" | Should -ReturnZeroExitCode
+       "pulumi version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/win/scripts/Tests/ChocoPackages.Tests.ps1
+++ b/images/win/scripts/Tests/ChocoPackages.Tests.ps1
@@ -42,31 +42,25 @@ Describe "Jq" {
 
 Describe "Nuget" {
     It "Nuget" {
-       "nuget" | Should -ReturnZeroExitCode
-    }
-}
-
-Describe "OpenSSL" {
-    It "OpenSSL" {
-       "openssl version" | Should -ReturnZeroExitCode
+        "nuget" | Should -ReturnZeroExitCode
     }
 }
 
 Describe "Packer" {
     It "Packer" {
-       "packer --version" | Should -ReturnZeroExitCode
+        "packer --version" | Should -ReturnZeroExitCode
     }
 }
 
 Describe "Perl" {
     It "Perl" {
-       "perl --version" | Should -ReturnZeroExitCode
+        "perl --version" | Should -ReturnZeroExitCode
     }
 }
 
 Describe "Pulumi" {
     It "pulumi" {
-       "pulumi version" | Should -ReturnZeroExitCode
+        "pulumi version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -2,11 +2,11 @@ Describe "Azure Cosmos DB Emulator" {
     $cosmosDbEmulatorRegKey = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" | Get-ItemProperty | Where-Object { $_.DisplayName -eq 'Azure Cosmos DB Emulator' }
     $installDir = $cosmosDbEmulatorRegKey.InstallLocation
 
-    It "Azure Cosmos DB Emulator install location registry key exists" -TestCases @{installDir = $installDir} {
+    It "Azure Cosmos DB Emulator install location registry key exists" -TestCases @{installDir = $installDir } {
         $installDir | Should -Not -BeNullOrEmpty
     }
 
-    It "Azure Cosmos DB Emulator exe file exists" -TestCases @{installDir = $installDir} {
+    It "Azure Cosmos DB Emulator exe file exists" -TestCases @{installDir = $installDir } {
         $exeFilePath = Join-Path $installDir 'CosmosDB.Emulator.exe'
         $exeFilePath | Should -Exist
     }
@@ -17,7 +17,7 @@ Describe "Bazel" {
         @{ ToolName = "bazel" }
         @{ ToolName = "bazelisk" }
     ) {
-        "$ToolName --version"| Should -ReturnZeroExitCode
+        "$ToolName --version" | Should -ReturnZeroExitCode
     }
 }
 
@@ -135,7 +135,7 @@ Describe "NET48" {
 
 Describe "NSIS" {
     It "NSIS" {
-       "makensis /VERSION" | Should -ReturnZeroExitCode
+        "makensis /VERSION" | Should -ReturnZeroExitCode
     }
 }
 
@@ -211,9 +211,9 @@ Describe "Pipx" {
 }
 
 Describe "Kotlin" {
-    $kotlinPackages =  @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-jvm")
+    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-jvm")
 
-    It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } })  {
+    It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
         "$toolName -version" | Should -ReturnZeroExitCode
     }
 }
@@ -221,5 +221,11 @@ Describe "Kotlin" {
 Describe "SQL OLEDB Driver" {
     It "SQL OLEDB Driver" {
         "HKLM:\SOFTWARE\Microsoft\MSOLEDBSQL" | Should -Exist
+    }
+}
+
+Describe "OpenSSL" {
+    It "OpenSSL" {
+        "openssl version" | Should -ReturnZeroExitCode
     }
 }

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -2,11 +2,11 @@ Describe "Azure Cosmos DB Emulator" {
     $cosmosDbEmulatorRegKey = Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" | Get-ItemProperty | Where-Object { $_.DisplayName -eq 'Azure Cosmos DB Emulator' }
     $installDir = $cosmosDbEmulatorRegKey.InstallLocation
 
-    It "Azure Cosmos DB Emulator install location registry key exists" -TestCases @{installDir = $installDir } {
+    It "Azure Cosmos DB Emulator install location registry key exists" -TestCases @{installDir = $installDir} {
         $installDir | Should -Not -BeNullOrEmpty
     }
 
-    It "Azure Cosmos DB Emulator exe file exists" -TestCases @{installDir = $installDir } {
+    It "Azure Cosmos DB Emulator exe file exists" -TestCases @{installDir = $installDir} {
         $exeFilePath = Join-Path $installDir 'CosmosDB.Emulator.exe'
         $exeFilePath | Should -Exist
     }
@@ -17,7 +17,7 @@ Describe "Bazel" {
         @{ ToolName = "bazel" }
         @{ ToolName = "bazelisk" }
     ) {
-        "$ToolName --version" | Should -ReturnZeroExitCode
+        "$ToolName --version"| Should -ReturnZeroExitCode
     }
 }
 
@@ -135,7 +135,7 @@ Describe "NET48" {
 
 Describe "NSIS" {
     It "NSIS" {
-        "makensis /VERSION" | Should -ReturnZeroExitCode
+       "makensis /VERSION" | Should -ReturnZeroExitCode
     }
 }
 
@@ -211,9 +211,9 @@ Describe "Pipx" {
 }
 
 Describe "Kotlin" {
-    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-jvm")
+    $kotlinPackages =  @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-jvm")
 
-    It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
+    It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } })  {
         "$toolName -version" | Should -ReturnZeroExitCode
     }
 }

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -455,10 +455,6 @@
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
-            {
-                "name": "openssl.light",
-                "args": [ "--version=1.1.1.20181020" ]
-            },
             { "name": "packer" },
             { "name": "strawberryperl" },
             { "name": "pulumi" },
@@ -503,5 +499,8 @@
     "kotlin": {
         "version": "latest",
         "binary_name": "kotlin-compiler"
+    },
+    "openssl": {
+        "version": "1.1.1"
     }
 }

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -366,10 +366,6 @@
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
-            {
-                "name": "openssl.light",
-                "args": [ "--version=1.1.1.20181020" ]
-            },
             { "name": "packer" },
             { "name": "strawberryperl" },
             { "name": "pulumi" },
@@ -414,5 +410,8 @@
     "kotlin": {
         "version": "latest",
         "binary_name": "kotlin-compiler"
+    },
+    "openssl": {
+        "version": "1.1.1"
     }
 }

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -185,7 +185,8 @@
                 "{{ template_dir }}/scripts/Installers/Install-AzureDevOpsCli.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-CommonUtils.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-Kotlin.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-Kotlin.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-OpenSSL.ps1"
             ]
         },
         {

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -191,7 +191,8 @@
                 "{{ template_dir }}/scripts/Installers/Install-AzureDevOpsCli.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-CommonUtils.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-JavaTools.ps1",
-                "{{ template_dir }}/scripts/Installers/Install-Kotlin.ps1"
+                "{{ template_dir }}/scripts/Installers/Install-Kotlin.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-OpenSSL.ps1"
             ]
         },
         {


### PR DESCRIPTION
# Description

Add script to install OpenSSL using executable installer rather then choco package. This is mainly to be able to select which version to install and to switch between light and full variants. The problem with choco is that light package doesn't provide up-to-date patch for OpenSSL 1.1.1 and full package doesn't have versions for OpenSSL 3.x.

Script uses repo https://github.com/slproweb/opensslhashes to get information about currently available versions of Win-OpenSSL installers, filters out installers that don't satisfy the requirements provided and selects the latest version among remaining ones.

Currently it is configured to install full variant of the version 1.1.1.

#### Related issue: https://github.com/actions/runner-images/issues/7283

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
