### PR TITLE
Test firefox without sudo

### DIFF
--- a/images/linux/scripts/tests/Browsers.Tests.ps1
+++ b/images/linux/scripts/tests/Browsers.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "Firefox" {
     It "Firefox" {
-        "sudo -i firefox --version" | Should -ReturnZeroExitCode
+        "firefox --version" | Should -ReturnZeroExitCode
     }
 
     It "Geckodriver" {


### PR DESCRIPTION
# Description
Pester test for Firefox browser uses sudo command that prevents test from succeeding on live VM after provisioning. This PR fixes that test.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
