### PR TITLE
[macos] enable python3 (and pipx) on macOS13

### DIFF
--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -3,14 +3,16 @@ source ~/utils/utils.sh
 
 echo "Installing Python Tooling"
 
-echo "Install latest Python 2"
-Python2Url="https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg"
-download_with_retries $Python2Url "/tmp" "python2.pkg"
-sudo installer -pkg /tmp/python2.pkg -target /
-pip install --upgrade pip
+if ! is_Veertu; then
+    echo "Install latest Python 2"
+    Python2Url="https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg"
+    download_with_retries $Python2Url "/tmp" "python2.pkg"
+    sudo installer -pkg /tmp/python2.pkg -target /
+    pip install --upgrade pip
 
-echo "Install Python2 certificates"
-bash -c "/Applications/Python\ 2.7/Install\ Certificates.command"
+    echo "Install Python2 certificates"
+    bash -c "/Applications/Python\ 2.7/Install\ Certificates.command"
+fi
 
 # Close Finder window
 if is_Veertu; then

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -52,8 +52,12 @@ $languageAndRuntime.AddToolVersion("Perl", $(Get-PerlVersion))
 if (-not $os.IsVenturaArm64) {
     $languageAndRuntime.AddToolVersion("PHP", $(Get-PHPVersion))
 }
-if (-not $os.IsVenturaArm64) {
+
+if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
     $languageAndRuntime.AddToolVersion("Python", $(Get-PythonVersion))
+}
+
+if (-not $os.IsVenturaArm64) {
     $languageAndRuntime.AddToolVersion("Python3", $(Get-Python3Version))
 }
 $languageAndRuntime.AddToolVersion("R", $(Get-RVersion))
@@ -72,10 +76,10 @@ if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
 $packageManagement.AddToolVersion("NPM", $(Get-NPMVersion))
 if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
     $packageManagement.AddToolVersion("NuGet", $(Get-NuGetVersion))
+    $packageManagement.AddToolVersion("Pip", $(Get-PipVersion -Version 2))
 }
 
 if (-not $os.IsVenturaArm64) {
-    $packageManagement.AddToolVersion("Pip", $(Get-PipVersion -Version 2))
     $packageManagement.AddToolVersion("Pip3", $(Get-PipVersion -Version 3))
     $packageManagement.AddToolVersion("Pipx", $(Get-PipxVersion))
 }

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -52,7 +52,7 @@ $languageAndRuntime.AddToolVersion("Perl", $(Get-PerlVersion))
 if (-not $os.IsVenturaArm64) {
     $languageAndRuntime.AddToolVersion("PHP", $(Get-PHPVersion))
 }
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
+if (-not $os.IsVenturaArm64) {
     $languageAndRuntime.AddToolVersion("Python", $(Get-PythonVersion))
     $languageAndRuntime.AddToolVersion("Python3", $(Get-Python3Version))
 }
@@ -72,10 +72,14 @@ if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
 $packageManagement.AddToolVersion("NPM", $(Get-NPMVersion))
 if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
     $packageManagement.AddToolVersion("NuGet", $(Get-NuGetVersion))
+}
+
+if (-not $os.IsVenturaArm64) {
     $packageManagement.AddToolVersion("Pip", $(Get-PipVersion -Version 2))
     $packageManagement.AddToolVersion("Pip3", $(Get-PipVersion -Version 3))
     $packageManagement.AddToolVersion("Pipx", $(Get-PipxVersion))
 }
+
 $packageManagement.AddToolVersion("RubyGems", $(Get-RubyGemsVersion))
 if (-not $os.IsVenturaArm64) {
     $packageManagement.AddToolVersion("Vcpkg", $(Get-VcpkgVersion))

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -163,6 +163,7 @@ build {
       "./provision/core/open_windows_check.sh",
       "./provision/core/powershell.sh",
       "./provision/core/dotnet.sh",
+      "./provision/core/python.sh",
       "./provision/core/azcopy.sh",
       "./provision/core/ruby.sh",
       "./provision/core/rubygem.sh",

--- a/images/macos/tests/Python.Tests.ps1
+++ b/images/macos/tests/Python.Tests.ps1
@@ -3,29 +3,13 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Python" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
-    It "Python 2 is available" {
-        "python --version" | Should -ReturnZeroExitCode
-    }
-
-    It "Python 2 is real 2.x" {
-        (Get-CommandResult "python --version").Output | Should -BeLike "Python 2.*"
-    }
-
-    It "Python 2 is installed under /usr/local/bin" {
-        Get-WhichTool "python" | Should -BeLike "/usr/local/bin*"
-    }
-
+Describe "Python3" -Skip:($os.IsVenturaArm64) {
     It "Python 3 is available" {
         "python3 --version" | Should -ReturnZeroExitCode
     }
 
     It "Python 3 is installed under /usr/local/bin" {
         Get-WhichTool "python3" | Should -BeLike "/usr/local/bin*"
-    }
-
-    It "Pip 2 is available" {
-        "pip --version" | Should -ReturnZeroExitCode
     }
 
     It "Pip 3 is available" {
@@ -40,6 +24,25 @@ Describe "Python" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
         $pip3Path = Split-Path (readlink (which pip3))
         $python3Path = Split-Path (readlink (which python3))
         $pip3Path | Should -BeExactly $python3Path
+    }
+
+}
+
+Describe "Python2" -Skip:($os.IsVenturaArm64 -or $os.IsVentura) {
+    It "Python 2 is available" {
+        "python --version" | Should -ReturnZeroExitCode
+    }
+
+    It "Python 2 is real 2.x" {
+        (Get-CommandResult "python --version").Output | Should -BeLike "Python 2.*"
+    }
+
+    It "Python 2 is installed under /usr/local/bin" {
+        Get-WhichTool "python" | Should -BeLike "/usr/local/bin*"
+    }
+
+    It "Pip 2 is available" {
+        "pip --version" | Should -ReturnZeroExitCode
     }
 
     It "2to3 symlink does not point to Python 2" {

--- a/images/macos/tests/Python.Tests.ps1
+++ b/images/macos/tests/Python.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Python" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
+Describe "Python" -Skip:($os.IsVenturaArm64) {
     It "Python 2 is available" {
         "python --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Python.Tests.ps1
+++ b/images/macos/tests/Python.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Python" -Skip:($os.IsVenturaArm64) {
+Describe "Python" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
     It "Python 2 is available" {
         "python --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description

python (and pipx) added to MacOS13

#### Related issue:

https://github.com/actions/runner-images/issues/7590

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
