### PR TITLE
[macos] add macOS-13 to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,6 +23,7 @@ body:
         - label: Ubuntu 22.04
         - label: macOS 11
         - label: macOS 12
+        - label: macOS 13
         - label: Windows Server 2019
         - label: Windows Server 2022
   - type: textarea


### PR DESCRIPTION
# Description

since macOS-13 is generally available, let us add to 

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5030

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
