### PR TITLE
[Windows] Update miniconda download link

### DIFF
--- a/images/win/scripts/Installers/Install-Miniconda.ps1
+++ b/images/win/scripts/Installers/Install-Miniconda.ps1
@@ -7,7 +7,7 @@ $CondaDestination = "C:\Miniconda"
 
 # Install the latest Miniconda
 $InstallerName = "Miniconda3-latest-Windows-x86_64.exe"
-$InstallerUrl = "https://repo.continuum.io/miniconda/${InstallerName}"
+$InstallerUrl = "https://repo.anaconda.com/miniconda/${InstallerName}"
 $ArgumentList = ("/S", "/AddToPath=0", "/RegisterPython=0", "/D=$CondaDestination")
 
 Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList


### PR DESCRIPTION
# Description

In 2018 repo.continuum.io was replaced with repo.anaconda.com (https://github.com/conda/conda/issues/6886). Recently old repo have been finally shut down and it causes image generation to fail. This updates repo URL in Miniconda installation script.

Related requests: [mac OS](https://github.com/actions/runner-images/pull/8042), [Ubuntu](https://github.com/actions/runner-images/pull/8043)

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
