### PR TITLE
[macOS] Add XCode 14.3.1 for macOS 13

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -40,6 +40,7 @@ body:
         - label: Ubuntu 22.04
         - label: macOS 11
         - label: macOS 12
+        - label: macOS 13
         - label: Windows Server 2019
         - label: Windows Server 2022
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -61,6 +61,7 @@ body:
         - label: Ubuntu 22.04
         - label: macOS 11
         - label: macOS 12
+        - label: macOS 13
         - label: Windows Server 2019
         - label: Windows Server 2022
   - type: textarea

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,6 +3,7 @@
         "default": "14.2",
         "x64": {
             "versions": [
+                { "link": "14.3.1", "version": "14.3.1" },
                 { "link": "14.3", "version": "14.3.0" },
                 { "link": "14.2", "version": "14.2.0" },
                 { "link": "14.1", "version": "14.1.0" }

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -11,6 +11,7 @@
         },
         "arm64":{
             "versions": [
+                { "link": "14.3.1", "version": "14.3.1" },
                 { "link": "14.3", "version": "14.3.0" },
                 { "link": "14.2", "version": "14.2.0" },
                 { "link": "14.1", "version": "14.1.0" }


### PR DESCRIPTION
# Description
The new version of XCode have been released recently for macOS 13. This PR is to install it on our runners.

#### Related issue: https://github.com/actions/runner-images/issues/7630

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
