### PR TITLE
[Windows] Update Edge installer to install only webdriver

### DIFF
--- a/images/win/scripts/Installers/Install-Edge.ps1
+++ b/images/win/scripts/Installers/Install-Edge.ps1
@@ -1,12 +1,7 @@
 ################################################################################
 ##  File:  Install-Edge.ps1
-##  Desc:  Install latest stable version of Microsoft Edge browser
+##  Desc:  Configure Edge browser and install Edge WebDriver
 ################################################################################
-
-# Installed by default on Windows Server 2022
-if (-not (Test-IsWin22)) {
-    Choco-Install -PackageName microsoft-edge
-}
 
 # Disable Edge auto-updates
 Rename-Item -Path "C:\Program Files (x86)\Microsoft\EdgeUpdate\MicrosoftEdgeUpdate.exe" -NewName "Disabled_MicrosoftEdgeUpdate.exe" -ErrorAction Stop


### PR DESCRIPTION
# Description
Edge is currently installed on base Windows Server 2019 VMs - there is no need to install it from Choco.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
