### PR TITLE
[Ubuntu] Install latest chromedriver for current build

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -58,12 +58,16 @@ rm -f /etc/cron.daily/google-chrome /etc/apt/sources.list.d/google-chrome.list /
 
 # Parse Google Chrome version
 FULL_CHROME_VERSION=$(google-chrome --product-version)
+CHROME_VERSION=${FULL_CHROME_VERSION%.*}
+echo "Chrome version is $FULL_CHROME_VERSION"
 
 # Determine the download url for chromedriver
-CHROME_VERSIONS_JSON=$(curl -fsSL https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json)
-CHROMEDRIVER_URL=$(echo $CHROME_VERSIONS_JSON | jq -r '.versions[] | select(.version=="'"$FULL_CHROME_VERSION"'").downloads.chromedriver[] | select(.platform=="linux64").url')
+CHROME_VERSIONS_JSON=$(curl -fsSL https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json)
+CHROMEDRIVER_VERSION=$(echo $CHROME_VERSIONS_JSON | jq -r '.builds["'"$CHROME_VERSION"'"].version')
+CHROMEDRIVER_URL=$(echo $CHROME_VERSIONS_JSON | jq -r '.builds["'"$CHROME_VERSION"'"].downloads.chromedriver[] | select(.platform=="linux64").url')
 
 # Download and unpack the latest release of chromedriver
+echo "Installing chromedriver version $CHROMEDRIVER_VERSION"
 download_with_retries $CHROMEDRIVER_URL "/tmp" "chromedriver_linux64.zip"
 unzip -qq /tmp/chromedriver_linux64.zip -d /usr/local/share
 

--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -14,6 +14,12 @@ function GetChromiumRevision {
     URL="https://omahaproxy.appspot.com/deps.json?version=${CHROME_VERSION}"
     REVISION=$(curl -s $URL | jq -r '.chromium_base_position')
 
+    # Temporarily hardcode revision as both requests
+    # for 115.0.5790.102 and 115.0.5790.98 return old incorrect revision
+    if [ $REVISION -eq "1583" ]; then
+       REVISION="1134878"
+    fi
+
     # Some Google Chrome versions are based on Chromium revisions for which a (usually very old) Chromium release with the same number exist. So far this has heppened with 4 digits long Chromium revisions (1060, 1086).
     # Use the previous Chromium release when this happens to avoid downloading and installing very old Chromium releases that would break image build because of incompatibilities.
     # First reported with: https://github.com/actions/runner-images/issues/5256


### PR DESCRIPTION
# Description
Following https://github.com/actions/runner-images/pull/7940, install latest ChromeDriver patch that matches current Chrome build. This is to address possible issue where image generation may fail when ChromeDriver and Chrome patch numbers differ.

#### Related issue: https://github.com/actions/runner-images/issues/7933

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
