### PR TITLE
second attempt to switch to run_id for release number generation

### DIFF
--- a/.github/workflows/ubuntu-win-generation.yml
+++ b/.github/workflows/ubuntu-win-generation.yml
@@ -81,12 +81,13 @@ jobs:
 
       - name: Build image
         run: |
+            $ResourcesNamePrefix = ${{ github.run_id }} % [System.UInt32]::MaxValue
             ./images.CI/linux-and-win/build-image.ps1 `
               -TemplatePath ${{ env.TemplatePath }} `
               -ClientId ${{ secrets.CLIENT_ID }} `
               -ClientSecret ${{ secrets.CLIENT_SECRET }} `
               -Location ${{ secrets.AZURE_LOCATION }} `
-              -ResourcesNamePrefix ${{ github.run_number }} `
+              -ResourcesNamePrefix $ResourcesNamePrefix `
               -ResourceGroup ${{ secrets.AZURE_RESOURCE_GROUP }} `
               -StorageAccount ${{ secrets.AZURE_STORAGE_ACCOUNT }} `
               -SubscriptionId ${{ secrets.AZURE_SUBSCRIPTION }} `
@@ -112,8 +113,9 @@ jobs:
 
       - name: Create release for VM deployment
         run: |
+          $BuildId = ${{ github.run_id }} % [System.UInt32]::MaxValue
           ./images.CI/linux-and-win/create-release.ps1 `
-            -BuildId ${{ github.run_number }} `
+            -BuildId $BuildId `
             -Organization ${{ secrets.RELEASE_TARGET_ORGANIZATION }} `
             -DefinitionId ${{ secrets.RELEASE_TARGET_DEFINITION_ID }} `
             -Project ${{ secrets.RELEASE_TARGET_PROJECT }} `


### PR DESCRIPTION
# Description

try to switch to "run_id" again, because "run_number" is not unique

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5253

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
