### PR TITLE
[macos] temporarily disable simulators on XCode-15

### DIFF
--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -31,7 +31,8 @@ $xcodeVersions | ForEach-Object {
     Write-Host "Configuring Xcode $($_.link) ..."
     Invoke-XcodeRunFirstLaunch -Version $_.link
 
-    if ($_.link.Split(".")[0] -ge 14) {
+    ##if ($_.link.Split(".")[0] -ge 14) {
+    if ($_.link.Split(".")[0] -eq 14) {
         # Additional simulator runtimes are included by default for Xcode < 14
         Install-AdditionalSimulatorRuntimes -Version $_.link
     }


### PR DESCRIPTION
# Description

temporarily skip installing XCode-15 simulators

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5219

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
