### PR TITLE
specify min tls for supporting stg acct - to support MS policy

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -198,9 +198,9 @@ Function GenerateResourcesAndImage {
         }
 
         if ($tags) {
-            New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS" -AllowBlobPublicAccess $AllowBlobPublicAccess -EnableHttpsTrafficOnly $EnableHttpsTrafficOnly -Tag $tags
+            New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS" -AllowBlobPublicAccess $AllowBlobPublicAccess -EnableHttpsTrafficOnly $EnableHttpsTrafficOnly -MinimumTlsVersion "TLS1_2" -Tag $tags
         } else {
-            New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS" -AllowBlobPublicAccess $AllowBlobPublicAccess -EnableHttpsTrafficOnly $EnableHttpsTrafficOnly
+            New-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $storageAccountName -Location $AzureLocation -SkuName "Standard_LRS" -AllowBlobPublicAccess $AllowBlobPublicAccess -EnableHttpsTrafficOnly $EnableHttpsTrafficOnly -MinimumTlsVersion "TLS1_2"
         }
 
         if ([string]::IsNullOrEmpty($AzureClientId)) {


### PR DESCRIPTION
# Description
Those organisations that have applied this built-in (Microsoft authored) Azure Policy [Storage accounts should have the specified minimum TLS version](https://portal.azure.com/#view/Microsoft_Azure_Policy/PolicyDetailBlade/definitionId/%2Fproviders%2FMicrosoft.Authorization%2FpolicyDefinitions%2Ffe83a0eb-a853-422d-aac2-1bffd182c5d0) are unable to use these build tools due to the requisite storage account command not passing in a minimum TLS version.

#### Related issue:

```powershell
GenerateResourcesAndImage: /agent/_work/1/s/UpdateRunnerImage.ps1:66
Line |
  66 |  GenerateResourcesAndImage -SubscriptionId ${env:SUBSCRIPTIONID} `
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Resource 'itcgiocstprunnerwin2022r' was disallowed by policy. Policy
     | identifiers: '[{"policyAssignment":{"name":"P!-DENY-290-Storage accounts
     | must have the specified minimum TLS
     | version","id":"/providers/Microsoft.Management/managementGroups/cfa5342f-a686-4a51-9d41-3736c6ba8c2e/providers/Microsoft.Authorization/policyAssignments/290"},"policyDefinition":{"name":"290-Storage accounts must have the specified minimum TLS version","id":"/providers/Microsoft.Management/managementGroups/76e3921f-489b-4b7e-9547-9ea297add9b5/providers/Microsoft.Authorization/policyDefinitions/290"}}]'.

##[error]PowerShell exited with code '1'.
```
