### PR TITLE
[Ubuntu 20.04/22.04] Add linux-modules-extra-azure to ubuntu images

### DIFF
--- a/images/linux/scripts/installers/linux-modules-extra-azure.sh
+++ b/images/linux/scripts/installers/linux-modules-extra-azure.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-################################################################################
-##  File:  linux-modules-extra-azure.sh
-##  Desc:  Installs linux-modules-extra-azure
-################################################################################
-
-kernelver=$(uname -r | sed 's/-azure//' | tr '-' '.')
-
-apt update -y && apt install -y linux-modules-extra-azure=$kernelver*

--- a/images/linux/scripts/installers/linux-modules-extra-azure.sh
+++ b/images/linux/scripts/installers/linux-modules-extra-azure.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+################################################################################
+##  File:  linux-modules-extra-azure.sh
+##  Desc:  Installs linux-modules-extra-azure
+################################################################################
+
+kernelver=$(uname -r | sed 's/-azure//' | tr '-' '.')
+
+apt update -y && apt install -y linux-modules-extra-azure=$kernelver*

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -206,6 +206,7 @@
             "type": "shell",
             "scripts": [
                 "{{template_dir}}/scripts/installers/apt-common.sh",
+                "{{template_dir}}/scripts/installers/linux-modules-extra-azure",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -206,7 +206,6 @@
             "type": "shell",
             "scripts": [
                 "{{template_dir}}/scripts/installers/apt-common.sh",
-                "{{template_dir}}/scripts/installers/linux-modules-extra-azure",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -206,6 +206,7 @@
             "type": "shell",
             "scripts": [
                 "{{template_dir}}/scripts/installers/apt-common.sh",
+                "{{template_dir}}/scripts/installers/linux-modules-extra-azure.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",
                 "{{template_dir}}/scripts/installers/azure-devops-cli.sh",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -285,6 +285,7 @@ build {
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
                         "${path.root}/scripts/installers/apt-common.sh",
+                        "${path.root}/scripts/installers/linux-modules-extra-azure.sh",
                         "${path.root}/scripts/installers/azcopy.sh",
                         "${path.root}/scripts/installers/azure-cli.sh",
                         "${path.root}/scripts/installers/azure-devops-cli.sh",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -285,7 +285,6 @@ build {
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
                         "${path.root}/scripts/installers/apt-common.sh",
-                        "${path.root}/scripts/installers/linux-modules-extra-azure",
                         "${path.root}/scripts/installers/azcopy.sh",
                         "${path.root}/scripts/installers/azure-cli.sh",
                         "${path.root}/scripts/installers/azure-devops-cli.sh",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -285,6 +285,7 @@ build {
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
                         "${path.root}/scripts/installers/apt-common.sh",
+                        "${path.root}/scripts/installers/linux-modules-extra-azure",
                         "${path.root}/scripts/installers/azcopy.sh",
                         "${path.root}/scripts/installers/azure-cli.sh",
                         "${path.root}/scripts/installers/azure-devops-cli.sh",


### PR DESCRIPTION
# Description
Add  linux-modules-extra-azure to ubuntu images 

#### Related issue:
https://github.com/actions/runner-images/issues/7587
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
