### PR TITLE
[ubuntu] Adjust kubectl version handling

### DIFF
--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -284,7 +284,7 @@ Describe "Kubernetes tools" {
     }
 
     It "kubectl" {
-        "kubectl version" | Should -MatchCommandOutput "Client Version: version.Info"
+        "kubectl version" | Should -MatchCommandOutput "Client Version: v"
     }
 
     It "helm" {


### PR DESCRIPTION
# Description
`kubectl` was updated to 1.28 and version output has been changed.
Adjust version handling in Pester test

#### Related issue: #8094

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
