### PR TITLE
[macOS] Remove sensitive data from a download log

### DIFF
--- a/images/macos/provision/bootstrap-provisioner/installNewProvisioner.sh
+++ b/images/macos/provision/bootstrap-provisioner/installNewProvisioner.sh
@@ -37,6 +37,10 @@ aria2c \
   --file-allocation=none \
   -d ${BOOTSTRAP_PATH} "${ProvisionerScriptUri}" >> ${BOOTSTRAP_PATH}/download.log
 
+# Remove sensitive data from logs
+sed -i '' 's/'${ProvisionerPackageUri}'/ProvisionerPackageUri/' ${BOOTSTRAP_PATH}/download.log
+sed -i '' 's/'${ProvisionerScriptUri}'/ProvisionerScriptUri/' ${BOOTSTRAP_PATH}/download.log
+
 chmod +x ${BOOTSTRAP_PATH}/${ScriptName}
 
 # Install Provisioner with provided scripts


### PR DESCRIPTION
# Description
During the process of downloading the provisioner installer, potentially vulnerable data got into the log. There won't be any more.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
