### PR TITLE
[macOS] Install swiftlint from Homebrew

### DIFF
--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -1,19 +1,5 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
-echo "Install SwiftLint"
-# SwiftLint now requires Swift 5.6 or higher to build, and macOS 12 or higher to run https://github.com/realm/SwiftLint/releases/tag/0.49.0
-if is_BigSur; then
-    version="0.48.0"
-else
-    version="latest"
-fi
-
-swiftlintUrl=$(get_github_package_download_url "realm/SwiftLint" "contains(\"portable_swiftlint.zip\")" "$version" "$API_PAT")
-download_with_retries $swiftlintUrl "/tmp" "portable_swiftlint.zip"
-unzip -q "/tmp/portable_swiftlint.zip" -d /usr/local/bin
-# Remove the LICENSE file that comes along with the binary and the downloaded archive
-rm -rf "/usr/local/bin/LICENSE"
-rm -rf "/tmp/portable_swiftlint.zip"
-
-invoke_tests "Linters" "SwiftLint"
+echo Installing Swiftlint...
+brew_smart_install "swiftlint"

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -3,10 +3,14 @@ source ~/utils/utils.sh
 
 echo Installing Swiftlint...
 if is_BigSur; then
-    # SwiftLint now requires Swift 5.6 or higher to build, and macOS 12 or higher to run https://github.com/realm/SwiftLint/releases/tag/0.49.0
-    brew_smart_install "swiftlint@0.48.0"
+  # SwiftLint now requires Swift 5.6 or higher to build, and macOS 12 or higher to run https://github.com/realm/SwiftLint/releases/tag/0.49.0
+  COMMIT=d1d5743344227fe6e3c37cfba19f0cfe15a9448a
+  FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/swiftlint.rb"
+
+  curl "$FORMULA_URL" > $(find $(brew --repository) -name swiftlint.rb)
+  HOMEBREW_NO_AUTO_UPDATE=1 brew_smart_install swiftlint
 else
-    brew_smart_install "swiftlint"
+  brew_smart_install "swiftlint"
 fi
 
 invoke_tests "Linters" "SwiftLint"

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -8,7 +8,7 @@ if is_BigSur; then
   FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/swiftlint.rb"
 
   curl "$FORMULA_URL" > $(find $(brew --repository) -name swiftlint.rb)
-  HOMEBREW_NO_AUTO_UPDATE=1 brew_smart_install swiftlint
+  HOMEBREW_NO_AUTO_UPDATE=1 brew install swiftlint
 else
   brew_smart_install "swiftlint"
 fi

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -8,7 +8,7 @@ if is_BigSur; then
   FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/swiftlint.rb"
 
   curl "$FORMULA_URL" > $(find $(brew --repository) -name swiftlint.rb)
-  HOMEBREW_NO_AUTO_UPDATE=1 brew install swiftlint
+  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install swiftlint
 else
   brew_smart_install "swiftlint"
 fi

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -7,7 +7,7 @@ if is_BigSur; then
   COMMIT=d1d5743344227fe6e3c37cfba19f0cfe15a9448a
   FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/swiftlint.rb"
 
-  curl "$FORMULA_URL" > $(find $(brew --repository) -name swiftlint.rb)
+  curl -fsSL -H "Authorization: token ${API_PAT}" "$FORMULA_URL" > $(find $(brew --repository) -name swiftlint.rb)
   HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install swiftlint
 else
   brew_smart_install "swiftlint"

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -7,7 +7,7 @@ if is_BigSur; then
   COMMIT=d1d5743344227fe6e3c37cfba19f0cfe15a9448a
   FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/swiftlint.rb"
 
-  curl -fsSL -H "Authorization: token ${API_PAT}" "$FORMULA_URL" > $(find $(brew --repository) -name swiftlint.rb)
+  curl -fsSL "$FORMULA_URL" > $(find $(brew --repository) -name swiftlint.rb)
   HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install swiftlint
 else
   brew_smart_install "swiftlint"

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -8,3 +8,5 @@ if is_BigSur; then
 else
     brew_smart_install "swiftlint"
 fi
+
+invoke_tests "Linters" "SwiftLint"

--- a/images/macos/provision/core/swiftlint.sh
+++ b/images/macos/provision/core/swiftlint.sh
@@ -2,4 +2,9 @@
 source ~/utils/utils.sh
 
 echo Installing Swiftlint...
-brew_smart_install "swiftlint"
+if is_BigSur; then
+    # SwiftLint now requires Swift 5.6 or higher to build, and macOS 12 or higher to run https://github.com/realm/SwiftLint/releases/tag/0.49.0
+    brew_smart_install "swiftlint@0.48.0"
+else
+    brew_smart_install "swiftlint"
+fi


### PR DESCRIPTION
# Description
Revert PR https://github.com/actions/runner-images/pull/2296 and install swiftlint from Homebrew again since Mojave and High Sierra have been deprecated yet.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
