### PR TITLE
[Ubuntu] Remove duplicated line with Python version from report

### DIFF
--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Common.psm1
@@ -99,12 +99,6 @@ function Get-PythonVersion {
     return $version
 }
 
-function Get-Python3Version {
-    $result = Get-CommandResult "python3 --version"
-    $version = $result.Output | Take-OutputPart -Part 1
-    return $version
-}
-
 function Get-PowershellVersion {
     return $(pwsh --version) | Take-OutputPart -Part 1
 }

--- a/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
+++ b/images/linux/scripts/SoftwareReport/SoftwareReport.Generator.ps1
@@ -54,7 +54,6 @@ $languageAndRuntime.AddToolVersion("MSBuild", $(Get-MsbuildVersion))
 $languageAndRuntime.AddToolVersion("Node.js", $(Get-NodeVersion))
 $languageAndRuntime.AddToolVersion("Perl", $(Get-PerlVersion))
 $languageAndRuntime.AddToolVersion("Python", $(Get-PythonVersion))
-$languageAndRuntime.AddToolVersion("Python3", $(Get-Python3Version))
 $languageAndRuntime.AddToolVersion("Ruby", $(Get-RubyVersion))
 $languageAndRuntime.AddToolVersion("Swift", $(Get-SwiftVersion))
 


### PR DESCRIPTION
# Description
As Python 2.7 has been removed from Ubuntu we don't require to separate items for Python version in software report. This PR removes one of that items.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
