### PR TITLE
Add hyper-v-powershell cmdlets

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -176,7 +176,8 @@
         { "name": "Client-ProjFS", "optionalFeature": true },
         { "name": "NET-Framework-Features", "includeAllSubFeatures": true },
         { "name": "Hyper-V", "includeAllSubFeatures": true },
-        { "name": "HypervisorPlatform", "optionalFeature": true }
+        { "name": "HypervisorPlatform", "optionalFeature": true },
+        { "name": "Hyper-V-PowerShell" }
     ],
     "visualStudio": {
         "version" : "2022",


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

Since Hyper-v is enabled, we can install the powershell cmdlest as well to make it easier to use.

Fixes issues like `The term 'Get-VHD' is not recognized as the name of a cmdlet, function, script file, or operable program.`

Was able to do this manually during action step (Install-WindowsFeature -name Hyper-V-PowerShell) but thought it might be worth having oob.


<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
