### PR TITLE
Add double quote escaping and update GenerateResourcesAndImage.ps1 documentation

### DIFF
--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -57,7 +57,7 @@ In any case you will need these software installed:
   ```
 
 - [Az Powershell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
-  
+
   Run this command in Powershell:
 
   ```powershell
@@ -91,6 +91,11 @@ Finally, run `GenerateResourcesAndImage` function setting mandatory arguments: i
 - `ResourceGroupName` - name of the resource group that will be created within your subscription (e.g. "imagegen-test")
 - `AzureLocation` - location where resources will be created (e.g. "East US")
 - `ImageType` - what image to build (we suggest choosing "UbuntuMinimal" here, other valid options are "Windows2019", "Windows2022", "Ubuntu2004", "Ubuntu2204")
+
+> :warning: When running `GenerateResourcesAndImage` in PowerShell 7.3, following command should be executed first:
+> ```powershell
+> $PSNativeCommandArgumentPassing = 'Legacy'
+> ```
 
 This function automatically creates all required Azure resources and kicks off packer image generation for the selected image type.
 

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -190,8 +190,8 @@ Function GenerateResourcesAndImage {
         # Resource group names may contain special characters, that are not allowed in the storage account name
         $storageAccountName = $storageAccountName.Replace("-", "").Replace("_", "").Replace("(", "").Replace(")", "").ToLower()
         $storageAccountName += "001"
-        
-        
+
+
         # Storage Account Name can only be 24 characters long
         if ($storageAccountName.Length -gt 24){
             $storageAccountName = $storageAccountName.Substring(0, 24)
@@ -266,10 +266,10 @@ Function GenerateResourcesAndImage {
             $AgentIp = (Invoke-RestMethod http://ipinfo.io/json).ip
             Write-Host "Restricting access to packer generated VM to agent IP Address: $AgentIp"
         }
-        
+
         if ($builderScriptPath.Contains("pkr.hcl")) {
             if ($AgentIp) {
-                $AgentIp = '[ "{0}" ]' -f $AgentIp
+                $AgentIp = '[ \"{0}\" ]' -f $AgentIp
             } else {
                 $AgentIp = "[]"
             }


### PR DESCRIPTION
# Description
Depending on PowerShell version, -RestrictToAgentIpAddress argument behaves differently.
Runners are using PowerShell 7.2, where double quotes should be escaped.
Documentation is updated.

#### Related issue: #7585

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
