### PR TITLE
[macos] suppress swiftc warnings regarding deprecated API

### DIFF
--- a/images/macos/provision/configuration/configure-machine.sh
+++ b/images/macos/provision/configuration/configure-machine.sh
@@ -37,7 +37,7 @@ defaults write com.apple.VoiceOver4/default SCREnableAppleScript -bool YES
 # sudo security delete-certificate -Z FF6797793A3CD798DC5B2ABEF56F73EDC9F83A64 /Library/Keychains/System.keychain
 # Big Sur requires user interaction to add a cert https://developer.apple.com/forums/thread/671582, we need to use a workaround with SecItemAdd swift method
 
-swiftc "${HOME}/image-generation/add-certificate.swift"
+swiftc -suppress-warnings "${HOME}/image-generation/add-certificate.swift"
 
 
 certs=(


### PR DESCRIPTION
# Description

we are fine with that API usage, no need to see warnings every time

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
