### PR TITLE
Relink brew packages

### DIFF
--- a/images/macos/provision/core/relink-brew-packages.sh
+++ b/images/macos/provision/core/relink-brew-packages.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e -o pipefail
+source ~/utils/utils.sh
+
+# What is this for?
+# This script fixes an issue appeared for some brew users where brew upgrade
+# would return an error code. This is caused by the official macOS
+# Python installers which install files into /usr/local/bin, and some
+# go installer which installs files into /usr/local/bin....
+#
+# What it does?
+# The script tells brew to reclaim these files
+#
+# License
+# Distributed by MIT license.
+
+echo "Tweaking usr/local/bin Tooling"
+
+for package in go python@3.11; do
+    if brew info "$package" | grep -q ^/; then
+        brew link --overwrite "$package"
+    fi
+done
+
+invoke_tests "Python"

--- a/images/macos/templates/macOS-11.anka.pkr.hcl
+++ b/images/macos/templates/macOS-11.anka.pkr.hcl
@@ -251,6 +251,12 @@ build {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
   }
   provisioner "shell" {
+    scripts = [
+      "./provision/core/relink-brew-packages.sh"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
     script = "./provision/core/delete-duplicate-sims.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
   }

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -252,6 +252,12 @@ build {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
   }
   provisioner "shell" {
+    scripts = [
+      "./provision/core/relink-brew-packages.sh"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
     script = "./provision/core/delete-duplicate-sims.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
   }

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -238,6 +238,12 @@ build {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
   }
   provisioner "shell" {
+    scripts = [
+      "./provision/core/relink-brew-packages.sh"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
     script = "./provision/core/delete-duplicate-sims.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
   }

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -127,6 +127,12 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/relink-brew-packages.sh"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    scripts = [
       "./provision/core/xcode-clt.sh",
       "./provision/core/homebrew.sh",
       "./provision/core/rosetta.sh"


### PR DESCRIPTION
# Description
Bug fixing
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

> Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide

That's really unfortunate because, apparently, currently, macOS runners are hostile to [`brew`](https://brew.sh/), and people often try to use `brew` 🍺 .

#### Related issue:

#6868, https://github.com/actions/setup-python/issues/577

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
