### PR TITLE
[Ubuntu] Use new official endpoints to get Chromium revision

### DIFF
--- a/images/linux/scripts/installers/google-chrome.sh
+++ b/images/linux/scripts/installers/google-chrome.sh
@@ -8,48 +8,27 @@
 source $HELPER_SCRIPTS/install.sh
 
 function GetChromiumRevision {
-    CHROME_VERSION=$1
+    CHROME_REVISION=$1
 
-    # Get the required Chromium revision corresponding to the Chrome version
-    URL="https://omahaproxy.appspot.com/deps.json?version=${CHROME_VERSION}"
-    REVISION=$(curl -s $URL | jq -r '.chromium_base_position')
-
-    # Temporarily hardcode revision as both requests
-    # for 115.0.5790.102 and 115.0.5790.98 return old incorrect revision
-    if [ $REVISION -eq "1583" ]; then
-       REVISION="1148114"
-    fi
-
-    # Some Google Chrome versions are based on Chromium revisions for which a (usually very old) Chromium release with the same number exist. So far this has heppened with 4 digits long Chromium revisions (1060, 1086).
-    # Use the previous Chromium release when this happens to avoid downloading and installing very old Chromium releases that would break image build because of incompatibilities.
-    # First reported with: https://github.com/actions/runner-images/issues/5256
-    if [ ${#REVISION} -le 4 ]; then
-      CURRENT_REVISIONS=$(curl -s "https://omahaproxy.appspot.com/all.json?os=linux&channel=stable")
-      PREVIOUS_VERSION=$(echo "$CURRENT_REVISIONS" | jq -r '.[].versions[].previous_version')
-      URL="https://omahaproxy.appspot.com/deps.json?version=${PREVIOUS_VERSION}"
-      REVISION=$(curl -s $URL | jq -r '.chromium_base_position')
-    fi
     # Take the first part of the revision variable to search not only for a specific version,
     # but also for similar ones, so that we can get a previous one if the required revision is not found
-    FIRST_PART_OF_REVISION=${REVISION:0:${#REVISION}/2}
-    FIRST_PART_OF_PREVIOUS_REVISION=$(expr $FIRST_PART_OF_REVISION - 1)
-    URL="https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o?delimiter=/&prefix=Linux_x64"
+    CHROME_REVISION_PREFIX=${CHROME_REVISION:0:${#CHROME_REVISION}/2+1}
+    SEARCH_URL="https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o?delimiter=/&prefix=Linux_x64"
     # Revision can include a hash instead of a number. Need to filter it out https://github.com/actions/runner-images/issues/5256
-    VERSIONS=$((curl -s $URL/${FIRST_PART_OF_REVISION} | jq -r '.prefixes[]' && curl -s $URL/${FIRST_PART_OF_PREVIOUS_REVISION} | jq -r '.prefixes[]') | grep -E "Linux_x64\/[0-9]+\/"| cut -d "/" -f 2 | sort --version-sort)
+    REVISIONS_AVAILABLE=$(curl -s $SEARCH_URL/${CHROME_REVISION_PREFIX} | jq -r '.prefixes[]' | grep -E "Linux_x64\/[0-9]+\/"| cut -d "/" -f 2 | sort --version-sort)
 
     # If required Chromium revision is not found in the list
     # we should have to decrement the revision number until we find one.
     # This is mentioned in the documentation we use for this installation:
     # https://www.chromium.org/getting-involved/download-chromium
-    RIGHT_REVISION=$(echo $VERSIONS | cut -f 1 -d " ")
-    for version in $VERSIONS; do
-        if [ $REVISION -lt $version ]; then
-            echo $RIGHT_REVISION
-            return
+    LATEST_VALID_REVISION=$(echo $REVISIONS_AVAILABLE | cut -f 1 -d " ")
+    for REVISION in $REVISIONS_AVAILABLE; do
+        if [ "$CHROME_REVISION" -lt "$REVISION" ]; then
+          break
         fi
-        RIGHT_REVISION=$version
+        LATEST_VALID_REVISION=$REVISION
     done
-    echo $RIGHT_REVISION
+    echo $LATEST_VALID_REVISION
 }
 
 # Download and install Google Chrome
@@ -67,36 +46,38 @@ FULL_CHROME_VERSION=$(google-chrome --product-version)
 CHROME_VERSION=${FULL_CHROME_VERSION%.*}
 echo "Chrome version is $FULL_CHROME_VERSION"
 
-# Determine the download url for chromedriver
-CHROME_VERSIONS_JSON=$(curl -fsSL https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json)
-CHROMEDRIVER_VERSION=$(echo $CHROME_VERSIONS_JSON | jq -r '.builds["'"$CHROME_VERSION"'"].version')
-CHROMEDRIVER_URL=$(echo $CHROME_VERSIONS_JSON | jq -r '.builds["'"$CHROME_VERSION"'"].downloads.chromedriver[] | select(.platform=="linux64").url')
+# Get chrome versions information
+CHROME_PLATFORM="linux64"
+CHROME_VERSIONS_URL="https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json"
+CHROME_VERSIONS_JSON=$(curl -fsSL "${CHROME_VERSIONS_URL}")
 
 # Download and unpack the latest release of chromedriver
-echo "Installing chromedriver version $CHROMEDRIVER_VERSION"
-download_with_retries $CHROMEDRIVER_URL "/tmp" "chromedriver_linux64.zip"
-unzip -qq /tmp/chromedriver_linux64.zip -d /usr/local/share
-
+CHROMEDRIVER_VERSION=$(echo "${CHROME_VERSIONS_JSON}" | jq -r '.builds["'"$CHROME_VERSION"'"].version')
+CHROMEDRIVER_URL=$(echo "${CHROME_VERSIONS_JSON}" | jq -r '.builds["'"$CHROME_VERSION"'"].downloads.chromedriver[] | select(.platform=="'"${CHROME_PLATFORM}"'").url')
+CHROMEDRIVER_ARCHIVE="chromedriver_linux64.zip"
 CHROMEDRIVER_DIR="/usr/local/share/chromedriver-linux64"
 CHROMEDRIVER_BIN="$CHROMEDRIVER_DIR/chromedriver"
+
+echo "Installing chromedriver version $CHROMEDRIVER_VERSION"
+download_with_retries $CHROMEDRIVER_URL "/tmp" $CHROMEDRIVER_ARCHIVE
+unzip -qq /tmp/$CHROMEDRIVER_ARCHIVE -d /usr/local/share
+
 chmod +x $CHROMEDRIVER_BIN
 ln -s "$CHROMEDRIVER_BIN" /usr/bin/
 echo "CHROMEWEBDRIVER=$CHROMEDRIVER_DIR" | tee -a /etc/environment
 
 # Download and unpack Chromium
-# Get Chromium version corresponding to the Google Chrome version
-REVISION=$(GetChromiumRevision $FULL_CHROME_VERSION)
-
-ZIP_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F${REVISION}%2Fchrome-linux.zip?alt=media"
-ZIP_FILE="${REVISION}-chromium-linux.zip"
-
+CHROME_REVISION=$(echo "${CHROME_VERSIONS_JSON}" | jq -r '.builds["'"$CHROME_VERSION"'"].revision')
+CHROMIUM_REVISION=$(GetChromiumRevision $CHROME_REVISION)
+CHROMIUM_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F${CHROMIUM_REVISION}%2Fchrome-linux.zip?alt=media"
+CHROMIUM_ARCHIVE="${CHROMIUM_REVISION}-chromium-linux.zip"
 CHROMIUM_DIR="/usr/local/share/chromium"
-CHROMIUM_BIN="$CHROMIUM_DIR/chrome-linux/chrome"
+CHROMIUM_BIN="${CHROMIUM_DIR}/chrome-linux/chrome"
 
-# Download and unzip Chromium archive
-download_with_retries $ZIP_URL "/tmp" $ZIP_FILE
+echo "Installing chromium revision $CHROMIUM_REVISION"
+download_with_retries $CHROMIUM_URL "/tmp" $CHROMIUM_ARCHIVE
 mkdir $CHROMIUM_DIR
-unzip -qq /tmp/${ZIP_FILE} -d $CHROMIUM_DIR
+unzip -qq /tmp/$CHROMIUM_ARCHIVE -d $CHROMIUM_DIR
 
 ln -s $CHROMIUM_BIN /usr/bin/chromium
 ln -s $CHROMIUM_BIN /usr/bin/chromium-browser


### PR DESCRIPTION
# Description
Currently [omahaproxy page](https://omahaproxy.appspot.com/) is used to get information about available Chrome revisions, but it was retired in April 2023 and doesn't work good now. Recently Google created [new page](https://googlechromelabs.github.io/chrome-for-testing/) and json endpoints that have all the information we need. This PR is to switch to the new endpoints.

#### Related issue: https://github.com/actions/runner-images/issues/7980

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
