### PR TITLE
Separate VM resizing and moving into two different scripts

### DIFF
--- a/.github/workflows/macos-generation.yml
+++ b/.github/workflows/macos-generation.yml
@@ -184,10 +184,16 @@ jobs:
           -VIServer "${{ secrets.VISERVER_V2 }}" `
           -VIUserName "${{ secrets.VI_USER_NAME }}" `
           -VIPassword "${{ secrets.VI_PASSWORD }}" `
-          -JobStatus "${{ job.status }}" `
+          -JobStatus "${{ job.status }}"
+
+        ./images.CI/macos/set-vm-size.ps1 `
+          -VMName "${{ env.VM_NAME }}" `
           -CpuCount "$cpuCount" `
           -CoresPerSocketCount "$coresPerSocketCount" `
-          -Memory "$memory"
+          -Memory "$memory" `
+          -VIServer "${{ secrets.VISERVER_V2 }}" `
+          -VIUserName "${{ secrets.VI_USER_NAME }}" `
+          -VIPassword "${{ secrets.VI_PASSWORD }}"
 
     - name: Destroy VM (if build canceled only)
       if: ${{ cancelled() }}

--- a/.github/workflows/macos-generation.yml
+++ b/.github/workflows/macos-generation.yml
@@ -174,10 +174,6 @@ jobs:
     - name: Move vm to cold storage and clear datastore tag
       if: ${{ always() }}
       run: |
-        $cpuCount = 3
-        $coresPerSocketCount = 3
-        $memory = 14336
-
         ./images.CI/macos/move-vm.ps1 `
           -VMName "${{ env.VM_NAME }}" `
           -TargetDataStore "${{ inputs.target_datastore }}" `
@@ -185,6 +181,12 @@ jobs:
           -VIUserName "${{ secrets.VI_USER_NAME }}" `
           -VIPassword "${{ secrets.VI_PASSWORD }}" `
           -JobStatus "${{ job.status }}"
+
+    - name: Set VM size
+      run: |
+        $cpuCount = 3
+        $coresPerSocketCount = 3
+        $memory = 14336
 
         ./images.CI/macos/set-vm-size.ps1 `
           -VMName "${{ env.VM_NAME }}" `

--- a/images.CI/macos/move-vm.ps1
+++ b/images.CI/macos/move-vm.ps1
@@ -66,7 +66,7 @@ try {
 $vm = Get-VM $VMName
 if (($env:AGENT_JOBSTATUS -and $env:AGENT_JOBSTATUS -eq 'Failed') -or ($JobStatus -and $JobStatus -eq 'failure')) {
     try {
-        if($vm.PowerState -ne "PoweredOff") {
+        if ($vm.PowerState -ne "PoweredOff") {
             Stop-VM -VM $vm -Confirm:$false -ErrorAction Stop | Out-Null
         }
         Set-VM -VM $vm -Name "${VMName}_failed" -Confirm:$false -ErrorAction Stop | Out-Null
@@ -82,13 +82,5 @@ try {
     Write-Host "VM has been moved successfully to target datastore '$TargetDataStore'"
 } catch {
     Write-Host "##vso[task.LogIssue type=error;]Failed to move VM '$VMName' to target datastore '$TargetDataStore'"
-    exit 1
-}
-
-try {
-    Write-Host "Change CPU count to $CpuCount, cores count to $CoresPerSocketCount, amount of RAM to $Memory"
-    $vm | Set-VM -NumCPU $CpuCount -CoresPerSocket $CoresPerSocketCount -MemoryMB $Memory -Confirm:$false -ErrorAction Stop | Out-Null
-} catch {
-    Write-Host "##vso[task.LogIssue type=error;]Failed to change specs for VM '$VMName'"
     exit 1
 }

--- a/images.CI/macos/set-vm-size.ps1
+++ b/images.CI/macos/set-vm-size.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+
+This script sets resources for VM
+
+.PARAMETER VMName
+VM name to resize (Example "macOS-10.15_20201012.4")
+
+.PARAMETER VIServer
+vCenter address (Example "10.0.1.16")
+
+.PARAMETER VIUserName
+vCenter username (Example "Administrator")
+
+.PARAMETER VIPassword
+vCenter password (Example "12345678")
+
+.PARAMETER CpuCount
+Target number of CPUs (Example "3")
+
+.PARAMETER CoresPerSocketCount
+Target number of cores per socket (Example "3")
+
+.PARAMETER Memory
+Target amount of memory in MB (Example "14336")
+
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$VMName,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$VIServer,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$VIUserName,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$VIPassword,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [int32]$CpuCount,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [int32]$CoresPerSocketCount,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [int64]$Memory
+)
+
+# Import helpers module
+Import-Module $PSScriptRoot\helpers.psm1 -DisableNameChecking
+
+# Connection to a vCenter Server system
+Connect-VCServer -VIServer $VIServer -VIUserName $VIUserName -VIPassword $VIPassword
+
+$vm = Get-VM $VMName
+try {
+    Write-Host "Change CPU count to $CpuCount, cores count to $CoresPerSocketCount, amount of RAM to $Memory"
+    $vm | Set-VM -NumCPU $CpuCount -CoresPerSocket $CoresPerSocketCount -MemoryMB $Memory -Confirm:$false -ErrorAction Stop | Out-Null
+} catch {
+    Write-Host "##vso[task.LogIssue type=error;]Failed to change specs for VM '$VMName'"
+    exit 1
+}


### PR DESCRIPTION
# Description

Currently `vm-move.ps1` script has off-target functionality in terms of setting VM size. It causes resizing to be performed twice in some image generation pipelines. This request separates logic of moving and resizing in two different scripts to avoid aforementioned behavior.

#### Related issue: https://github.com/actions/runner-images-internal/issues/5061

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
