### PR TITLE
[mac OS] Update miniconda download link

### DIFF
--- a/images/macos/provision/core/miniconda.sh
+++ b/images/macos/provision/core/miniconda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e -o pipefail
 
 MINICONDA_INSTALLER="/tmp/miniconda.sh"
-curl -fsSL https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o $MINICONDA_INSTALLER
+curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o $MINICONDA_INSTALLER
 chmod +x $MINICONDA_INSTALLER
 sudo $MINICONDA_INSTALLER -b -p /usr/local/miniconda
 


### PR DESCRIPTION
# Description

In 2018 repo.continuum.io was replaced with repo.anaconda.com (https://github.com/conda/conda/issues/6886). Recently old repo have been finally shut down and it causes image generation to fail. This updates repo URL in Miniconda installation script.

Related requests: [Ubuntu](https://github.com/actions/runner-images/pull/8043), [Windows](https://github.com/actions/runner-images/pull/8041)

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
