### PR TITLE
[macOS] Fix Python2 installer condition

### DIFF
--- a/images/macos/provision/core/python.sh
+++ b/images/macos/provision/core/python.sh
@@ -3,7 +3,7 @@ source ~/utils/utils.sh
 
 echo "Installing Python Tooling"
 
-if ! is_Veertu; then
+if is_Monterey || is_BigSur; then
     echo "Install latest Python 2"
     Python2Url="https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg"
     download_with_retries $Python2Url "/tmp" "python2.pkg"


### PR DESCRIPTION
# Description
Fix Python installer script to install Python2 only on macOS 11 and 12

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
