### PR TITLE
Fix XCode simulators installation

### DIFF
--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -166,14 +166,14 @@ function Install-AdditionalSimulatorRuntimes {
         [string]$Version
     )
 
-    if (-not $Version.StartsWith("14.")) {
+    if ($Version.Split(".")[0] -lt 14) {
         # Additional simulator runtimes are included by default for Xcode < 14
         return
     }
 
     Write-Host "Installing Simulator Runtimes for Xcode $($_.link) ..."
     $xcodebuildPath = Get-XcodeToolPath -Version $Version -ToolName "xcodebuild"
-    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms"
+    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms | xcpretty"
 }
 
 function Build-XcodeSymlinks {

--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -173,7 +173,7 @@ function Install-AdditionalSimulatorRuntimes {
 
     Write-Host "Installing Simulator Runtimes for Xcode $Version ..."
     $xcodebuildPath = Get-XcodeToolPath -Version $Version -ToolName "xcodebuild"
-    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms"
+    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms | xcpretty"
 }
 
 function Build-XcodeSymlinks {

--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -171,9 +171,9 @@ function Install-AdditionalSimulatorRuntimes {
         return
     }
 
-    Write-Host "Installing Simulator Runtimes for Xcode $($_.link) ..."
+    Write-Host "Installing Simulator Runtimes for Xcode $Version ..."
     $xcodebuildPath = Get-XcodeToolPath -Version $Version -ToolName "xcodebuild"
-    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms | xcpretty"
+    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms"
 }
 
 function Build-XcodeSymlinks {

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -36,10 +36,12 @@ $xcodeVersions | ForEach-Object -ThrottleLimit $threadCount -Parallel {
 Write-Host "Configuring Xcode versions..."
 $xcodeVersions | ForEach-Object {
     Write-Host "Configuring Xcode $($_.link) ..."
-
     Invoke-XcodeRunFirstLaunch -Version $_.link
-    Install-AdditionalSimulatorRuntimes -Version $_.link
 }
+
+$latestVersion = $xcodeVersions | Sort-Object -Property link -Descending | Select-Object -First 1 -ExpandProperty link
+Write-Host "Installing simulators for version $latestVersion..."
+Install-AdditionalSimulatorRuntimes -Version $latestVersion
 
 Invoke-XcodeRunFirstLaunch -Version $defaultXcode
 

--- a/images/macos/tests/Xcode.Tests.ps1
+++ b/images/macos/tests/Xcode.Tests.ps1
@@ -98,14 +98,16 @@ Describe "Xcode simulators" {
             It "No duplicates in devices" -TestCases $testCase {
                 Switch-Xcode -Version $XcodeVersion
                 [array]$devicesList = @(Get-XcodeDevicesList | Where-Object { $_ })
-                Write-Host $devicesList
+                Write-Host "Devices for $XcodeVersion"
+                Write-Host ($devicesList -join "`n")
                 Validate-ArrayWithoutDuplicates $devicesList -Because "Found duplicate device simulators"
             }
 
             It "No duplicates in pairs" -TestCases $testCase {
                 Switch-Xcode -Version $XcodeVersion
                 [array]$pairsList = @(Get-XcodePairsList | Where-Object { $_ })
-                Write-Host $pairsList
+                Write-Host "Pairs for $XcodeVersion"
+                Write-Host ($pairsList -join "`n")
                 Validate-ArrayWithoutDuplicates $pairsList -Because "Found duplicate pairs simulators"
             }
         }

--- a/images/macos/tests/Xcode.Tests.ps1
+++ b/images/macos/tests/Xcode.Tests.ps1
@@ -98,12 +98,14 @@ Describe "Xcode simulators" {
             It "No duplicates in devices" -TestCases $testCase {
                 Switch-Xcode -Version $XcodeVersion
                 [array]$devicesList = @(Get-XcodeDevicesList | Where-Object { $_ })
+                Write-Host $devicesList
                 Validate-ArrayWithoutDuplicates $devicesList -Because "Found duplicate device simulators"
             }
 
             It "No duplicates in pairs" -TestCases $testCase {
                 Switch-Xcode -Version $XcodeVersion
                 [array]$pairsList = @(Get-XcodePairsList | Where-Object { $_ })
+                Write-Host $pairsList
                 Validate-ArrayWithoutDuplicates $pairsList -Because "Found duplicate pairs simulators"
             }
         }


### PR DESCRIPTION
# Description
Additional simulator runtimes were installed by default with XCode until version 14, so we have switch in our repo that enables simulators installation for XCode 14.*. As version 15 have released and it behaves the same we have to fix this switch to run installation for new XCode as well.

#### Related issue: https://github.com/actions/runner-images/issues/7766

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
