### PR TITLE
[macos] use unxip if available for XCode unpacking

### DIFF
--- a/images/macos/helpers/Common.Helpers.psm1
+++ b/images/macos/helpers/Common.Helpers.psm1
@@ -166,3 +166,16 @@ function Get-Architecture {
 
     return $arch
 }
+
+Function Test-CommandExists {
+    param
+    (
+        $command
+    )
+
+    try {
+        if(Get-Command $command -ErrorAction 'Stop' ){ $true }
+    } Catch {
+        $false
+    }
+}

--- a/images/macos/helpers/Common.Helpers.psm1
+++ b/images/macos/helpers/Common.Helpers.psm1
@@ -167,11 +167,11 @@ function Get-Architecture {
     return $arch
 }
 
-Function Test-CommandExists {
+function Test-CommandExists {
     param
     (
-        $command
+        [Parameter(Mandatory)] [string] $Command
     )
 
-    [boolean] (Get-Command $command  -ErrorAction 'SilentlyContinue')
+    [boolean] (Get-Command $Command  -ErrorAction 'SilentlyContinue')
 }

--- a/images/macos/helpers/Common.Helpers.psm1
+++ b/images/macos/helpers/Common.Helpers.psm1
@@ -173,9 +173,5 @@ Function Test-CommandExists {
         $command
     )
 
-    try {
-        if(Get-Command $command -ErrorAction 'Stop' ){ $true }
-    } Catch {
-        $false
-    }
+    [boolean] (Get-Command $command  -ErrorAction 'SilentlyContinue')
 }

--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -1,3 +1,4 @@
+Import-Module "$PSScriptRoot/Common.Helpers.psm1"
 Import-Module "$PSScriptRoot/Xcode.Helpers.psm1"
 
 function Install-XcodeVersion {
@@ -86,7 +87,11 @@ function Expand-XcodeXipArchive {
 
     Write-Host "Extracting Xcode from '$xcodeXipPath'"
     Push-Location $DownloadDirectory
-    Invoke-ValidateCommand "xip -x $xcodeXipPath"
+    if(Test-CommandExists 'unxip') {
+        Invoke-ValidateCommand "unxip $xcodeXipPath"
+    } else {
+        Invoke-ValidateCommand "xip -x $xcodeXipPath"
+    }
     Pop-Location
 
     if (Test-Path "$DownloadDirectory/Xcode-beta.app") {

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -212,7 +212,8 @@
             "tcl-tk",
             "r",
             "yq",
-            "imagemagick"
+            "imagemagick",
+            "unxip"
         ],
         "cask_packages": [
             "julia",

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -80,7 +80,8 @@
             "zstd",
             "gmp",
             "r",
-            "yq"
+            "yq",
+            "unxip"
         ],
         "cask_packages": [
             "julia",


### PR DESCRIPTION
# Description

small improvement, use "unxip" utility from Homebrew if available

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5272

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
