### PR TITLE
[mac OS] Remove AdoptOpenJDK

### DIFF
--- a/images/macos/provision/core/openjdk.sh
+++ b/images/macos/provision/core/openjdk.sh
@@ -3,10 +3,9 @@ source ~/utils/utils.sh
 
 createEnvironmentVariable() {
     local JAVA_VERSION=$1
-    local VENDOR_NAME=$2
-    local DEFAULT=$3
+    local DEFAULT=$2
 
-    INSTALL_PATH_PATTERN=$(echo ${AGENT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk/${JAVA_VERSION}*/x64/Contents/Home/)
+    INSTALL_PATH_PATTERN=$(echo ${AGENT_TOOLSDIRECTORY}/Java_Temurin-Hotspot_jdk/${JAVA_VERSION}*/x64/Contents/Home/)
 
     if [[ ${DEFAULT} == "True" ]]; then
         echo "Setting up JAVA_HOME variable to ${INSTALL_PATH_PATTERN}"
@@ -19,62 +18,46 @@ createEnvironmentVariable() {
 
 installOpenJDK() {
     local JAVA_VERSION=$1
-    local VENDOR_NAME=$2
 
     # Get link for Java binaries and Java version
-    if [[ ${VENDOR_NAME} == "Temurin-Hotspot" ]]; then
-        assetUrl=$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
-    elif [[ ${VENDOR_NAME} == "Adopt" ]]; then
-        assetUrl=$(curl -fsSL "https://api.adoptopenjdk.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
-    else
-        echo "${VENDOR_NAME} is invalid, valid names are: Temurin-Hotspot and Adopt"
-        exit 1
-    fi
+    assetUrl=$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/${JAVA_VERSION}/hotspot")
 
     asset=$(echo ${assetUrl} | jq -r '.[] | select(.binary.os=="mac" and .binary.image_type=="jdk" and .binary.architecture=="x64")')
     archivePath=$(echo ${asset} | jq -r '.binary.package.link')
     fullVersion=$(echo ${asset} | jq -r '.version.semver' | tr '+' '-')
 
-    JAVA_TOOLCACHE_PATH=${AGENT_TOOLSDIRECTORY}/Java_${VENDOR_NAME}_jdk
+    JAVA_TOOLCACHE_PATH=${AGENT_TOOLSDIRECTORY}/Java_Temurin-Hotspot_jdk
 
     javaToolcacheVersionPath=$JAVA_TOOLCACHE_PATH/${fullVersion}
     javaToolcacheVersionArchPath=${javaToolcacheVersionPath}/x64
 
     # Download and extract Java binaries
-    download_with_retries ${archivePath} /tmp OpenJDK-${VENDOR_NAME}-${fullVersion}.tar.gz
+    download_with_retries ${archivePath} /tmp OpenJDK-${fullVersion}.tar.gz
     
     echo "Creating ${javaToolcacheVersionArchPath} directory"
     mkdir -p ${javaToolcacheVersionArchPath}
 
-    tar -xf /tmp/OpenJDK-${VENDOR_NAME}-${fullVersion}.tar.gz -C ${javaToolcacheVersionArchPath} --strip-components=1
+    tar -xf /tmp/OpenJDK-${fullVersion}.tar.gz -C ${javaToolcacheVersionArchPath} --strip-components=1
     # Create complete file
     touch ${javaToolcacheVersionPath}/x64.complete
 
     # Create a symlink to '/Library/Java/JavaVirtualMachines'
     # so '/usr/libexec/java_home' will be able to find Java
-    sudo ln -sf ${javaToolcacheVersionArchPath} /Library/Java/JavaVirtualMachines/${VENDOR_NAME}-${JAVA_VERSION}.jdk
+    sudo ln -sf ${javaToolcacheVersionArchPath} /Library/Java/JavaVirtualMachines/Temurin-Hotspot-${JAVA_VERSION}.jdk
 }
 
 defaultVersion=$(get_toolset_value '.java.default')
-defaultVendor=$(get_toolset_value '.java.default_vendor')
-jdkVendors=($(get_toolset_value '.java.vendors[].name'))
+jdkVersionsToInstall=($(get_toolset_value ".java.versions[]"))
 
-for jdkVendor in ${jdkVendors[@]}; do
-
-     # get vendor-specific versions
-     jdkVersionsToInstall=($(get_toolset_value ".java.vendors[] | select (.name==\"${jdkVendor}\") | .versions[]"))
-
-     for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
-
-        installOpenJDK ${jdkVersionToInstall} ${jdkVendor}
-
-        isDefaultVersion=False; [[ ${jdkVersionToInstall} == ${defaultVersion} ]] && isDefaultVersion=True
-
-        if [[ ${jdkVendor} == ${defaultVendor} ]]; then
-            createEnvironmentVariable ${jdkVersionToInstall} ${jdkVendor} ${isDefaultVersion}
-        fi
-
-    done
+for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
+    installOpenJDK ${jdkVersionToInstall}
+    
+    if [[ ${jdkVersionToInstall} == ${defaultVersion} ]]
+    then
+        createEnvironmentVariable ${jdkVersionToInstall} True
+    else
+        createEnvironmentVariable ${jdkVersionToInstall} False
+    fi
 done
 
 echo Installing Maven...

--- a/images/macos/software-report/SoftwareReport.Java.psm1
+++ b/images/macos/software-report/SoftwareReport.Java.psm1
@@ -12,11 +12,9 @@ function Get-JavaVersions {
         $version = $javaPath.split('/')[5]
         $fullVersion = $version.Replace('-', '+')
         $defaultPostfix = ($javaPath -eq $defaultJavaPath) ? " (default)" : ""
-        $vendorName = ($javaPath -like '*Java_Adopt_jdk*') ? "Adopt OpenJDK" :  "Eclipse Temurin"
 
         [PSCustomObject] @{
-            "Version" = $fullVersion + $defaultPostfix
-            "Vendor" = $vendorName
+            "Version"              = $fullVersion + $defaultPostfix
             "Environment Variable" = $_.Name
         }
     }

--- a/images/macos/tests/Java.Tests.ps1
+++ b/images/macos/tests/Java.Tests.ps1
@@ -27,13 +27,8 @@ Describe "Java" -Skip:($os.IsVenturaArm64) {
 
     $toolsetJava = Get-ToolsetValue "java"
     $defaultVersion = $toolsetJava.default
-    $defaultVendor = $toolsetJava.default_vendor
-    $javaVendors = $toolsetJava.vendors
+    $jdkVersions = $toolsetJava.versions
 
-    [array]$jdkVersions = ($javaVendors | Where-Object {$_.name -eq $defaultVendor}).versions
-    [array]$adoptJdkVersions = ($javaVendors | Where-Object {$_.name -eq "Adopt"}).versions
-
-    $adoptCases = $adoptJdkVersions | ForEach-Object { @{Version = $_} }
     $testCases = $jdkVersions | ForEach-Object { @{ Title = $_; Version = (Get-NativeVersionFormat $_); EnvVariable = "JAVA_HOME_${_}_X64" } }
     $testCases += @{ Title = "Default"; Version = (Get-NativeVersionFormat $defaultVersion); EnvVariable = "JAVA_HOME" }
 
@@ -53,17 +48,6 @@ Describe "Java" -Skip:($os.IsVenturaArm64) {
                 It "Version is default" -TestCases $_ {
                     Validate-JavaVersion -JavaCommand "java -version" -ExpectedVersion $Version
                 }
-            }
-        }
-    }
-
-    Context "Java Adopt" {
-        Describe "Java Adopt" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
-                It "Java Adopt <Version>" -TestCases $adoptCases {
-                $adoptPath = Join-Path (Get-ChildItem ${env:AGENT_TOOLSDIRECTORY}\Java_Adopt_jdk\${Version}*) "x64\Contents\Home\bin\java"
-
-                $result = Get-CommandResult "`"$adoptPath`" -version"
-                $result.ExitCode | Should -Be 0
             }
         }
     }

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -154,17 +154,7 @@
     },
     "java": {
         "default": "8",
-        "default_vendor": "Temurin-Hotspot",
-        "vendors": [
-            {
-                "name": "Temurin-Hotspot",
-                "versions": [ "8", "11", "17" ]
-            },
-            {
-                "name": "Adopt",
-                "versions": [ "8", "11" ]
-            }
-        ]
+        "versions": [ "8", "11", "17" ]
     },
     "android": {
         "platform_min_version": "27",

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -141,17 +141,7 @@
     },
     "java": {
         "default": "8",
-        "default_vendor": "Temurin-Hotspot",
-        "vendors": [
-            {
-                "name": "Temurin-Hotspot",
-                "versions": [ "8", "11", "17" ]
-            },
-            {
-                "name": "Adopt",
-                "versions": [ "8", "11" ]
-            }
-        ]
+        "versions": [ "8", "11", "17" ]
     },
     "android": {
         "platform_min_version": "27",

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -28,13 +28,7 @@
     },
     "java": {
         "default": "17",
-        "default_vendor": "Temurin-Hotspot",
-        "vendors": [
-            {
-                "name": "Temurin-Hotspot",
-                "versions": [ "8", "11", "17" ]
-            }
-        ]
+        "versions": [ "8", "11", "17" ]
     },
     "android": {
         "platform_min_version": "27",


### PR DESCRIPTION
# Description

Recently Adoptium team started brownouts for AdoptOpenJDK and it breaks image generation process. This PR remove AdoptOpenJDK references from images.

Request for Ubuntu: #8022
Request for Windows: #8026

#### Related issue: #8030

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
