### PR TITLE
Upgrade az powershell to 9.6.0

### DIFF
--- a/images/linux/Ubuntu2004-Readme.md
+++ b/images/linux/Ubuntu2004-Readme.md
@@ -252,7 +252,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - PowerShell 7.2.10
 
 #### PowerShell Modules
-- Az: 9.3.0
+- Az: 9.6.0
 - Az (Cached): 3.1.0.zip, 4.4.0.zip, 5.9.0.zip, 6.6.0.zip, 7.5.0.zip
 - MarkdownPS: 1.9
 - Microsoft.Graph: 1.25.0

--- a/images/linux/Ubuntu2204-Readme.md
+++ b/images/linux/Ubuntu2204-Readme.md
@@ -236,7 +236,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - PowerShell 7.2.10
 
 #### PowerShell Modules
-- Az: 9.3.0
+- Az: 9.6.0
 - MarkdownPS: 1.9
 - Microsoft.Graph: 1.25.0
 - Pester: 5.4.1

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -121,7 +121,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "9.3.0"
+                "9.6.0"
             ],
             "zip_versions": [
                 "3.1.0",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -109,7 +109,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "9.3.0"
+                "9.6.0"
             ],
             "zip_versions": [
             ]

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -506,7 +506,7 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 - PowerShell 7.2.10
 
 #### Powershell Modules
-- Az: 9.3.0
+- Az: 9.6.0
 - Azure: 2.1.0 (Default), 5.3.0
 - AzureRM: 2.1.0 (Default), 6.13.1
 - Az (Cached): 1.0.0.zip, 1.6.0.zip, 2.3.2.zip, 2.6.0.zip, 3.1.0.zip, 3.5.0.zip, 3.8.0.zip, 4.3.0.zip, 4.4.0.zip, 4.7.0.zip, 5.5.0.zip, 5.9.0.zip, 6.6.0.zip, 7.5.0.zip

--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -537,7 +537,7 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 - PowerShell 7.2.10
 
 #### Powershell Modules
-- Az: 9.3.0
+- Az: 9.6.0
 - Azure: 2.1.0 (Default), 5.3.0
 - AzureRM: 2.1.0 (Default), 6.13.1
 - Az (Cached): 7.5.0.zip

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -127,7 +127,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "9.3.0"
+                "9.6.0"
             ],
             "zip_versions": [
                 "1.0.0",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -119,7 +119,7 @@
             "name": "az",
             "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
-                "9.3.0"
+                "9.6.0"
             ],
             "zip_versions": [
                 "7.5.0"


### PR DESCRIPTION
# Description
This will just upgrade the powershell Az module from 9.3.0 to 9.6.0

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
Fixes #7441 

## Check list
- [X] Related issue / work item is attached
- [] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [] Changes are tested and related VM images are successfully generated
