### PR TITLE
Fix issue where tags json is wrong in PS5

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -288,6 +288,12 @@ Function GenerateResourcesAndImage {
             }
         }
 
+        $TagsJson = $Tags | ConvertTo-Json -Compress
+        if ($PSVersionTable.PSVersion.Major -eq 5) {
+            Write-Verbose "PowerShell 5 detected. Replacing double quotes with escaped double quotes in tags JSON."
+            $TagsJson = $TagsJson -replace '"', '\"'
+        }
+
         & $packerBinary build -on-error="$($OnError)" `
             -var "client_id=$($spClientId)" `
             -var "client_secret=$($ServicePrincipalClientSecret)" `
@@ -298,7 +304,7 @@ Function GenerateResourcesAndImage {
             -var "storage_account=$($storageAccountName)" `
             -var "install_password=$($InstallPassword)" `
             -var "allowed_inbound_ip_addresses=$($AgentIp)" `
-            -var "azure_tags=$($Tags | ConvertTo-Json -Compress)" `
+            -var "azure_tags=$($TagsJson)" `
             $builderScriptPath
     }
     catch {


### PR DESCRIPTION
# Description
Extra escaping is required for quotes in PS5 when passing arguments to external commands.\

#### Related issue: #7939

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
