### PR TITLE
[Ubuntu] update curl command to work with https

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -72,7 +72,7 @@ get_github_package_download_url() {
     local VERSION=$3
     local SEARCH_IN_COUNT="100"
 
-    json=$(curl -s "https://api.github.com/repos/${REPO_ORG}/releases?per_page=${SEARCH_IN_COUNT}")
+    json=$(curl -sSL "https://api.github.com/repos/${REPO_ORG}/releases?per_page=${SEARCH_IN_COUNT}")
 
     if [ -n "$VERSION" ]; then
         tagName=$(echo $json | jq -r '.[] | select(.prerelease==false).tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]|beta" | egrep "\w*${VERSION}" | tail -1)


### PR DESCRIPTION
# Description
Something was changed in the curl command and key -s stopped working with HTTPS URLs, the key was updated to -sSL

#### Related issue:
#7722 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
