### PR TITLE
[mac OS] Install Google Chrome for Testing

### DIFF
--- a/images/macos/provision/core/chrome.sh
+++ b/images/macos/provision/core/chrome.sh
@@ -1,16 +1,49 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
+arch=$(get_arch)
 
-echo "Installing Chrome..."
+echo "Installing Google Chrome..."
 brew_cask_install_ignoring_sha256 "google-chrome"
 
-echo "Installing Chrome Driver"
-brew install --cask chromedriver
+# Parse Google Chrome version
+FULL_CHROME_VERSION=$("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --version)
+FULL_CHROME_VERSION=${FULL_CHROME_VERSION#Google Chrome }
+CHROME_VERSION=${FULL_CHROME_VERSION%.*}
+echo "Google Chrome version is $FULL_CHROME_VERSION"
+
+# Get Google Chrome versions information
+CHROME_PLATFORM="mac-$arch"
+CHROME_VERSIONS_URL="https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build-with-downloads.json"
+CHROME_VERSIONS_JSON=$(curl -fsSL "${CHROME_VERSIONS_URL}")
+
+# Download and unpack the latest release of Chrome Driver
+CHROMEDRIVER_VERSION=$(echo "${CHROME_VERSIONS_JSON}" | jq -r '.builds["'"$CHROME_VERSION"'"].version')
+echo "Installing Chrome Driver version $CHROMEDRIVER_VERSION"
+
+CHROMEDRIVER_URL=$(echo "${CHROME_VERSIONS_JSON}" | jq -r '.builds["'"$CHROME_VERSION"'"].downloads.chromedriver[] | select(.platform=="'"${CHROME_PLATFORM}"'").url')
+CHROMEDRIVER_ARCHIVE="chromedriver-${CHROME_PLATFORM}.zip"
+CHROMEDRIVER_DIR="/usr/local/share/chromedriver-${CHROME_PLATFORM}"
+CHROMEDRIVER_BIN="$CHROMEDRIVER_DIR/chromedriver"
+
+download_with_retries "$CHROMEDRIVER_URL" "/tmp" "$CHROMEDRIVER_ARCHIVE"
+unzip -qq /tmp/$CHROMEDRIVER_ARCHIVE -d /usr/local/share
+chmod +x $CHROMEDRIVER_BIN
+ln -s "$CHROMEDRIVER_BIN" /usr/local/bin/chromedriver
+echo "export CHROMEWEBDRIVER=$CHROMEDRIVER_DIR" >> "${HOME}/.bashrc"
+
+# Download and unpack the latest release of Google Chrome for Testing
+CHROME_FOR_TESTING_VERSION=$(echo "${CHROME_VERSIONS_JSON}" | jq -r '.builds["'"$CHROME_VERSION"'"].version')
+echo "Installing Google Chrome for Testing version $CHROME_FOR_TESTING_VERSION"
+
+CHROME_FOR_TESTING_URL=$(echo "${CHROME_VERSIONS_JSON}" | jq -r '.builds["'"$CHROME_VERSION"'"].downloads.chrome[] | select(.platform=="'"${CHROME_PLATFORM}"'").url')
+CHROME_FOR_TESTING_ARCHIVE="chrome-${CHROME_PLATFORM}.zip"
+CHROME_FOR_TESTING_APP="Google Chrome for Testing.app"
+
+download_with_retries $CHROME_FOR_TESTING_URL "/tmp" $CHROME_FOR_TESTING_ARCHIVE
+unzip -qq /tmp/$CHROME_FOR_TESTING_ARCHIVE -d /tmp/
+mv "/tmp/chrome-${CHROME_PLATFORM}/${CHROME_FOR_TESTING_APP}" "/Applications/${CHROME_FOR_TESTING_APP}"
 
 echo "Installing Selenium"
 brew_smart_install "selenium-server"
-
-CHROMEWEBDRIVER_DIR=$(readlink $(which chromedriver) | xargs dirname)
-echo "export CHROMEWEBDRIVER=$CHROMEWEBDRIVER_DIR" >> "${HOME}/.bashrc"
 
 invoke_tests "Browsers" "Chrome"

--- a/images/macos/software-report/SoftwareReport.Browsers.psm1
+++ b/images/macos/software-report/SoftwareReport.Browsers.psm1
@@ -3,6 +3,7 @@ function Build-BrowserSection {
         [ToolVersionNode]::new("Safari", $(Get-SafariVersion))
         [ToolVersionNode]::new("SafariDriver", $(Get-SafariDriverVersion))
         [ToolVersionNode]::new("Google Chrome", $(Get-ChromeVersion))
+        [ToolVersionNode]::new("Google Chrome for Testing", $(Get-ChromeForTestingVersion))
         [ToolVersionNode]::new("ChromeDriver", $(Get-ChromeDriverVersion))
         [ToolVersionNode]::new("Microsoft Edge", $(Get-EdgeVersion))
         [ToolVersionNode]::new("Microsoft Edge WebDriver", $(Get-EdgeDriverVersion))
@@ -19,7 +20,7 @@ function Get-SafariVersion {
 }
 
 function Get-SafariDriverVersion {
-    $version = Run-Command "safaridriver --version" | Take-Part -Part 3,4
+    $version = Run-Command "safaridriver --version" | Take-Part -Part 3, 4
     return $version
 }
 
@@ -27,6 +28,12 @@ function Get-ChromeVersion {
     $chromePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
     $version = Run-Command "'${chromePath}' --version"
     return ($version -replace ("^Google Chrome")).Trim()
+}
+
+function Get-ChromeForTestingVersion {
+    $chromePath = "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+    $version = Run-Command "'${chromePath}' --version"
+    return ($version -replace ("^Google Chrome for Testing")).Trim()
 }
 
 function Get-ChromeDriverVersion {

--- a/images/macos/tests/Browsers.Tests.ps1
+++ b/images/macos/tests/Browsers.Tests.ps1
@@ -4,6 +4,7 @@ $os = Get-OSVersion
 Describe "Chrome" -Skip:($os.IsVenturaArm64) {
     BeforeAll {
         $chromeLocation = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        $chromeForTestingLocation = "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
     }
 
     It "Chrome" {
@@ -11,12 +12,17 @@ Describe "Chrome" -Skip:($os.IsVenturaArm64) {
         "'$chromeLocation' --version" | Should -ReturnZeroExitCode
     }
 
+    It "Chrome for Testing" {
+        $chromeForTestingLocation | Should -Exist
+        "'$chromeForTestingLocation' --version" | Should -ReturnZeroExitCode
+    }
+
     It "Chrome Driver" {
         "chromedriver --version" | Should -ReturnZeroExitCode
     }
 
-    It "Chrome and Chrome Driver major versions are the same" {
-        $chromeMajor = (& $chromeLocation --version).Trim("Google Chrome ").Split(".")[0]
+    It "Chrome for Testing and Chrome Driver major versions are the same" {
+        $chromeMajor = (& $chromeForTestingLocation --version).Trim("Google Chrome for Testing ").Split(".")[0]
         $chromeDriverMajor = (chromedriver --version).Trim("ChromeDriver ").Split(".")[0]
         $chromeMajor | Should -BeExactly $chromeDriverMajor
     }


### PR DESCRIPTION
# Description
With the new [ChromeDriver release process](https://groups.google.com/g/chromedriver-users/c/qVPTFXnedw0) it's advised to use Google Chrome for Testing for automation and development instead of a "classic" Google Chrome. Furthermore on mac OS new ChromeDriver [can only work with Google Chrome for Testing](https://bugs.chromium.org/p/chromium/issues/detail?id=1466427). This PR is to install both ChromeDriver and Google Chrome for Testing from the official site to ensure versions match and compatibility.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
