### PR TITLE
hide builds using dedicated runners from forks

### DIFF
--- a/.github/workflows/macos-generation.yml
+++ b/.github/workflows/macos-generation.yml
@@ -40,7 +40,12 @@ defaults:
 
 jobs:
   build:
+    #
+    # "macos-vmware" is dedicated runner not available in forks.
+    # to reduce undesired run attempts in forks, stick jobs to "actions" organization only
+    #
     runs-on: macos-vmware
+    if: ${{ github.repository_owner == 'actions' }}
     timeout-minutes: 1200
     steps:
     - uses: azure/login@v1

--- a/.github/workflows/ubuntu-win-generation.yml
+++ b/.github/workflows/ubuntu-win-generation.yml
@@ -24,7 +24,12 @@ defaults:
 
 jobs:
   build:
+    #
+    # "azure-builds" is dedicated runner not available in forks.
+    # to reduce undesired run attempts in forks, stick jobs to "actions" organization only
+    #
     runs-on: azure-builds
+    if: ${{ github.repository_owner == 'actions' }}
     timeout-minutes: 1200
     steps:
       - name: Determine checkout type


### PR DESCRIPTION
# Description

scheduled image generation uses dedicated "macos-vmware" runner not available in forks. 
thus builds should not be scheduled in forks

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
