### PR TITLE
[Ubuntu] Temporarily hardcode chromium revision

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -14,6 +14,12 @@ function GetChromiumRevision {
     URL="https://omahaproxy.appspot.com/deps.json?version=${CHROME_VERSION}"
     REVISION=$(curl -s $URL | jq -r '.chromium_base_position')
 
+    # Temporarily hardcode revision as both requests
+    # for 115.0.5790.102 and 115.0.5790.98 return old incorrect revision
+    if [ $REVISION -eq "1583" ]; then
+       REVISION="1134878"
+    fi
+
     # Some Google Chrome versions are based on Chromium revisions for which a (usually very old) Chromium release with the same number exist. So far this has heppened with 4 digits long Chromium revisions (1060, 1086).
     # Use the previous Chromium release when this happens to avoid downloading and installing very old Chromium releases that would break image build because of incompatibilities.
     # First reported with: https://github.com/actions/runner-images/issues/5256


### PR DESCRIPTION
# Description
Currently omahaproxy portal returns incorrect revision for chromium so we have to hardcode it temporarily

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
