### PR TITLE
Dev add targeting xp for win images

### DIFF
--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -469,6 +469,7 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 | Microsoft.VisualStudio.Component.Windows11SDK.22000                       | 17.6.33605.316  |
 | Microsoft.VisualStudio.Component.Windows11SDK.22621                       | 17.6.33605.316  |
 | Microsoft.VisualStudio.Component.Workflow                                 | 17.6.33605.316  |
+| Microsoft.VisualStudio.Component.WinXP                                    | 17.6.33605.316  |
 | Microsoft.VisualStudio.Component.WslDebugging                             | 17.6.33605.316  |
 | Microsoft.VisualStudio.ComponentGroup.ArchitectureTools.Native            | 17.6.33605.316  |
 | Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices                 | 17.6.33605.316  |

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -296,6 +296,7 @@
             "Microsoft.VisualStudio.Component.Windows10SDK.20348",
             "Microsoft.VisualStudio.Component.Windows11SDK.22000",
             "Microsoft.VisualStudio.Component.Windows11SDK.22621",
+            "Microsoft.VisualStudio.Component.WinXP",
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices",
             "Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools",


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Add Microsoft.VisualStudio.Component.WinXP for VS2022

#### Related issue:

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable) [no]
- [X] Documentation is updated (if applicable) [please check comonpent version]
- [ ] Changes are tested and related VM images are successfully generated [no]
