### PR TITLE
Fix variable references in Ubuntu 22 template

### DIFF
--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -257,7 +257,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["DEBIAN_FRONTEND=noninteractive", "HELPER_SCRIPTS=${local.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${local.installer_script_folder}"]
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive", "HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = ["${path.root}/scripts/installers/apt-vital.sh"]
   }


### PR DESCRIPTION
# Description
Ubuntu 22 generation is broken due to invalid variable references in HCL template. This PR fixes those references.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
