### PR TITLE
[ubuntu] include apt vital pkgs in software report

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -322,7 +322,7 @@ function Get-CachedDockerImagesTableData {
 function Get-AptPackages {
     $apt = (Get-ToolsetContent).Apt
     $output = @()
-    ForEach ($pkg in ($apt.common_packages + $apt.cmd_packages)) {
+    ForEach ($pkg in ($apt.vital_packages + $apt.common_packages + $apt.cmd_packages)) {
         $version = $(dpkg-query -W -f '${Version}' $pkg)
         if ($Null -eq $version) {
             $version = $(dpkg-query -W -f '${Version}' "$pkg*")


### PR DESCRIPTION
# Description
Includes APT vital packages such as `curl`, `gcc` and `jq` in software report. Was there any reason to move them out of the report or is this an unexpected side-effect?

#### Related issue:
N/A. 

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
