### PR TITLE
[Ubuntu] Remove old Alpine Docker images

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -229,8 +229,6 @@
     ],
     "docker": {
         "images": [
-            "alpine:3.14",
-            "alpine:3.15",
             "alpine:3.16",
             "alpine:3.17",
             "alpine:3.18",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -215,8 +215,6 @@
     ],
     "docker": {
         "images": [
-            "alpine:3.14",
-            "alpine:3.15",
             "alpine:3.16",
             "alpine:3.17",
             "alpine:3.18",


### PR DESCRIPTION
# Description
Alpine 3.14 & 3.15 Docker images removing.

#### Related issue:
#7824

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
