### PR TITLE
[ubuntu] remove go 1.17

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -45,12 +45,11 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "1.17.*",
                 "1.18.*",
                 "1.19.*",
                 "1.20.*"
             ],
-            "default": "1.17.*"
+            "default": "1.20.*"
         },
         {
             "name": "Ruby",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -41,12 +41,11 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "1.17.*",
                 "1.18.*",
                 "1.19.*",
                 "1.20.*"
             ],
-            "default": "1.18.*"
+            "default": "1.20.*"
         },
         {
             "name": "Ruby",


### PR DESCRIPTION
# Description

### Breaking changes
Go 1.17.x will be removed from all OSes and 1.20.x will be set as default.

### Target date
Image deployment is starting on April 3 and will take 3-4 days.

### The motivation for the changes
As of the [software support](https://github.com/actions/runner-images#software-and-image-support) policy only 3 latest versions of Go are supported.

### Possible impact
If your builds depend on Go 1.17.x they can be broken.

#### Related issue:

https://github.com/actions/runner-images/issues/7276

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
