### PR TITLE
Correct typo from 'Delimeter' to 'Delimiter'

### DIFF
--- a/helpers/software-report-base/SoftwareReport.Nodes.psm1
+++ b/helpers/software-report-base/SoftwareReport.Nodes.psm1
@@ -279,10 +279,10 @@ class TableNode: BaseNode {
         $maxColumnWidths = $this.CalculateColumnsWidth()
         $columnsCount = $maxColumnWidths.Count
 
-        $delimeterLine = [String]::Join("|", @("-") * $columnsCount)
+        $delimiterLine = [String]::Join("|", @("-") * $columnsCount)
 
         $sb = [System.Text.StringBuilder]::new()
-        @($this.Headers) + @($delimeterLine) + $this.Rows | ForEach-Object {
+        @($this.Headers) + @($delimiterLine) + $this.Rows | ForEach-Object {
             $sb.Append("|")
             $row = $_.Split("|")
 

--- a/images/win/scripts/ImageHelpers/TestsHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/TestsHelpers.ps1
@@ -113,8 +113,8 @@ function ShouldReturnZeroExitCodeWithParam {
 
     while ($delimiterCharacter.Length -le 2)
     {
-        $callParameterWithDelimeter = $delimiterCharacter + $CallParameter
-        $commandToCheck = "$ActualValue $callParameterWithDelimeter"
+        $callParameterWithDelimiter = $delimiterCharacter + $CallParameter
+        $commandToCheck = "$ActualValue $callParameterWithDelimiter"
         [bool]$succeeded = (ShouldReturnZeroExitCode -ActualValue $commandToCheck).Succeeded
         
         if ($succeeded)


### PR DESCRIPTION
# Description

Correct typo from 'Delimeter' to 'Delimiter'.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

None

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
