### PR TITLE
Enable `nf_conntrack_tcp_be_liberal` for Ubuntu 22.04 until kernel update

### DIFF
--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -37,7 +37,11 @@ echo 'fs.inotify.max_user_watches=655360' | tee -a /etc/sysctl.conf
 echo 'fs.inotify.max_user_instances=1280' | tee -a /etc/sysctl.conf
 
 # https://github.com/actions/runner-images/pull/7860
-echo 'net.netfilter.nf_conntrack_tcp_be_liberal=1' | tee -a /etc/sysctl.conf
+netfilter_rule='/etc/udev/rules.d/50-netfilter.rules'
+rulesd="$(dirname "${netfilter_rule}")"
+mkdir -p $rulesd
+touch $netfilter_rule
+echo 'ACTION=="add", SUBSYSTEM=="module", KERNEL=="nf_conntrack", RUN+="/usr/sbin/sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1"' | tee -a $netfilter_rule
 
 # Create symlink for tests running
 chmod +x $HELPER_SCRIPTS/invoke-tests.sh

--- a/images/linux/scripts/installers/configure-environment.sh
+++ b/images/linux/scripts/installers/configure-environment.sh
@@ -36,6 +36,9 @@ echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf
 echo 'fs.inotify.max_user_watches=655360' | tee -a /etc/sysctl.conf
 echo 'fs.inotify.max_user_instances=1280' | tee -a /etc/sysctl.conf
 
+# https://github.com/actions/runner-images/pull/7860
+echo 'net.netfilter.nf_conntrack_tcp_be_liberal=1' | tee -a /etc/sysctl.conf
+
 # Create symlink for tests running
 chmod +x $HELPER_SCRIPTS/invoke-tests.sh
 ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -434,4 +434,9 @@ build {
     inline          = ["sleep 30", "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"]
   }
 
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    inline          = ["echo 1 > /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal"]
+  }
+
 }

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -380,11 +380,6 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    inline          = ["cat /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal", "sysctl -a | grep nf_conntrack_tcp_be_liberal"]
-  }
-
-  provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     pause_before        = "1m0s"
     scripts             = ["${path.root}/scripts/installers/cleanup.sh"]

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -380,6 +380,11 @@ build {
   }
 
   provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    inline          = ["cat /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal", "sysctl -a | grep nf_conntrack_tcp_be_liberal"]
+  }
+
+  provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     pause_before        = "1m0s"
     scripts             = ["${path.root}/scripts/installers/cleanup.sh"]
@@ -432,11 +437,6 @@ build {
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = ["sleep 30", "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"]
-  }
-
-  provisioner "shell" {
-    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    inline          = ["echo 1 > /proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal"]
   }
 
 }


### PR DESCRIPTION
## Description

Azure's latest Ubuntu 22.04 image is lacking a kernel fix https://github.com/torvalds/linux/commit/6e250dcbff1d3ce347b8294e4ec6da96a2cecdb5.

GitHub Actions' `ubuntu-22.04` image is built upon Azure's base image. Without the fix, when customers' workflows upload large-size artifacts to remote servers and remote server fell behind in responding with ACK TCP packets, the delayed ACK packets are counted as INVALID because they are out of the TCP window, leading to the client kernel panic and responding with RST. This results in the intermittent connection reset symptom that has been reported by multiple customers[^1][^2][^3][^4].

> With permission, a more detailed analysis/history can be seen [here](https://github.com/github/c2c-actions-support/issues/2441#issuecomment-1610588448).

## Solution

Until the base image is updated to include the kernel fix, this PR proposes to enable the `nf_conntrack_tcp_be_liberal` kernel flag[^5]. As a result, only out-of-window RST segments will be marked as INVALID while out-of-window ACK packets will be allowed.

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

[^1]: https://github.com/github/c2c-actions-support/issues/2441
[^2]: https://github.com/github/c2c-actions-support/issues/2461
[^3]: https://github.com/github/c2c-package-registry/issues/6891
[^4]: https://github.com/github/c2c-package-registry/issues/7013
[^5]: https://www.kernel.org/doc/Documentation/networking/nf_conntrack-sysctl.txt