### PR TITLE
[Ubuntu] Remove .Net 3.1 as its EOL

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -263,12 +263,10 @@
     ],
     "dotnet": {
         "aptPackages": [
-            "dotnet-sdk-3.1",
             "dotnet-sdk-6.0",
             "dotnet-sdk-7.0"
         ],
         "versions": [
-            "3.1",
             "6.0",
             "7.0"
         ],


### PR DESCRIPTION
# Description
Remove .Net 3.1 from images.

#### Related issue:
#7667

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
