### PR TITLE
[macOS] CodeQL: Simplify the toolcache version number for bundles tagged using semver

### DIFF
--- a/images/macos/provision/core/codeql-bundle.sh
+++ b/images/macos/provision/core/codeql-bundle.sh
@@ -1,16 +1,36 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-# Retrieve the name of the CodeQL bundle preferred by the Action (in the format codeql-bundle-YYYYMMDD).
+# Retrieve the CLI versions and bundle tags of the latest two CodeQL bundles.
 base_url="$(curl -sSL https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json)"
 codeql_tag_name="$(echo "$base_url" | jq -r '.bundleVersion')"
 codeql_cli_version="$(echo "$base_url" | jq -r '.cliVersion')"
 prior_codeql_tag_name="$(echo "$base_url" | jq -r '.priorBundleVersion')"
 prior_codeql_cli_version="$(echo "$base_url" | jq -r '.priorCliVersion')"
 
-# Convert the tag names to bundles with a version number (x.y.z-YYYYMMDD).
-codeql_bundle_version="${codeql_cli_version}-${codeql_tag_name##*-}"
-prior_codeql_bundle_version="${prior_codeql_cli_version}-${prior_codeql_tag_name##*-}"
+# Compute the toolcache version number for each bundle. This is either `x.y.z` or `x.y.z-YYYYMMDD`.
+if [[ "${codeql_tag_name##*-}" == "v"* ]]; then
+  # Tag name of the format `codeql-bundle-vx.y.z`, where x.y.z is the CLI version.
+  # We don't need to include the tag name in the toolcache version number because it's derivable
+  # from the CLI version.
+  codeql_bundle_version="$codeql_cli_version"
+else
+  # Tag name of the format `codeql-bundle-YYYYMMDD`.
+  # We need to include the tag name in the toolcache version number because it can't be derived
+  # from the CLI version.
+  codeql_bundle_version="$codeql_cli_version-${codeql_tag_name##*-}"
+fi
+if [[ "${prior_codeql_tag_name##*-}" == "v"* ]]; then
+  # Tag name of the format `codeql-bundle-vx.y.z`, where x.y.z is the CLI version.
+  # We don't need to include the tag name in the toolcache version number because it's derivable
+  # from the CLI version.
+  prior_codeql_bundle_version="$prior_codeql_cli_version"
+else
+  # Tag name of the format `codeql-bundle-YYYYMMDD`.
+  # We need to include the tag name in the toolcache version number because it can't be derived
+  # from the CLI version.
+  prior_codeql_bundle_version="$prior_codeql_cli_version-${prior_codeql_tag_name##*-}"
+fi
 
 # Download and name both CodeQL bundles.
 codeql_bundle_versions=("${codeql_bundle_version}" "${prior_codeql_bundle_version}")

--- a/images/macos/provision/core/codeql-bundle.sh
+++ b/images/macos/provision/core/codeql-bundle.sh
@@ -14,7 +14,7 @@ if [[ "${codeql_tag_name##*-}" == "v"* ]]; then
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   codeql_bundle_version="$codeql_cli_version"
-elif [[ "${codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
+elif [[ "${codeql_tag_name##*-}" =~ ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.
@@ -29,7 +29,7 @@ if [[ "${prior_codeql_tag_name##*-}" == "v"* ]]; then
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   prior_codeql_bundle_version="$prior_codeql_cli_version"
-elif [[ "${prior_codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
+elif [[ "${prior_codeql_tag_name##*-}" =~ ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.

--- a/images/macos/provision/core/codeql-bundle.sh
+++ b/images/macos/provision/core/codeql-bundle.sh
@@ -14,22 +14,30 @@ if [[ "${codeql_tag_name##*-}" == "v"* ]]; then
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   codeql_bundle_version="$codeql_cli_version"
-else
+elif [[ "${codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.
   codeql_bundle_version="$codeql_cli_version-${codeql_tag_name##*-}"
+else
+  echo "Unrecognised current CodeQL bundle tag name: $codeql_tag_name." \
+    "Could not compute toolcache version number."
+  exit 1
 fi
 if [[ "${prior_codeql_tag_name##*-}" == "v"* ]]; then
   # Tag name of the format `codeql-bundle-vx.y.z`, where x.y.z is the CLI version.
   # We don't need to include the tag name in the toolcache version number because it's derivable
   # from the CLI version.
   prior_codeql_bundle_version="$prior_codeql_cli_version"
-else
+elif [[ "${prior_codeql_tag_name##*-}" ~= ^[0-9]+$ ]]; then
   # Tag name of the format `codeql-bundle-YYYYMMDD`.
   # We need to include the tag name in the toolcache version number because it can't be derived
   # from the CLI version.
   prior_codeql_bundle_version="$prior_codeql_cli_version-${prior_codeql_tag_name##*-}"
+else
+  echo "Unrecognised prior CodeQL bundle tag name: $prior_codeql_tag_name." \
+    "Could not compute toolcache version number."
+  exit 1
 fi
 
 # Download and name both CodeQL bundles.


### PR DESCRIPTION
# Description

(Originally opened as a cross-platform PR here: #7602)

We are migrating to tagging the CodeQL bundle using semantic versions (like `codeql-bundle-v2.13.3`) rather than a date-based versions (like `codeql-bundle-20230516`). This lets us simplify how we version these bundles within the toolcache.

Previously, we used a version number like `2.13.3-20230516` to allow us to look up the version in the toolcache by either the CLI version number (2.13.3) or the bundle tag name (`codeql-bundle-20230516`).  This PR changes how we version bundles in the toolcache to take advantage of the new bundle tag name.  For bundles versioned as `codeql-bundle-v2.13.3`, we can just version the bundle in the toolcache as `2.13.3` since the bundle tag name is derivable from the CLI version number.

#### Related issue: https://github.com/github/codeql-core/issues/3158

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
