### PR TITLE
set $IsLatest to false when specifying exact version

### DIFF
--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -109,7 +109,7 @@ function Get-MacOSIPSWInstaller {
         $targetVersion = Get-AvailableIPSWVersions -IsBeta $true -MacOSCodeNameOrVersion $MacOSName
         Write-host "`t[*] The 'BetaSearch' flag is set to true. Latestbeta macOS version is '$MacOSName' - '$targetVersion' now"
     } else {
-        $targetVersion = Get-AvailableIPSWVersions -MacOSCodeNameOrVersion $MacOSName
+        $targetVersion = Get-AvailableIPSWVersions -MacOSCodeNameOrVersion $MacOSName -IsLatest $false
         Write-host "`t[*] The exact version was specified - '$MacOSName' "
     }
 


### PR DESCRIPTION
# Description

set $IsLatest to false when specifying exact version

This is so that we take [this path](https://github.com/actions/runner-images/blob/dfdd2daf84e33e18c114a9986bab5418c381664a/images.CI/macos/anka/Service.Helpers.psm1#LL70C31-L70C31) when requesting the version from mist as currently, `IsLatest` is true by default.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
