### PR TITLE
[macOS] Add pkg-config to the software report

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -134,6 +134,7 @@ if ($os.IsBigSur) {
 }
 $utilities.AddToolVersion("OpenSSL", $(Get-OpenSSLVersion))
 $utilities.AddToolVersion("Packer", $(Get-PackerVersion))
+$utilities.AddToolVersion("pkg-config", $(Get-PKGConfigVersion))
 if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
     $utilities.AddToolVersion("PostgreSQL", $(Get-PostgresServerVersion))
     $utilities.AddToolVersion("psql (PostgreSQL)", $(Get-PostgresClientVersion))


### PR DESCRIPTION
# Description
Add pkg-config to the software report
Previously was deleted by mistake - https://github.com/actions/runner-images/commit/c6c271672676f9d02828e6262d4126d6860700b3#diff-d7d6fd7f830c5bd0d43cf8aebeb9f2e32574fddac321eff8419f4aafb043f70a

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
