### PR TITLE
[Windows] Fix chromedriver download process

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -451,7 +451,9 @@ function Extract-7Zip {
         [Parameter(Mandatory=$true)]
         [string]$Path,
         [Parameter(Mandatory=$true)]
-        [string]$DestinationPath
+        [string]$DestinationPath,
+        [ValidateSet("x", "e")]
+        [char]$ExtractMethod = "x"
     )
 
     Write-Host "Expand archive '$PATH' to '$DestinationPath' directory"

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -457,7 +457,7 @@ function Extract-7Zip {
     )
 
     Write-Host "Expand archive '$PATH' to '$DestinationPath' directory"
-    7z.exe x "$Path" -o"$DestinationPath" -y | Out-Null
+    7z.exe $ExtractMethod "$Path" -o"$DestinationPath" -y | Out-Null
 
     if ($LASTEXITCODE -ne 0)
     {

--- a/images/win/scripts/Installers/Install-Chrome.ps1
+++ b/images/win/scripts/Installers/Install-Chrome.ps1
@@ -63,8 +63,9 @@ if (-not ($ChromeDriverVersion)) {
     $availableVersions = $ChromeDriverVersions.builds | Get-Member | Select-Object -ExpandProperty Name
     Write-Host "Available chromedriver builds are $availableVersions"
     Throw "Can't determine chromedriver version that matches chrome build $ChromeBuild"
-    exit 1
 }
+
+$ChromeDriverVersion.version | Out-File -FilePath "$ChromeDriverPath\versioninfo.txt" -Force;
 
 Write-Host "Chrome WebDriver version to install is $($ChromeDriverVersion.version)"
 $ChromeDriverZipDownloadUrl = ($ChromeDriverVersion.downloads.chromedriver | Where-Object platform -eq "win64").url


### PR DESCRIPTION
According to the information on [ChromeDriver website](https://chromedriver.chromium.org/), starting with version 115 these json endpoints should be used to determine compatible versions and download urls: https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints. This PR updates script that installs Chrome and ChromeDriver to use one of these endpoints.

#### Related issue: https://github.com/actions/runner-images/issues/7933

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
