### PR TITLE
[ubuntu] script after reboot need more time before executing

### DIFF
--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -312,7 +312,7 @@
         },
         {
             "type": "shell",
-            "pause_before": "60s",
+            "pause_before": "2m0s",
             "start_retry_timeout": "10m",
             "scripts": [
                 "{{template_dir}}/scripts/installers/cleanup.sh"

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -369,7 +369,7 @@ build {
 
   provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    pause_before        = "1m0s"
+    pause_before        = "2m0s"
     scripts             = ["${path.root}/scripts/installers/cleanup.sh"]
     start_retry_timeout = "10m"
   }


### PR DESCRIPTION
# Description

When trying to build the ubuntu 22.04 image (also relevant for ubuntu20.04), there is a provisioner in  `images/linux/ubuntu2204.pkr.hcl` which does a reboot:

    provisioner "shell" {
    execute_command   = "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
    expect_disconnect = true
    scripts           = ["${local.scripts_folder}/base/reboot.sh"]
    }

the next provisioner has pause_before of "1m0s":

    provisioner "shell" {
    execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
    pause_before        = "1m0s"
    scripts             = ["${local.scripts_folder}/installers/cleanup.sh"]
    start_retry_timeout = "10m"
  }

When running the pipeline I get:
`Error uploading script: Error copying input data into local temporary file. Check that TEMPDIR has enough space`.
After running this multiple times the pipeline succeeded once, i figured that the "pause_before" was too short and the VM hasn't finished rebooting and ssh service was still down, after changing the value in cleanup.sh to `pause_before = "2m0s" `  the code consistently works.

#### Related issue: [https://github.com/actions/runner-images/discussions/6074](https://github.com/actions/runner-images/discussions/6074)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
