### PR TITLE
[Linux] Update miniconda download link

### DIFF
--- a/images/linux/scripts/installers/miniconda.sh
+++ b/images/linux/scripts/installers/miniconda.sh
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Install Miniconda
-curl -fsSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
+curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
     && chmod +x miniconda.sh \
     && ./miniconda.sh -b -p /usr/share/miniconda \
     && rm miniconda.sh


### PR DESCRIPTION
# Description

In 2018 repo.continuum.io was replaced with repo.anaconda.com (https://github.com/conda/conda/issues/6886). Recently old repo have been finally shut down and it causes image generation to fail. This updates repo URL in Miniconda installation script.

Related requests: [mac OS](https://github.com/actions/runner-images/pull/8042), [Windows](https://github.com/actions/runner-images/pull/8041)

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
