### PR TITLE
Revert "[Ubuntu] do not check ssl cert for hhvm"

### DIFF
--- a/images/linux/scripts/installers/hhvm.sh
+++ b/images/linux/scripts/installers/hhvm.sh
@@ -6,9 +6,7 @@
 
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 add-apt-repository https://dl.hhvm.com/ubuntu
-echo 'Acquire::https::dl.hhvm.com::Verify-Peer "false";' > /etc/apt/apt.conf.d/99hhvm-cert
 apt-get update
 apt-get -qq install -y hhvm
-rm /etc/apt/apt.conf.d/99hhvm-cert
 
 invoke_tests "Tools" "HHVM"


### PR DESCRIPTION
Reverts actions/runner-images#7817 due to update of https://github.com/facebook/hhvm/issues/9376