### PR TITLE
Add ca cert to the command line to use TLS in DVT racks

### DIFF
--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -22,7 +22,9 @@ function Push-AnkaTemplateToRegistry {
         Invoke-WebRequest -Uri $uri -Method Delete | Out-Null
     }
 
-    $command = "anka registry --registry-path $RegistryUrl push --force --tag $TagName $TemplateName"
+    $AnkaConfigPath="/Users/maccloud/.config/anka/certs"
+    $AnkaCaCrtPath="$AnkaConfigPath/anka-ca-crt.pem"
+    $command = "anka registry --cacert $AnkaCaCrtPath --registry-path $RegistryUrl push --force --tag $TagName $TemplateName"
     Invoke-AnkaCommand -Command $command
 }
 

--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -22,8 +22,7 @@ function Push-AnkaTemplateToRegistry {
         Invoke-WebRequest -Uri $uri -Method Delete | Out-Null
     }
 
-    $AnkaConfigPath="$HOME/.config/anka/certs"
-    $AnkaCaCrtPath="$AnkaConfigPath/anka-ca-crt.pem"
+    $AnkaCaCrtPath="$HOME/.config/anka/certs/anka-ca-crt.pem"
     $command = "anka registry --cacert $AnkaCaCrtPath --registry-path $RegistryUrl push --force --tag $TagName $TemplateName"
     Invoke-AnkaCommand -Command $command
 }

--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -19,7 +19,7 @@ function Push-AnkaTemplateToRegistry {
     $images | Where-Object name -eq $TemplateName | ForEach-Object {
         $id = $_.uuid
         Show-StringWithFormat "Deleting '$TemplateName[$id]' VM and '$TagName' tag"
-        $curlCommand='curl -X DELETE -k "{0}/registry/vm?id={1}"' -f $RegistryUrl, $id
+        $curlCommand='curl -s -X DELETE -k "{0}/registry/vm?id={1}"' -f $RegistryUrl, $id
         Invoke-AnkaCommand -Command $curlCommand
     }
 

--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -14,7 +14,8 @@ function Push-AnkaTemplateToRegistry {
     )
 
     # if registry uuid doesn't match than delete an image in registry
-    $images = anka --machine-readable registry --registry-path $RegistryUrl list | ConvertFrom-Json | ForEach-Object body
+    $AnkaCaCrtPath="$HOME/.config/anka/certs/anka-ca-crt.pem"
+    $images = anka --machine-readable registry --cacert $AnkaCaCrtPath --registry-path $RegistryUrl list | ConvertFrom-Json | ForEach-Object body
     $images | Where-Object name -eq $TemplateName | ForEach-Object {
         $id = $_.uuid
         Show-StringWithFormat "Deleting '$TemplateName[$id]' VM and '$TagName' tag"
@@ -22,7 +23,6 @@ function Push-AnkaTemplateToRegistry {
         Invoke-AnkaCommand -Command $curlCommand
     }
 
-    $AnkaCaCrtPath="$HOME/.config/anka/certs/anka-ca-crt.pem"
     $command = "anka registry --cacert $AnkaCaCrtPath --registry-path $RegistryUrl push --force --tag $TagName $TemplateName"
     Invoke-AnkaCommand -Command $command
 }

--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -18,8 +18,8 @@ function Push-AnkaTemplateToRegistry {
     $images | Where-Object name -eq $TemplateName | ForEach-Object {
         $id = $_.uuid
         Show-StringWithFormat "Deleting '$TemplateName[$id]' VM and '$TagName' tag"
-        $uri = '{0}/registry/vm?id={1}' -f $RegistryUrl, $id
-        Invoke-WebRequest -Uri $uri -Method Delete | Out-Null
+        $curlCommand='curl -X DELETE -k "{0}/registry/vm?id={1}"' -f $RegistryUrl, $id
+        Invoke-AnkaCommand -Command $curlCommand
     }
 
     $AnkaCaCrtPath="$HOME/.config/anka/certs/anka-ca-crt.pem"

--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -22,7 +22,7 @@ function Push-AnkaTemplateToRegistry {
         Invoke-WebRequest -Uri $uri -Method Delete | Out-Null
     }
 
-    $AnkaConfigPath="/Users/maccloud/.config/anka/certs"
+    $AnkaConfigPath="$HOME/.config/anka/certs"
     $AnkaCaCrtPath="$AnkaConfigPath/anka-ca-crt.pem"
     $command = "anka registry --cacert $AnkaCaCrtPath --registry-path $RegistryUrl push --force --tag $TagName $TemplateName"
     Invoke-AnkaCommand -Command $command


### PR DESCRIPTION
# Description
Fixing an issue in generating Anka images for MacOS arm64 images. TLS was not enabled for the Anka node, and TLS verification was failing.
MacOS Intel images generation was not impacted as Anka TLS and TLS verification were disabled. It will be enabled there too.

Error seen first in [this build](https://dev.azure.com/mseng/AzDevNext.Deploy/_build/results?buildId=19752222&view=logs&j=80d86624-2c9a-5cad-9434-144b838e69fb&t=829dae9b-42f5-5e1c-cb9a-4dfa99b6fb63&l=117):  `Invoke-AnkaCommand: There is an error during command execution: anka: SSL connect error`
Error after enabling TLS for Anka in [this build](https://dev.azure.com/mseng/AzDevNext.Deploy/_build/results?buildId=19756189&view=logs&j=80d86624-2c9a-5cad-9434-144b838e69fb&t=829dae9b-42f5-5e1c-cb9a-4dfa99b6fb63&l=116): `Invoke-AnkaCommand: There is an error during command execution: anka: SSL peer certificate or SSH remote key was not OK`

Tested directly on the M1 and Intel racks.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
