### PR TITLE
[macos,ubuntu,windows] remove go 1.17

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -45,12 +45,11 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "1.17.*",
                 "1.18.*",
                 "1.19.*",
                 "1.20.*"
             ],
-            "default": "1.17.*"
+            "default": "1.20.*"
         },
         {
             "name": "Ruby",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -41,12 +41,11 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "1.17.*",
                 "1.18.*",
                 "1.19.*",
                 "1.20.*"
             ],
-            "default": "1.18.*"
+            "default": "1.20.*"
         },
         {
             "name": "Ruby",

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -268,7 +268,6 @@
             "platform" : "darwin",
             "variable_template" : "GOROOT_{0}_{1}_X64",
             "versions": [
-                "1.17.*",
                 "1.18.*",
                 "1.19.*",
                 "1.20.*"

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -95,7 +95,7 @@
         ]
     },
     "go": {
-        "default": "1.18"
+        "default": "1.20"
     },
     "node": {
         "default": "18"

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -74,12 +74,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.17.*",
                 "1.18.*",
                 "1.19.*",
                 "1.20.*"
             ],
-            "default": "1.17.*"
+            "default": "1.20.*"
         }
     ],
     "powershellModules": [

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -66,12 +66,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.17.*",
                 "1.18.*",
                 "1.19.*",
                 "1.20.*"
             ],
-            "default": "1.17.*"
+            "default": "1.20.*"
         }
     ],
     "powershellModules": [


### PR DESCRIPTION
# Description

### Breaking changes
Go 1.17.x will be removed from all OSes and 1.20.x will be set as default.

### Target date
Image deployment is starting on April 3 and will take 3-4 days.

### The motivation for the changes
As of the [software support](https://github.com/actions/runner-images#software-and-image-support) policy only 3 latest versions of Go are supported.

### Possible impact
If your builds depend on Go 1.17.x they can be broken.

#### Related issue:

https://github.com/actions/runner-images/issues/7276

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
