### PR TITLE
[Windows] targeting the previous release of Vcpkg

### DIFF
--- a/images/win/scripts/Installers/Install-Vcpkg.ps1
+++ b/images/win/scripts/Installers/Install-Vcpkg.ps1
@@ -8,6 +8,7 @@ $InstallDir = 'C:\vcpkg'
 $VcpkgExecPath = 'vcpkg.exe'
 
 git clone $Uri $InstallDir -q
+git checkout 638b1588be3a265a9c7ad5b212cef72a1cad336a
 
 # Build and integrate vcpkg
 Invoke-Expression "$InstallDir\bootstrap-vcpkg.bat"


### PR DESCRIPTION
# Description
In order to unlock the image generation, Vcpkg will use previous release.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/5147

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
