### PR TITLE
Run bcdedit /set hypervisorschedulertyupe root

### DIFF
--- a/images/win/scripts/Installers/Install-WindowsFeatures.ps1
+++ b/images/win/scripts/Installers/Install-WindowsFeatures.ps1
@@ -24,3 +24,6 @@ foreach ($feature in $windowsFeatures) {
         throw "Failed to activate Windows Feature '$($feature.name)'"
     }
 }
+
+# 
+bcdedit /set hypervisorschedulertype root

--- a/images/win/scripts/Installers/Install-WindowsFeatures.ps1
+++ b/images/win/scripts/Installers/Install-WindowsFeatures.ps1
@@ -25,5 +25,6 @@ foreach ($feature in $windowsFeatures) {
     }
 }
 
-# 
+# it improves Android emulator launch on Windows Server
+# https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types
 bcdedit /set hypervisorschedulertype root


### PR DESCRIPTION
# Description

According to the email from: Alexander Grest <Alexander.Grest@microsoft.com>
```
[Hyper-V hypervisor scheduler types | Microsoft Learn](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/manage/manage-hyper-v-scheduler-types)

You could try to enable the root scheduler (bcdedit /set hypervisorschedulertyupe root) and see if it improves emulator launch, but please note that you lose isolation guarantees between SMT threads.
```


#### Related issue:

https://github.com/actions/runner-images-internal/issues/4786


## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
