### PR TITLE
Fix failure when tags are set for Ubuntu 22 generation

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -268,6 +268,9 @@ Function GenerateResourcesAndImage {
             } else {
                 $AgentIp = "[]"
             }
+            if (-not $Tags) {
+                $Tags = @{}
+            }
         }
 
         if ($builderScriptPath.Contains(".json")) {

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -270,12 +270,14 @@ Function GenerateResourcesAndImage {
             }
         }
 
-        if ($Tags) {
-            $builderScriptPath_temp = $builderScriptPath.Replace(".json", "-temp.json")
-            $packer_script = Get-Content -Path $builderScriptPath | ConvertFrom-Json
-            $packer_script.builders | Add-Member -Name "azure_tags" -Value $Tags -MemberType NoteProperty
-            $packer_script | ConvertTo-Json -Depth 3 | Out-File $builderScriptPath_temp
-            $builderScriptPath = $builderScriptPath_temp
+        if ($builderScriptPath.Contains(".json")) {
+            if ($Tags) {
+                $builderScriptPath_temp = $builderScriptPath.Replace(".json", "-temp.json")
+                $packer_script = Get-Content -Path $builderScriptPath | ConvertFrom-Json
+                $packer_script.builders | Add-Member -Name "azure_tags" -Value $Tags -MemberType NoteProperty
+                $packer_script | ConvertTo-Json -Depth 3 | Out-File $builderScriptPath_temp
+                $builderScriptPath = $builderScriptPath_temp
+            }
         }
 
         & $packerBinary build -on-error="$($OnError)" `
@@ -288,6 +290,7 @@ Function GenerateResourcesAndImage {
             -var "storage_account=$($storageAccountName)" `
             -var "install_password=$($InstallPassword)" `
             -var "allowed_inbound_ip_addresses=$($AgentIp)" `
+            -var "azure_tags=$($Tags | ConvertTo-Json -Compress)" `
             $builderScriptPath
     }
     catch {

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -4,7 +4,7 @@ variable "allowed_inbound_ip_addresses" {
   default = []
 }
 
-variable "azure_tag" {
+variable "azure_tags" {
   type    = map(string)
   default = {}
 }
@@ -171,7 +171,7 @@ source "azure-arm" "build_vhd" {
   vm_size                                = "${var.vm_size}"
 
   dynamic "azure_tag" {
-    for_each = var.azure_tag
+    for_each = var.azure_tags
     content {
       name = azure_tag.key
       value = azure_tag.value


### PR DESCRIPTION
# Description
The logic is used in GenerateResourcesAndImage for setting tags is suitable for json manifests only. It causes function failure when tags are set for Ubuntu22 build. This PR is use proper way to pass tags to the build based on hcl2 manifest.

#### Related issue: https://github.com/actions/runner-images/issues/6946

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
