### PR TITLE
[Ubuntu] do not source os-release during mysql installation

### DIFF
--- a/images/linux/scripts/installers/mysql.sh
+++ b/images/linux/scripts/installers/mysql.sh
@@ -4,7 +4,6 @@
 ##  Desc:  Installs MySQL Client
 ################################################################################
 
-source /etc/os-release
 source $HELPER_SCRIPTS/os.sh
 
 # Mysql setting up root password


### PR DESCRIPTION
Looks like we do not need it anymore
