### PR TITLE
Cache Android SDK packages list

### DIFF
--- a/images/linux/scripts/helpers/Common.Helpers.psm1
+++ b/images/linux/scripts/helpers/Common.Helpers.psm1
@@ -72,9 +72,20 @@ function Get-ToolsetValue {
 }
 
 function Get-AndroidPackages {
-    $androidSDKManagerPath = "/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager"
-    $androidPackages = & $androidSDKManagerPath --list --verbose 2>&1
-    return $androidPackages
+    $packagesListFile = "/usr/local/lib/android/sdk/packages-list.txt"
+
+    if (-Not (Test-Path -Path $packagesListFile -PathType Leaf)) {
+        (/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager --list --verbose 2>&1) |
+        Where-Object { $_ -Match "^[^\s]" } |
+        Where-Object { $_ -NotMatch "^(Loading |Info: Parsing |---|\[=+|Installed |Available )" } |
+        Where-Object { $_ -NotMatch "^[^;]*$" } |
+        Out-File -FilePath $packagesListFile
+
+        Write-Host Android packages list:
+        Get-Content $packagesListFile
+    }
+
+    return Get-Content $packagesListFile
 }
 
 function Get-EnvironmentVariable($variable) {

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -24,9 +24,20 @@ function Get-AndroidInstalledPackages {
 }
 
 function Get-AndroidPackages {
-    $androidSDKManagerPath = Get-AndroidSDKManagerPath
-    $androidPackages = & $androidSDKManagerPath --list --verbose
-    return $androidPackages
+    $packagesListFile = Join-Path $androidSDKDir "packages-list.txt"
+
+    if (-Not (Test-Path -Path $packagesListFile -PathType Leaf)) {
+        (/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager --list --verbose) |
+        Where-Object { $_ -Match "^[^\s]" } |
+        Where-Object { $_ -NotMatch "^(Loading |Info: Parsing |---|\[=+|Installed |Available )" } |
+        Where-Object { $_ -NotMatch "^[^;]*$" } |
+        Out-File -FilePath $packagesListFile
+
+        Write-Host Android packages list:
+        Get-Content $packagesListFile
+    }
+
+    return Get-Content $packagesListFile
 }
 
 function Build-AndroidTable {

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -24,10 +24,13 @@ function Get-AndroidInstalledPackages {
 }
 
 function Get-AndroidPackages {
+    $androidSDKDir = Get-AndroidSDKRoot
+    $androidSDKManagerPath = Get-AndroidSDKManagerPath
+
     $packagesListFile = Join-Path $androidSDKDir "packages-list.txt"
 
     if (-Not (Test-Path -Path $packagesListFile -PathType Leaf)) {
-        (/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager --list --verbose) |
+        (& $androidSDKManagerPath --list --verbose) |
         Where-Object { $_ -Match "^[^\s]" } |
         Where-Object { $_ -NotMatch "^(Loading |Info: Parsing |---|\[=+|Installed |Available )" } |
         Where-Object { $_ -NotMatch "^[^;]*$" } |

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -489,7 +489,17 @@ function Get-AndroidPackages {
         [string]$AndroidSDKManagerPath
     )
 
-    return (cmd /c "$AndroidSDKManagerPath --list --verbose 2>&1").Trim() | Foreach-Object { $_.Split()[0] } | Where-Object {$_}
+    $packagesListFile = "C:\Android\android-sdk\packages-list.txt"
+
+    if (-Not (Test-Path -Path $packagesListFile -PathType Leaf)) {
+        (cmd /c "$AndroidSDKManagerPath --list --verbose 2>&1") |
+        Where-Object { $_ -Match "^[^\s]" } |
+        Where-Object { $_ -NotMatch "^(Loading |Info: Parsing |---|\[=+|Installed |Available )" } |
+        Where-Object { $_ -NotMatch "^[^;]*$" } |
+        Out-File -FilePath $packagesListFile
+    }
+
+    return Get-Content $packagesListFile
 }
 
 function Get-AndroidPackagesByName {


### PR DESCRIPTION
# Description
Pester test for Android SDK may fail if new version of any package was released after image had been created. This PR enables packages list caching so we always get the same result.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
