### PR TITLE
[Linux] CodeQL: Simplify the toolcache version number for bundles tagged using semver

### DIFF
--- a/images/linux/scripts/installers/codeql-bundle.sh
+++ b/images/linux/scripts/installers/codeql-bundle.sh
@@ -19,7 +19,7 @@ if [[ "${codeql_tag_name##*-}" == "v"* ]]; then
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   codeql_bundle_version="$codeql_cli_version"
-elif [[ "${codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
+elif [[ "${codeql_tag_name##*-}" =~ ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.
@@ -34,7 +34,7 @@ if [[ "${prior_codeql_tag_name##*-}" == "v"* ]]; then
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   prior_codeql_bundle_version="$prior_codeql_cli_version"
-elif [[ "${prior_codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
+elif [[ "${prior_codeql_tag_name##*-}" =~ ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.

--- a/images/linux/scripts/installers/codeql-bundle.sh
+++ b/images/linux/scripts/installers/codeql-bundle.sh
@@ -19,22 +19,30 @@ if [[ "${codeql_tag_name##*-}" == "v"* ]]; then
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   codeql_bundle_version="$codeql_cli_version"
-else
+elif [[ "${codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.
   codeql_bundle_version="$codeql_cli_version-${codeql_tag_name##*-}"
+else
+  echo "Unrecognised current CodeQL bundle tag name: $codeql_tag_name." \
+    "Could not compute toolcache version number."
+  exit 1
 fi
 if [[ "${prior_codeql_tag_name##*-}" == "v"* ]]; then
   # Tag name of the format `codeql-bundle-vx.y.z`, where x.y.z is the CLI version.
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   prior_codeql_bundle_version="$prior_codeql_cli_version"
-else
+elif [[ "${prior_codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.
   prior_codeql_bundle_version="$prior_codeql_cli_version-${prior_codeql_tag_name##*-}"
+else
+  echo "Unrecognised prior CodeQL bundle tag name: $prior_codeql_tag_name." \
+    "Could not compute toolcache version number."
+  exit 1
 fi
 
 # Download and name both CodeQL bundles.


### PR DESCRIPTION
# Description

(Originally opened as a cross-platform PR here: #7602)

We are migrating to tagging the CodeQL bundle using semantic versions (like `codeql-bundle-v2.13.3`) rather than a date-based versions (like `codeql-bundle-20230516`). This lets us simplify how we version these bundles within the toolcache.

Previously, we used a version number like `2.13.3-20230516` to allow us to look up the version in the toolcache by either the CLI version number (2.13.3) or the bundle tag name (`codeql-bundle-20230516`).  This PR changes how we version bundles in the toolcache to take advantage of the new bundle tag name.  For bundles versioned as `codeql-bundle-v2.13.3`, we can just version the bundle in the toolcache as `2.13.3` since the bundle tag name is derivable from the CLI version number.

#### Related issue: https://github.com/github/codeql-core/issues/3158

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
