### PR TITLE
[Ubuntu] Remove AdoptOpenJDK

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Java.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Java.psm1
@@ -1,22 +1,17 @@
 function Get-JavaVersionsTable {
     $javaToolcacheVersions = Get-ChildItem $env:AGENT_TOOLSDIRECTORY/Java*/* -Directory | Sort-Object { [int]$_.Name.Split(".")[0] }
 
-    $existingVersions = $javaToolcacheVersions | ForEach-Object {
+    return $javaToolcacheVersions | ForEach-Object {
         $majorVersion = $_.Name.split(".")[0]
         $fullVersion = $_.Name.Replace("-", "+")
         $defaultJavaPath = $env:JAVA_HOME
         $javaPath = Get-Item env:JAVA_HOME_${majorVersion}_X64
 
         $defaultPostfix = ($javaPath.Value -eq $defaultJavaPath) ? " (default)" : ""
-        $vendorName = ($_.FullName -like '*Java_Adopt_jdk*') ? "Adopt OpenJDK" :  "Eclipse Temurin"
 
         [PSCustomObject] @{
-            "Version" = $fullVersion + $defaultPostfix
-            "Vendor" = $vendorName
+            "Version"              = $fullVersion + $defaultPostfix
             "Environment Variable" = $javaPath.Name
         }
     }
-    # Return all the vendors which are not Adopt, also look for version 12 of Adopt (Eclipse Temurin does not have this version)
-    $versionsToReturn = $existingVersions | Where-Object {$_.Vendor -notlike "Adopt*" -or $_.Version.Split(".")[0] -eq 12}
-    return $versionsToReturn
 }

--- a/images/linux/scripts/installers/java-tools.sh
+++ b/images/linux/scripts/installers/java-tools.sh
@@ -10,21 +10,9 @@ source $HELPER_SCRIPTS/etc-environment.sh
 
 createJavaEnvironmentalVariable() {
     local JAVA_VERSION=$1
-    local VENDOR_NAME=$2
-    local DEFAULT=$3
+    local DEFAULT=$2
 
-    case ${VENDOR_NAME} in
-
-        "Adopt" )
-            INSTALL_PATH_PATTERN="/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64" ;;
-
-        "Temurin-Hotspot" )
-            INSTALL_PATH_PATTERN="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64" ;;
-        *)
-            echo "Unknown vendor"
-            exit 1
-
-    esac
+    local INSTALL_PATH_PATTERN="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64"
 
     if [[ ${DEFAULT} == "True" ]]; then
         echo "Setting up JAVA_HOME variable to ${INSTALL_PATH_PATTERN}"
@@ -38,14 +26,7 @@ createJavaEnvironmentalVariable() {
 }
 
 enableRepositories() {
-
-osLabel=$(getOSVersionLabel)
-
-    if isUbuntu20; then
-        # Add Adopt PPA
-        wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | gpg --dearmor > /usr/share/keyrings/adopt.gpg
-        echo "deb [signed-by=/usr/share/keyrings/adopt.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ $osLabel main" > /etc/apt/sources.list.d/adopt.list
-    fi
+    osLabel=$(getOSVersionLabel)
 
     # Add Addoptium PPA
     # apt-key is deprecated, dearmor and add manually
@@ -56,21 +37,12 @@ osLabel=$(getOSVersionLabel)
 
 installOpenJDK() {
     local JAVA_VERSION=$1
-    local VENDOR_NAME=$2
 
     # Install Java from PPA repositories.
-    if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]]; then
-        apt-get -y install temurin-${JAVA_VERSION}-jdk=\*
-        javaVersionPath="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64"
-    elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
-        apt-get -y install adoptopenjdk-${JAVA_VERSION}-hotspot=\*
-        javaVersionPath="/usr/lib/jvm/adoptopenjdk-${JAVA_VERSION}-hotspot-amd64"
-    else
-        echo "${VENDOR_NAME} is invalid, valid names are: Temurin-Hotspot and Adopt"
-        exit 1
-    fi
+    apt-get -y install temurin-${JAVA_VERSION}-jdk=\*
+    javaVersionPath="/usr/lib/jvm/temurin-${JAVA_VERSION}-jdk-amd64"
 
-    JAVA_TOOLCACHE_PATH="${AGENT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk"
+    JAVA_TOOLCACHE_PATH="${AGENT_TOOLSDIRECTORY}/Java_Temurin-Hotspot_jdk"
 
     fullJavaVersion=$(cat "${javaVersionPath}/release" | grep "^SEMANTIC" | cut -d "=" -f 2 | tr -d "\"" | tr "+" "-")
 
@@ -101,25 +73,17 @@ enableRepositories
 apt-get update
 
 defaultVersion=$(get_toolset_value '.java.default')
-defaultVendor=$(get_toolset_value '.java.default_vendor')
-jdkVendors=($(get_toolset_value '.java.vendors[].name'))
+jdkVersionsToInstall=($(get_toolset_value ".java.versions[]"))
 
-for jdkVendor in ${jdkVendors[@]}; do
+for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
+    installOpenJDK ${jdkVersionToInstall}
 
-     # get vendor-specific versions
-     jdkVersionsToInstall=($(get_toolset_value ".java.vendors[] | select (.name==\"${jdkVendor}\") | .versions[]"))
-
-     for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
-
-        installOpenJDK ${jdkVersionToInstall} ${jdkVendor}
-
-        isDefaultVersion=False; [[ ${jdkVersionToInstall} == ${defaultVersion} ]] && isDefaultVersion=True
-
-        if [[ ${jdkVendor} == ${defaultVendor} ]]; then
-            createJavaEnvironmentalVariable ${jdkVersionToInstall} ${jdkVendor} ${isDefaultVersion}
-        fi
-
-    done
+    if [[ ${jdkVersionToInstall} == ${defaultVersion} ]]
+    then
+        createJavaEnvironmentalVariable ${jdkVersionToInstall} True
+    else
+        createJavaEnvironmentalVariable ${jdkVersionToInstall} False
+    fi
 done
 
 # Install Ant
@@ -147,10 +111,8 @@ ln -s /usr/share/gradle-"${gradleLatestVersion}"/bin/gradle /usr/bin/gradle
 echo "GRADLE_HOME=$(find /usr/share -depth -maxdepth 1 -name "gradle*")" | tee -a /etc/environment
 
 # Delete java repositories and keys
-rm -f /etc/apt/sources.list.d/adopt.list
 rm -f /etc/apt/sources.list.d/adoptium.list
 rm -f /etc/apt/sources.list.d/zulu.list
-rm -f /usr/share/keyrings/adopt.gpg
 rm -f /usr/share/keyrings/adoptium.gpg
 rm -f /usr/share/keyrings/zulu.gpg
 

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -73,17 +73,7 @@
     ],
     "java": {
         "default": "11",
-        "default_vendor": "Temurin-Hotspot",
-        "vendors": [
-            {
-                "name": "Temurin-Hotspot",
-                "versions": [ "8", "11", "17" ]
-            },
-            {
-                "name": "Adopt",
-                "versions": [ "8", "11" ]
-            }
-        ],
+        "versions": [ "8", "11", "17" ],
         "maven": "3.8.8"
     },
     "android": {

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -66,13 +66,7 @@
     ],
     "java": {
         "default": "11",
-        "default_vendor": "Temurin-Hotspot",
-        "vendors": [
-            {
-                "name": "Temurin-Hotspot",
-                "versions": [ "8", "11", "17" ]
-            }
-        ],
+        "versions": [ "8", "11", "17" ],
         "maven": "3.8.8"
     },
     "android": {


### PR DESCRIPTION
# Description
Recently Adoptium team started brownouts for AdoptOpenJDK and it breaks image generation process. This PR remove AdoptOpenJDK references from images.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
