### PR TITLE
[Ubuntu] Pin Android cmdline-tools version

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -87,7 +87,7 @@
         "maven": "3.8.8"
     },
     "android": {
-        "cmdline-tools": "latest",
+        "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra_list": [

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -76,7 +76,7 @@
         "maven": "3.8.8"
     },
     "android": {
-        "cmdline-tools": "latest",
+        "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra_list": [


### PR DESCRIPTION
# Description
The latest version of Android cmdline tools are build for Java 17 that is not default in both Ubuntu 20.04 and Ubuntu 22.04. It causes installation script failure. This PR pins package version to workaround that failure.

#### Related issue: https://github.com/actions/runner-images/issues/8000

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
