### PR TITLE
[macos] add cookie based installation for Xcode

### DIFF
--- a/.github/workflows/macos-generation.yml
+++ b/.github/workflows/macos-generation.yml
@@ -105,6 +105,13 @@ jobs:
           -VIPassword ${{ secrets.VI_PASSWORD }} `
           -Cluster ${{ env.ESXI_CLUSTER }}
 
+    - name: Create xcversion session cookie file
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/xcversion-cookie
+        cookie='${{ secrets.XCVERSION_AUTH_COOKIE }}'
+        echo "$cookie" > ${{ runner.temp }}/xcversion-cookie/cookie
+
     - name: Build VM
       run: |
         $SensitiveData = @(
@@ -126,6 +133,7 @@ jobs:
         -var="baseimage_name=${{ inputs.base_image_name }}" `
         -var="xcode_install_user=${{ secrets.XCODE_USER }}" `
         -var="xcode_install_password=${{ secrets.XCODE_PASSWORD }}" `
+        -var="xcversion_auth_cookie=${{ env.XCVERSION_COOKIE_PATH }}" `
         -color=false `
         ${{ inputs.template_path }} `
         | Where-Object {
@@ -138,6 +146,7 @@ jobs:
       env:
         PACKER_LOG: 1
         PACKER_LOG_PATH: ${{ runner.temp }}/packer-log.txt
+        XCVERSION_COOKIE_PATH: ${{ runner.temp }}/xcversion-cookie/cookie
 
     - name: Prepare artifact
       shell: bash

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -7,6 +7,7 @@ jobs:
   variables:
   - group: Mac-Cloud Image Generation
   - group: Mac-Cloud Image Generation Key Vault
+  - group: XCode Installation
 
   steps:
   - pwsh: |
@@ -77,8 +78,9 @@ jobs:
         -var="github_api_pat=$(github_api_pat)" `
         -var="build_id=$(VirtualMachineName)" `
         -var="baseimage_name=${{ parameters.base_image_name }}" `
-        -var="xcode_install_user=$(xcode-installation-user)" `
-        -var="xcode_install_password=$(xcode-installation-password)" `
+        -var="xcode_install_user=$(xcode-installation-dummy-user)" `
+        -var="xcode_install_password=$(xcode-installation-dummy-password)" `
+        -var="xcversion_auth_cookie=$(xcversion_auth_cookie)" `
         -color=false `
         ${{ parameters.template_path }} `
         | Where-Object {

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -7,7 +7,6 @@ jobs:
   variables:
   - group: Mac-Cloud Image Generation
   - group: Mac-Cloud Image Generation Key Vault
-  - group: XCode Installation
 
   steps:
   - pwsh: |
@@ -61,7 +60,7 @@ jobs:
 
   - task: DownloadSecureFile@1
     name: xcVersionCookie
-    displayName: 'Download CA certificate'
+    displayName: 'Download xcversion session cookie'
     inputs:
       secureFile: 'cookie'
 
@@ -84,8 +83,8 @@ jobs:
         -var="github_api_pat=$(github_api_pat)" `
         -var="build_id=$(VirtualMachineName)" `
         -var="baseimage_name=${{ parameters.base_image_name }}" `
-        -var="xcode_install_user=$(xcode-installation-dummy-user)" `
-        -var="xcode_install_password=$(xcode-installation-dummy-password)" `
+        -var="xcode_install_user=$(xcode-installation-user)" `
+        -var="xcode_install_password=$(xcode-installation-password)" `
         -var="xcversion_auth_cookie=$(xcVersionCookie.secureFilePath)" `
         -color=false `
         ${{ parameters.template_path }} `

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -59,6 +59,12 @@ jobs:
                  -VIPassword '$(vcenter-password-v2)' `
                  -Cluster "$(esxi-cluster-v2)"
 
+  - task: DownloadSecureFile@1
+    name: xcVersionCookie
+    displayName: 'Download CA certificate'
+    inputs:
+      secureFile: 'cookie'
+
   - pwsh: |
       $SensitiveData = @(
           'IP address:',
@@ -80,7 +86,7 @@ jobs:
         -var="baseimage_name=${{ parameters.base_image_name }}" `
         -var="xcode_install_user=$(xcode-installation-dummy-user)" `
         -var="xcode_install_password=$(xcode-installation-dummy-password)" `
-        -var="xcversion_auth_cookie=$(xcversion_auth_cookie)" `
+        -var="xcversion_auth_cookie=$(xcVersionCookie.secureFilePath)" `
         -color=false `
         ${{ parameters.template_path }} `
         | Where-Object {

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -10,9 +10,6 @@ if ([string]::IsNullOrEmpty($env:XCODE_INSTALL_USER) -or [string]::IsNullOrEmpty
     throw "Required environment variables XCODE_INSTALL_USER and XCODE_INSTALL_PASSWORD are not set"
 }
 
-$xcCookieFile = New-Item -Type File -Path "$env:HOME/.fastlane/spaceship/$env:XCODE_INSTALL_USER/cookie" -Force
-$env:XCVERSION_AUTH_COOKIE >> $xcCookieFile
-
 # Spaceship Apple ID login fails due to Apple ID prompting to be upgraded to 2FA.
 # https://github.com/fastlane/fastlane/pull/18116
 $env:SPACESHIP_SKIP_2FA_UPGRADE = 1

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -10,6 +10,9 @@ if ([string]::IsNullOrEmpty($env:XCODE_INSTALL_USER) -or [string]::IsNullOrEmpty
     throw "Required environment variables XCODE_INSTALL_USER and XCODE_INSTALL_PASSWORD are not set"
 }
 
+$xcCookieFile = New-Item -Type File -Path "$env:HOME/.fastlane/spaceship/$env:XCODE_INSTALL_USER/cookie" -Force
+$env:XCVERSION_AUTH_COOKIE >> $xcCookieFile
+
 # Spaceship Apple ID login fails due to Apple ID prompting to be upgraded to 2FA.
 # https://github.com/fastlane/fastlane/pull/18116
 $env:SPACESHIP_SKIP_2FA_UPGRADE = 1

--- a/images/macos/templates/macOS-11.anka.pkr.hcl
+++ b/images/macos/templates/macOS-11.anka.pkr.hcl
@@ -44,6 +44,11 @@ variable "xcode_install_password" {
   sensitive = true
 }
 
+variable "xcversion_auth_cookie" {
+  type = string
+  default = ""
+}
+
 variable "vcpu_count" {
   type = string
   default = "6"
@@ -181,6 +186,15 @@ build {
       "USER_PASSWORD=${var.vm_password}"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    inline = [
+      "mkdir -p ~/.fastlane/spaceship/${var.xcode_install_user}"
+    ]
+  }
+  provisioner "file" {
+    destination = "~/.fastlane/spaceship/${var.xcode_install_user}/cookie"
+    source = "${var.xcversion_auth_cookie}"
   }
   provisioner "shell" {
     script = "./provision/core/xcode.ps1"

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -167,12 +167,20 @@
         },
         {
             "type": "shell",
+            "inline": "mkdir -p ~/.fastlane/spaceship/{{user `xcode_install_user`}}"
+        },
+        {
+            "type": "file",
+            "source": "{{user `xcversion_auth_cookie`}}",
+            "destination": "~/.fastlane/spaceship/{{user `xcode_install_user`}}/cookie"
+        },
+        {
+            "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
             "script": "./provision/core/xcode.ps1",
             "environment_vars": [
                 "XCODE_INSTALL_USER={{user `xcode_install_user`}}",
-                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}",
-                "XCVERSION_AUTH_COOKIE={{user `xcversion_auth_cookie`}}"
+                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}"
             ]
         },
         {

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -14,6 +14,7 @@
         "github_api_pat": null,
         "xcode_install_user": null,
         "xcode_install_password": null,
+        "xcversion_auth_cookie": null,
         "image_os": "macos11"
     },
     "builders": [
@@ -170,7 +171,8 @@
             "script": "./provision/core/xcode.ps1",
             "environment_vars": [
                 "XCODE_INSTALL_USER={{user `xcode_install_user`}}",
-                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}"
+                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}",
+                "XCVERSION_AUTH_COOKIE={{user `xcversion_auth_cookie`}}"
             ]
         },
         {

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -44,6 +44,11 @@ variable "xcode_install_password" {
   sensitive = true
 }
 
+variable "xcversion_auth_cookie" {
+  type = string
+  default = ""
+}
+
 variable "vcpu_count" {
   type = string
   default = "6"
@@ -182,6 +187,15 @@ build {
       "USER_PASSWORD=${var.vm_password}"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    inline = [
+      "mkdir -p ~/.fastlane/spaceship/${var.xcode_install_user}"
+    ]
+  }
+  provisioner "file" {
+    destination = "~/.fastlane/spaceship/${var.xcode_install_user}/cookie"
+    source = "${var.xcversion_auth_cookie}"
   }
   provisioner "shell" {
     script = "./provision/core/xcode.ps1"

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -169,12 +169,20 @@
         },
         {
             "type": "shell",
+            "inline": "mkdir -p ~/.fastlane/spaceship/{{user `xcode_install_user`}}"
+        },
+        {
+            "type": "file",
+            "source": "{{user `xcversion_auth_cookie`}}",
+            "destination": "~/.fastlane/spaceship/{{user `xcode_install_user`}}/cookie"
+        },
+        {
+            "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}",
             "script": "./provision/core/xcode.ps1",
             "environment_vars": [
                 "XCODE_INSTALL_USER={{user `xcode_install_user`}}",
-                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}",
-                "XCVERSION_AUTH_COOKIE={{user `xcversion_auth_cookie`}}"
+                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}"
             ]
         },
         {

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -14,6 +14,7 @@
         "github_api_pat": null,
         "xcode_install_user": null,
         "xcode_install_password": null,
+        "xcversion_auth_cookie": null,
         "image_os": "macos12"
     },
     "builders": [
@@ -172,7 +173,8 @@
             "script": "./provision/core/xcode.ps1",
             "environment_vars": [
                 "XCODE_INSTALL_USER={{user `xcode_install_user`}}",
-                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}"
+                "XCODE_INSTALL_PASSWORD={{user `xcode_install_password`}}",
+                "XCVERSION_AUTH_COOKIE={{user `xcversion_auth_cookie`}}"
             ]
         },
         {

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -44,6 +44,11 @@ variable "xcode_install_password" {
   sensitive = true
 }
 
+variable "xcversion_auth_cookie" {
+  type = string
+  default = ""
+}
+
 variable "vcpu_count" {
   type = string
   default = "6"
@@ -176,6 +181,15 @@ build {
       "USER_PASSWORD=${var.vm_password}"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    inline = [
+      "mkdir -p ~/.fastlane/spaceship/${var.xcode_install_user}"
+    ]
+  }
+  provisioner "file" {
+    destination = "~/.fastlane/spaceship/${var.xcode_install_user}/cookie"
+    source = "${var.xcversion_auth_cookie}"
   }
   provisioner "shell" {
     script = "./provision/core/xcode.ps1"

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -44,6 +44,11 @@ variable "xcode_install_password" {
   sensitive = true
 }
 
+variable "xcversion_auth_cookie" {
+  type = string
+  default = ""
+}
+
 variable "vcpu_count" {
   type = string
   default = "6"
@@ -176,6 +181,15 @@ build {
       "USER_PASSWORD=${var.vm_password}"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    inline = [
+      "mkdir -p ~/.fastlane/spaceship/${var.xcode_install_user}"
+    ]
+  }
+  provisioner "file" {
+    destination = "~/.fastlane/spaceship/${var.xcode_install_user}/cookie"
+    source = "${var.xcversion_auth_cookie}"
   }
   provisioner "shell" {
     script = "./provision/core/xcode.ps1"


### PR DESCRIPTION
# Description
XCode installation using xcode-install and 2FA enabled AppleID requires session cookie.
Add to image-generation workflows and packer templates

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
