### PR TITLE
use "license accept timeout" only on MacOS-13

### DIFF
--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -126,10 +126,17 @@ function Approve-XcodeLicense {
         [string]$Version
     )
 
+    $os = Get-OSVersion
+
     $XcodeRootPath = Get-XcodeRootPath -Version $Version
     Write-Host "Approving Xcode license for '$XcodeRootPath'..."
     $xcodeBuildPath = Get-XcodeToolPath -XcodeRootPath $XcodeRootPath -ToolName "xcodebuild"
-    Invoke-ValidateCommand -Command "sudo $xcodeBuildPath -license accept" -Timeout 15
+
+    if ($os.IsVentura -or $os.IsVenturaArm64) {
+        Invoke-ValidateCommand -Command "sudo $xcodeBuildPath -license accept" -Timeout 15
+    } else {
+        Invoke-ValidateCommand -Command "sudo $xcodeBuildPath -license accept"
+    }
 }
 
 function Install-XcodeAdditionalPackages {


### PR DESCRIPTION
# Description

XCode license acceptance: limit execution timeouts just for macos-13

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5319

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
