### PR TITLE
[ubuntu] fix the condition in docker-moby.sh

### DIFF
--- a/images/linux/scripts/installers/docker-moby.sh
+++ b/images/linux/scripts/installers/docker-moby.sh
@@ -29,7 +29,7 @@ systemctl is-enabled --quiet docker.service || systemctl enable docker.service
 sleep 10
 docker info
 
-if [ "${DOCKERHUB_PULL_IMAGES:-yes}" -eq "yes" ]; then
+if [ "${DOCKERHUB_PULL_IMAGES:-yes}" == "yes" ]; then
     # If credentials are provided, attempt to log into Docker Hub
     # with a paid account to avoid Docker Hub's rate limit.
     if [ "${DOCKERHUB_LOGIN}" ] && [ "${DOCKERHUB_PASSWORD}" ]; then


### PR DESCRIPTION
# Description
Fix the condition in the file docker-moby.sh
Instead of "-eq" we will use "=="
"==" is for string comparisons and "-eq" is for numeric ones.

#### Related issue:
#7586

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
