### PR TITLE
[Windows] Remove AdoptOpenJDK

### DIFF
--- a/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
+++ b/images/win/scripts/SoftwareReport/SoftwareReport.Java.psm1
@@ -13,11 +13,9 @@ function Get-JavaVersions {
         $versionInPath = (Split-Path $javaPath) -replace "\w:\\.*\\"
         $version = $versionInPath -replace '-', '+'
         $defaultPostfix = ($javaPath -eq $defaultJavaPath) ? " (default)" : ""
-        $VendorName = ($javaPath -like '*Java_Adopt_jdk*') ? "Adopt OpenJDK" :  "Eclipse Temurin"
 
         [PSCustomObject] @{
-            "Version" = $version + $defaultPostfix
-            "Vendor" = $VendorName
+            "Version"              = $version + $defaultPostfix
             "Environment Variable" = $_.Name
         }
     }

--- a/images/win/scripts/Tests/Java.Tests.ps1
+++ b/images/win/scripts/Tests/Java.Tests.ps1
@@ -1,11 +1,9 @@
 Describe "Java" {
     $toolsetJava = (Get-ToolsetContent).java
-    $defaultVendor = $toolsetJava.default_vendor
-    $javaVendors = $toolsetJava.vendors
     $defaultVersion = $toolsetJava.default
+    $jdkVersions = $toolsetJava.versions
 
-    [array]$jdkVersions = ($javaVendors | Where-Object {$_.name -eq $defaultVendor}).versions | ForEach-Object { @{Version = $_} }
-    [array]$adoptJdkVersions = ($javaVendors | Where-Object {$_.name -eq "Adopt"}).versions | ForEach-Object { @{Version = $_} }
+    [array]$testCases = $jdkVersions | ForEach-Object { @{Version = $_ } }
 
     It "Java <DefaultJavaVersion> is default" -TestCases @(@{ DefaultJavaVersion = $defaultVersion }) {
         $actualJavaPath = Get-EnvironmentVariable "JAVA_HOME"
@@ -25,25 +23,12 @@ Describe "Java" {
         "$ToolName -version" | Should -ReturnZeroExitCode
     }
 
-    It "Java <Version>" -TestCases $jdkVersions {
+    It "Java <Version>" -TestCases $testCases {
         $javaVariableValue = Get-EnvironmentVariable "JAVA_HOME_${Version}_X64"
         $javaVariableValue | Should -Not -BeNullOrEmpty
         $javaPath = Join-Path $javaVariableValue "bin\java"
 
         $result = Get-CommandResult "`"$javaPath`" -version"
-        $result.ExitCode | Should -Be 0
-
-        if ($Version -eq 8) {
-            $Version = "1.${Version}"
-        }
-        $outputPattern = "openjdk version `"${Version}"
-        $result.Output[0] | Should -Match $outputPattern
-    }
-
-    It "Java Adopt Jdk <Version>" -TestCases $adoptJdkVersions {
-        $adoptPath = Join-Path (Get-ChildItem ${env:AGENT_TOOLSDIRECTORY}\Java_Adopt_jdk\${Version}*) "x64\bin\java"
-
-        $result = Get-CommandResult "`"$adoptPath`" -version"
         $result.ExitCode | Should -Be 0
 
         if ($Version -eq 8) {

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -147,17 +147,7 @@
     ],
     "java": {
         "default": "8",
-        "default_vendor": "Temurin-Hotspot",
-        "vendors": [
-            {
-                "name": "Temurin-Hotspot",
-                "versions": [ "8", "11", "17" ]
-            },
-            {
-                "name": "Adopt",
-                "versions": [ "8", "11", "13" ]
-            }
-        ]
+        "versions": [ "8", "11", "17" ]
     },
     "android": {
         "platform_min_version": "19",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -128,17 +128,7 @@
     ],
     "java": {
         "default": "8",
-        "default_vendor": "Temurin-Hotspot",
-        "vendors": [
-            {
-                "name": "Temurin-Hotspot",
-                "versions": [ "8", "11", "17" ]
-            },
-            {
-                "name": "Adopt",
-                "versions": [ "8", "11"]
-            }
-        ]
+        "versions": [ "8", "11", "17" ]
     },
     "android": {
         "platform_min_version": "27",


### PR DESCRIPTION
# Description

Recently Adoptium team started brownouts for AdoptOpenJDK and it breaks image generation process. This PR remove AdoptOpenJDK references from images.

Request for mac OS: #8025
Request for Ubuntu: #8022

#### Related issue: #8030

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
