### PR TITLE
use unique run_id instead of repeative run_number for VM releases

### DIFF
--- a/.github/workflows/ubuntu-win-generation.yml
+++ b/.github/workflows/ubuntu-win-generation.yml
@@ -86,7 +86,7 @@ jobs:
               -ClientId ${{ secrets.CLIENT_ID }} `
               -ClientSecret ${{ secrets.CLIENT_SECRET }} `
               -Location ${{ secrets.AZURE_LOCATION }} `
-              -ResourcesNamePrefix ${{ github.run_number }} `
+              -ResourcesNamePrefix ${{ github.run_id }} `
               -ResourceGroup ${{ secrets.AZURE_RESOURCE_GROUP }} `
               -StorageAccount ${{ secrets.AZURE_STORAGE_ACCOUNT }} `
               -SubscriptionId ${{ secrets.AZURE_SUBSCRIPTION }} `
@@ -113,7 +113,7 @@ jobs:
       - name: Create release for VM deployment
         run: |
           ./images.CI/linux-and-win/create-release.ps1 `
-            -BuildId ${{ github.run_number }} `
+            -BuildId ${{ github.run_id }} `
             -Organization ${{ secrets.RELEASE_TARGET_ORGANIZATION }} `
             -DefinitionId ${{ secrets.RELEASE_TARGET_DEFINITION_ID }} `
             -Project ${{ secrets.RELEASE_TARGET_PROJECT }} `


### PR DESCRIPTION
# Description

run_number is unique per workflow, several workflows may use the same number. It breaks VM deployment convention. let us switch to unique run_id 

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5253

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
