### PR TITLE
[win] specify accept header when downloading mysql meta

### DIFF
--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -15,7 +15,7 @@ Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentLi
 $MysqlVersionMajorMinor = $MysqlVersion.ToString(2)
 
 if ($MysqlVersion.Build -lt 0) {
-    $MysqlVersion = (Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html" |
+    $MysqlVersion = (Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html" -Headers @{'Accept'='text/html'} |
         Select-String -Pattern "${MysqlVersionMajorMinor}\.\d+").Matches.Value
 }
 


### PR DESCRIPTION
# Description

mimic to browser behaviour by speciifying "Accept: text/html" when determining current mysql version

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

https://github.com/actions/runner-images/issues/8004

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
