### PR TITLE
[mac OS] Don't try to copy test results to artifacts directory

### DIFF
--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -101,12 +101,8 @@ jobs:
       PACKER_LOG_PATH: $(Agent.TempDirectory)/packer-log.txt
 
   - bash: |
-      echo "Copy image output files"
-      cp -R "images/image-output/software-report/." "$(Build.ArtifactStagingDirectory)/"
-
-      echo "Copy test results"
-      cp -R "images/image-output/tests/." "$(Common.TestResultsDirectory)/"
-      ls $(Common.TestResultsDirectory)
+      echo "Copy software report files"
+      cp -vR "images/image-output/software-report/." "$(Build.ArtifactStagingDirectory)/"
 
       echo "Put VM name to 'VM_Done_Name' file"
       echo "$(VirtualMachineName)" > "$(Build.ArtifactStagingDirectory)/VM_Done_Name"


### PR DESCRIPTION
# Description
Test results generation was removed a long time ago: https://github.com/actions/runner-images/pull/2261. We don't need this command anymore.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated