### PR TITLE
[macos] add XCode 15 to MacOS 13 images

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,6 +3,7 @@
         "default": "14.2",
         "x64": {
             "versions": [
+                { "link": "15_beta", "version": "15_beta" },
                 { "link": "14.3.1", "version": "14.3.1" },
                 { "link": "14.3", "version": "14.3.0" },
                 { "link": "14.2", "version": "14.2.0" },
@@ -11,6 +12,7 @@
         },
         "arm64":{
             "versions": [
+                { "link": "15_beta", "version": "15_beta" },
                 { "link": "14.3.1", "version": "14.3.1" },
                 { "link": "14.3", "version": "14.3.0" },
                 { "link": "14.2", "version": "14.2.0" },


### PR DESCRIPTION
# Description

XCode 15 beta added to MacOS 13 (it is the only supported OS, no releases for MacOS 11,12)

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

https://github.com/actions/runner-images/issues/7672

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
