### PR TITLE
Fix issue where json encoding is wrong in PS5

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -278,7 +278,7 @@ Function GenerateResourcesAndImage {
                 $builderScriptPath_temp = $builderScriptPath.Replace(".json", "-temp.json")
                 $packer_script = Get-Content -Path $builderScriptPath | ConvertFrom-Json
                 $packer_script.builders | Add-Member -Name "azure_tags" -Value $Tags -MemberType NoteProperty
-                $packer_script | ConvertTo-Json -Depth 3 | Out-File $builderScriptPath_temp
+                $packer_script | ConvertTo-Json -Depth 3 | Out-File -Encoding Ascii $builderScriptPath_temp
                 $builderScriptPath = $builderScriptPath_temp
             }
         }


### PR DESCRIPTION
# Description

Out-File cmdlet uses different encodings by default in PS5 and PS7. While it defaults to UTF8 with no BOM in PS7, the default in PS5 is UTF-16LE that makes temporary json (that is generated when tags are set) unreadable by Packer.

This PR forces Out-File cmdlet to use ANSI encoding.

#### Related issue: https://github.com/actions/runner-images/issues/7534

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
