### PR TITLE
Set checkout options in image generation pipeline

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -43,6 +43,9 @@ jobs:
 
   steps:
   - checkout: ${{ parameters.repository_ref }}
+    clean: true
+    fetchDepth: 0
+    fetchTags: false
 
   - task: PowerShell@2
     displayName: 'Download custom repository'


### PR DESCRIPTION
# Description
Prevent image generation failure when invalid remote ref exists

Example: https://dev.azure.com/github/runner-images/_build/results?buildId=132220&view=logs&j=747417c8-a650-5aed-afed-d9b52dbd7d24&t=58defa89-d6ac-5420-9bcc-1b908ffd19eb

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
