### PR TITLE
Keep generation scripts in macOS and Ubuntu images

### DIFF
--- a/images/linux/scripts/installers/post-deployment.sh
+++ b/images/linux/scripts/installers/post-deployment.sh
@@ -11,9 +11,6 @@ chmod -R 777 /opt
 echo "chmod -R 777 /usr/share"
 chmod -R 777 /usr/share
 
-# remove installer and helper folders
-rm -rf $HELPER_SCRIPT_FOLDER
-rm -rf $INSTALLER_SCRIPT_FOLDER
 chmod 755 $IMAGE_FOLDER
 
 # Remove quotes around PATH

--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -32,7 +32,7 @@ if ! is_Ventura; then
     yarn cache clean
 fi
 # Clean up temporary directories
-sudo rm -rf ~/utils ~/image-generation /tmp/*
+sudo rm -rf ~/utils /tmp/*
 
 # Erase all indexes and wait until the rebuilding process ends,
 # for now there is no way to get status of indexing process, it takes around 3 minutes to accomplish


### PR DESCRIPTION
# Description
Currently generation scripts are removed from image in one of the last stages of image generation. We need them to run Pester tests on runners provisioned in real environment.

The alternative solution would be to checkout this repo each time we want to run tests. But in may cause unexpected failures when testing previously built image after tests or toolset in repo have been updated.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
