### PR TITLE
[Windows] Validate OpenSSL version

### DIFF
--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -226,6 +226,7 @@ Describe "SQL OLEDB Driver" {
 
 Describe "OpenSSL" {
     It "OpenSSL" {
-        "openssl version" | Should -ReturnZeroExitCode
+        $OpenSSLVersion = (Get-ToolsetContent).openssl.version
+        openssl version | Should -BeLike "* ${OpenSSLVersion}*"
     }
 }


### PR DESCRIPTION
# Description
Currently test for OpenSSL only checks that OpenSSL binary exists and is executable but the version is not validated. This request changes test to ensure that the version of OpenSSL binary that is located using PATH matches the version specified in toolset.

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
