### PR TITLE
[Windows] fix software report for innosetup

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Tools.psm1
@@ -87,7 +87,7 @@ function Get-GitLFSVersion {
 }
 
 function Get-InnoSetupVersion {
-    $innoSetupVersion = $(choco list --local-only innosetup) | Select-String -Pattern "InnoSetup"
+    $innoSetupVersion = $(choco list innosetup) | Select-String -Pattern "InnoSetup"
     return ($innoSetupVersion -replace "^InnoSetup").Trim()
 }
 


### PR DESCRIPTION
# Description
The "--local-only" key was deprecated and deleted from the software report generation.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
