### PR TITLE
[windows] Temporarily pin syft version for SBOM report

### DIFF
--- a/.github/workflows/create_sbom_report.yml
+++ b/.github/workflows/create_sbom_report.yml
@@ -34,7 +34,7 @@ jobs:
       #Installation section
       - name: Install SYFT tool on Windows
         if: ${{ runner.os == 'Windows' }}
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b D:/syft
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b D:/syft v0.84.1
       - name: Install SYFT tool on Ubuntu or macOS
         if: ${{ runner.os != 'Windows' }}
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin


### PR DESCRIPTION
# Description
With latest `v0.85.0` release of `syft`, SBOM workflow fails to complete successfully on Windows.
Temporarily pin `syft` to `v0.84.1`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
