### PR TITLE
[Windows] CodeQL: Simplify the toolcache version number for bundles tagged using semver

### DIFF
--- a/images/win/scripts/Installers/Install-CodeQLBundle.ps1
+++ b/images/win/scripts/Installers/Install-CodeQLBundle.ps1
@@ -3,16 +3,36 @@
 ##  Desc:  Install the CodeQL CLI Bundle to the toolcache.
 ################################################################################
 
-# Retrieve the name of the CodeQL bundle preferred by the Action (in the format codeql-bundle-YYYYMMDD).
+# Retrieve the CLI versions and bundle tags of the latest two CodeQL bundles.
 $Defaults = (Invoke-RestMethod "https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json")
 $CodeQLTagName = $Defaults.bundleVersion
 $CodeQLCliVersion = $Defaults.cliVersion
 $PriorCodeQLTagName = $Defaults.priorBundleVersion
 $PriorCodeQLCliVersion = $Defaults.priorCliVersion
 
-# Convert the tag names to bundles with a version number (x.y.z-YYYYMMDD).
-$CodeQLBundleVersion = $CodeQLCliVersion + "-" + $CodeQLTagName.split("-")[-1]
-$PriorCodeQLBundleVersion = $PriorCodeQLCliVersion + "-" + $PriorCodeQLTagName.split("-")[-1]
+# Compute the toolcache version number for each bundle. This is either `x.y.z` or `x.y.z-YYYYMMDD`.
+if ($CodeQLTagName.split("-")[-1].StartsWith("v")) {
+    # Tag name of the format `codeql-bundle-vx.y.z`, where x.y.z is the CLI version.
+    # We don't need to include the tag name in the toolcache version number because it's derivable
+    # from the CLI version.
+    $CodeQLBundleVersion = $CodeQLCliVersion
+} else {
+    # Tag name of the format `codeql-bundle-YYYYMMDD`.
+    # We need to include the tag name in the toolcache version number because it can't be derived
+    # from the CLI version.
+    $CodeQLBundleVersion = $CodeQLCliVersion + "-" + $CodeQLTagName.split("-")[-1]
+}
+if ($PriorCodeQLTagName.split("-")[-1].StartsWith("v")) {
+    # Tag name of the format `codeql-bundle-vx.y.z`, where x.y.z is the CLI version.
+    # We don't need to include the tag name in the toolcache version number because it's derivable
+    # from the CLI version.
+    $PriorCodeQLBundleVersion = $PriorCodeQLCliVersion
+} else {
+    # Tag name of the format `codeql-bundle-YYYYMMDD`.
+    # We need to include the tag name in the toolcache version number because it can't be derived
+    # from the CLI version.
+    $PriorCodeQLBundleVersion = $PriorCodeQLCliVersion + "-" + $PriorCodeQLTagName.split("-")[-1]
+}
 
 $Bundles = @(
     [PSCustomObject]@{

--- a/images/win/scripts/Installers/Install-CodeQLBundle.ps1
+++ b/images/win/scripts/Installers/Install-CodeQLBundle.ps1
@@ -30,7 +30,7 @@ if ($PriorCodeQLTagName.split("-")[-1].StartsWith("v")) {
     # We don't need to include the tag name in the toolcache version number because it's derivable
     # from the CLI version.
     $PriorCodeQLBundleVersion = $PriorCodeQLCliVersion
-} elseif ($PriorCodeQLTagName.split("-")[-1] -match "^\d+$")) {
+} elseif ($PriorCodeQLTagName.split("-")[-1] -match "^\d+$") {
     # Tag name of the format `codeql-bundle-YYYYMMDD`.
     # We need to include the tag name in the toolcache version number because it can't be derived
     # from the CLI version.

--- a/images/win/scripts/Installers/Install-CodeQLBundle.ps1
+++ b/images/win/scripts/Installers/Install-CodeQLBundle.ps1
@@ -16,22 +16,28 @@ if ($CodeQLTagName.split("-")[-1].StartsWith("v")) {
     # We don't need to include the tag name in the toolcache version number because it's derivable
     # from the CLI version.
     $CodeQLBundleVersion = $CodeQLCliVersion
-} else {
+} elseif ($CodeQLTagName.split("-")[-1] -match "^\d+$") {
     # Tag name of the format `codeql-bundle-YYYYMMDD`.
     # We need to include the tag name in the toolcache version number because it can't be derived
     # from the CLI version.
     $CodeQLBundleVersion = $CodeQLCliVersion + "-" + $CodeQLTagName.split("-")[-1]
+} else {
+    Write-Error "Unrecognised current CodeQL bundle tag name: $CodeQLTagName. Could not compute toolcache version number."
+    exit 1
 }
 if ($PriorCodeQLTagName.split("-")[-1].StartsWith("v")) {
     # Tag name of the format `codeql-bundle-vx.y.z`, where x.y.z is the CLI version.
     # We don't need to include the tag name in the toolcache version number because it's derivable
     # from the CLI version.
     $PriorCodeQLBundleVersion = $PriorCodeQLCliVersion
-} else {
+} elseif ($PriorCodeQLTagName.split("-")[-1] -match "^\d+$")) {
     # Tag name of the format `codeql-bundle-YYYYMMDD`.
     # We need to include the tag name in the toolcache version number because it can't be derived
     # from the CLI version.
     $PriorCodeQLBundleVersion = $PriorCodeQLCliVersion + "-" + $PriorCodeQLTagName.split("-")[-1]
+} else {
+    Write-Error "Unrecognised prior CodeQL bundle tag name: $PriorCodeQLTagName. Could not compute toolcache version number."
+    exit 1
 }
 
 $Bundles = @(


### PR DESCRIPTION
# Description

(Originally opened as a cross-platform PR here: #7602)

We are migrating to tagging the CodeQL bundle using semantic versions (like `codeql-bundle-v2.13.3`) rather than a date-based versions (like `codeql-bundle-20230516`). This lets us simplify how we version these bundles within the toolcache.

Previously, we used a version number like `2.13.3-20230516` to allow us to look up the version in the toolcache by either the CLI version number (2.13.3) or the bundle tag name (`codeql-bundle-20230516`).  This PR changes how we version bundles in the toolcache to take advantage of the new bundle tag name.  For bundles versioned as `codeql-bundle-v2.13.3`, we can just version the bundle in the toolcache as `2.13.3` since the bundle tag name is derivable from the CLI version number.

#### Related issue: https://github.com/github/codeql-core/issues/3158

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
