### PR TITLE
[macos] propagate XCode install variables to github image generation

### DIFF
--- a/.github/workflows/macos-generation.yml
+++ b/.github/workflows/macos-generation.yml
@@ -121,6 +121,8 @@ jobs:
         -var="output_folder=${{ env.OUTPUT_FOLDER }}" `
         -var="vm_username=${{ secrets.VM_USERNAME }}" `
         -var="vm_password=${{ secrets.VM_PASSWORD }}" `
+        -var="xcode_install_storage_url=${{ secrets.xcode_install_storage_url }}" `
+        -var="xcode_install_sas=${{ secrets.xcode_install_sas }}" `
         -var="github_api_pat=${{ secrets.GH_FEED_TOKEN }}" `
         -var="build_id=${{ env.VM_NAME }}" `
         -var="baseimage_name=${{ inputs.base_image_name }}" `


### PR DESCRIPTION
# Description

XCode installers now are downloaded from intermediate storage account, it is required to add appropriate parameters to github generation pipeline as well 

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5204

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
