### PR TITLE
[MacOS] Change directory owner root => runner for .cache and .config in arm64

### DIFF
--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -41,6 +41,7 @@ for module in ${psModules[@]}; do
     fi
 done
 
+# Fix permission root => runner after installing powershell for arm64 arch
 if [[ $arch == "arm64" ]]; then
     sudo chown -R $USER ~/.local ~/.cache ~/.config
 fi

--- a/images/macos/provision/core/powershell.sh
+++ b/images/macos/provision/core/powershell.sh
@@ -42,7 +42,7 @@ for module in ${psModules[@]}; do
 done
 
 if [[ $arch == "arm64" ]]; then
-    sudo chown -R $USER ~/.local
+    sudo chown -R $USER ~/.local ~/.cache ~/.config
 fi
 
 # A dummy call to initialize .IdentityService directory


### PR DESCRIPTION
# Description

Add additional `chown`  command to PowerShell installation script for fixing permission issue during pipeline/workflow

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5217

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
