### PR TITLE
[Windows] Remove deprecated kubectl flag

### DIFF
--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -95,7 +95,7 @@ Describe "KubernetesTools" {
     }
 
     It "kubectl" {
-        "kubectl version --client=true --short=true" | Should -ReturnZeroExitCode
+        "kubectl version --client=true" | Should -ReturnZeroExitCode
     }
 
     It "Helm" {


### PR DESCRIPTION
# Description

Kubernetes v1.28 have been released recently.

It removes --short flag from `kubectl version` command so build will start failing as soon as choco package `kubernetes-cli` is updated to the latest version (that usually happens in a couple of days after official release). In order to prevent Windows image builds from failing, I request to remove this flag in Kubernetes Tools tests.

More information: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#deprecation

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
