### PR TITLE
[Ubuntu] Fix url for Ubuntu 20 libcontainers repo key

### DIFF
--- a/images/linux/scripts/installers/containers.sh
+++ b/images/linux/scripts/installers/containers.sh
@@ -13,7 +13,7 @@ if isUbuntu20; then
     REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable"
     source /etc/os-release
     sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-    wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+    wget -nv https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
     apt-key add Release.key
 fi
 


### PR DESCRIPTION
# Description
Ubuntu 20 image generation silently fails on execution of containers.sh script because URL for libcontainers repo key is invalid.
Failed run example: https://github.com/actions/runner-images/actions/runs/5055635815/jobs/9072092744?pr=7627

This PR fixed URL and removes `-q` flag from `wget` command to see it's execution result.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
