### PR TITLE
[macos] split XCode installation and validation into two steps

### DIFF
--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -29,6 +29,10 @@ $xcodeVersions | ForEach-Object -ThrottleLimit $threadCount -Parallel {
     Import-Module "$env:HOME/image-generation/helpers/Xcode.Installer.psm1"
 
     Install-XcodeVersion -Version $_.version -LinkTo $_.link
+}
+
+Write-Host "Validating Xcode integrity..."
+$xcodeVersions | ForEach-Object {
     Confirm-XcodeIntegrity -Version $_.link
     Approve-XcodeLicense -Version $_.link
 }


### PR DESCRIPTION
quite often we observe "invalid resource directory (directory or signature have been modified)" during validating XCode integrity.

there are might be some issues with running "spctl" in parallel, so let us move validating out of parallel loop

# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

#### Related issue:

https://github.com/actions/runner-images-internal/issues/4912

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
