### PR TITLE
[Windows] use VsixInstaller from the installer

### DIFF
--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -272,8 +272,6 @@ function Install-VsixExtension
         [Parameter(Mandatory = $true)]
         [string] $Name,
         [string] $FilePath,
-        [Parameter(Mandatory = $true)]
-        [string] $VSversion,
         [int] $Retries = 20,
         [switch] $InstallOnly
     )
@@ -288,20 +286,14 @@ function Install-VsixExtension
     do
     {
         Write-Host "Starting Install $Name..."
-        $vsEdition = (Get-ToolsetContent).visualStudio.edition
         try
         {
             $installPath = ${env:ProgramFiles(x86)}
 
-            if (Test-IsWin22)
-            {
-                $installPath = ${env:ProgramFiles}
-            }
-
-            #There are 2 types of packages at the moment - exe and vsix
+            # There are 2 types of packages at the moment - exe and vsix
             if ($Name -match "vsix")
             {
-                $process = Start-Process -FilePath "${installPath}\Microsoft Visual Studio\${VSversion}\${vsEdition}\Common7\IDE\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
+                $process = Start-Process -FilePath "${installPath}\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\VSIXInstaller.exe" -ArgumentList $argumentList -Wait -PassThru
             }
             else
             {
@@ -327,7 +319,8 @@ function Install-VsixExtension
             $Retries--
             if ($Retries -eq 0) {
                 Write-Host "The $Name couldn't be installed after 20 attempts."
-            }else {
+                exit 1
+            } else {
                 Write-Host "Waiting 10 seconds before retrying. Retries left: $Retries"
                 Start-Sleep -Seconds 10
             }

--- a/images/win/scripts/Installers/Install-Vsix.ps1
+++ b/images/win/scripts/Installers/Install-Vsix.ps1
@@ -10,12 +10,11 @@ if (-not $vsixPackagesList) {
     exit 0
 }
 
-$vsVersion = $toolset.visualStudio.Version
 $vsixPackagesList | ForEach-Object {
     # Retrieve cdn endpoint to avoid HTTP error 429 https://github.com/actions/runner-images/issues/3074
     $vsixPackage = Get-VsixExtenstionFromMarketplace -ExtensionMarketPlaceName $_
     if ($vsixPackage.FileName.EndsWith(".vsix")) {
-        Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -VSversion $vsVersion
+        Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName
     } else {
         $argumentList = ('/install', '/quiet', '/norestart')
         Install-Binary -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -ArgumentList $argumentList

--- a/images/win/scripts/Installers/Install-WDK.ps1
+++ b/images/win/scripts/Installers/Install-WDK.ps1
@@ -8,12 +8,10 @@ if (Test-IsWin22) {
     # SDK available through Visual Studio
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2196230"
     $FilePath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2022\*\WDK.vsix"
-    $VSver = "2022"
 } elseif (Test-IsWin19) {
     $winSdkUrl = "https://go.microsoft.com/fwlink/?linkid=2173743"
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2166289"
     $FilePath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"
-    $VSver = "2019"
 } else {
     throw "Invalid version of Visual Studio is found. Either 2019 or 2022 are required"
 }
@@ -30,6 +28,6 @@ Install-Binary -Url $wdkUrl -Name "wdksetup.exe" -ArgumentList $argumentList
 
 # Need to install the VSIX to get the build targets when running VSBuild
 $FilePath = Resolve-Path -Path $FilePath
-Install-VsixExtension -FilePath $FilePath -Name "WDK.vsix" -VSversion $VSver -InstallOnly
+Install-VsixExtension -FilePath $FilePath -Name "WDK.vsix" -InstallOnly
 
 Invoke-PesterTests -TestFile "WDK"


### PR DESCRIPTION
# Description tool, Bug fixing, or Improvement?

We shall attempt using VSIX installer from the VS installer and not the VS itself as recommended by the team. The installer from the VS references the installer from the VS installer in anyway.

#### Related issue: https://github.com/actions/runner-images/issues/8069

Closes: https://github.com/actions/runner-images/issues/8069

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
