### PR TITLE
[Windows] Rm "-stable" part  from rustfmt version

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -42,7 +42,7 @@ function Get-RustdocVersion {
 }
 
 function Get-RustfmtVersion {
-    rustfmt --version | Take-Part -Part 1
+    rustfmt --version | Take-Part -Part 1 | Take-Part -Part 0 -Delimiter ('-')
 }
 
 function Get-RustClippyVersion {


### PR DESCRIPTION
# Description
Reverting the rustfmt version output to its previous state. [Example](https://github.com/actions/runner-images/pull/7843/commits/819a32b679df2546059d45103a2c49924a262a59#:~:text=Rustfmt%201.5.2%2D-,stable,-Member).

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
