### PR TITLE
[Windows] Add more releases per page for Ruby installer

### DIFF
--- a/images/win/scripts/Installers/Install-Ruby.ps1
+++ b/images/win/scripts/Installers/Install-Ruby.ps1
@@ -7,10 +7,11 @@ function Get-RubyVersions
 {
     param (
         [System.String] $Arch = "x64",
-        [System.String] $Extension = "7z"
+        [System.String] $Extension = "7z",
+        [System.String] $ReleasesAmount = "50"
     )
 
-    $uri = "https://api.github.com/repos/oneclick/rubyinstaller2/releases"
+    $uri = "https://api.github.com/repos/oneclick/rubyinstaller2/releases?per_page=$ReleasesAmount"
     try
     {
         $versionLists = @{}


### PR DESCRIPTION
# Description
Ruby 2.4 is too deep in current releases manifest. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
