### PR TITLE
Add .NET environment variables to windows image 

### DIFF
--- a/images/win/scripts/Installers/Install-DotnetSDK.ps1
+++ b/images/win/scripts/Installers/Install-DotnetSDK.ps1
@@ -9,6 +9,8 @@ New-Item -Path C:\Temp -Force -ItemType Directory
 
 # Set environment variables
 Set-SystemVariable -SystemVariable DOTNET_MULTILEVEL_LOOKUP -Value "0"
+Set-SystemVariable -SystemVariable DOTNET_NOLOGO -Value "1"
+Set-SystemVariable -SystemVariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE -Value "1"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
 


### PR DESCRIPTION
# Description
Improvement

Adds .NET environments variables that are already being added in the [Linux image](https://github.com/actions/runner-images/blob/07662e65bab775c1bf9e974047a33ab2929d1f1a/images/linux/scripts/installers/dotnetcore-sdk.sh#L87-L89).

This will remove some noise in the output and squeeze out some performance.

#### Related issue:

I started a [discussion post](https://github.com/actions/runner-images/discussions/7209), but I never received any feedback.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
