### PR TITLE
[macos] systeminfo.txt: remove debug leftover

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -302,21 +302,11 @@ PARALLELS_DMG_URL environment variable. A system extension is allowed for this v
     $miscellaneousEnvNotes.AddNote($notes)
 }
 
-#
-# Generate systeminfo.txt with information about image (for debug purpose)
-#
-$dateTime = (Get-Date).ToString("yyyy-MM-dd HH:mm:ss")
-$systemInfo = [string]::Join([System.Environment]::NewLine, @(
-        "Date: ${dateTime}",
-        "Image name: ${ImageName}"
-    ))
-
 if (-not (Test-Path $OutputDirectory)) { New-Item -Path $OutputDirectory -ItemType Directory | Out-Null }
 
 #
 # Write final reports
 #
 Write-Host $markdownExtended
-$systemInfo | Out-File -FilePath "${OutputDirectory}/systeminfo.txt" -Encoding UTF8NoBOM
 $softwareReport.ToJson() | Out-File -FilePath "${OutputDirectory}/systeminfo.json" -Encoding UTF8NoBOM
 $softwareReport.ToMarkdown() | Out-File -FilePath "${OutputDirectory}/systeminfo.md" -Encoding UTF8NoBOM


### PR DESCRIPTION
# Description

in image generation pipeline several "software report" files are created, including "systeminfo.txt"
that file is not used later, we can drop its generation

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5013

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
