### PR TITLE
[macOS] update scripts to fix image generation

### DIFF
--- a/images/macos/provision/configuration/auto-software-update-arm64.exp
+++ b/images/macos/provision/configuration/auto-software-update-arm64.exp
@@ -1,0 +1,7 @@
+#! /usr/bin/expect -f
+
+set timeout -1
+spawn sudo /usr/sbin/softwareupdate --all --install --restart --verbose
+expect "Password*"
+send "[lindex $argv 0]\r"
+expect eof


### PR DESCRIPTION
# Description
This PR will update clean macOS generation scripts to support macOS 13 arm64.
Only in macOS13 arm64 asks for a password during software updates. 
And in this PR we are using additional **auto-software-update-arm64.exp** script to invoke software update and pass the password.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
