### PR TITLE
[ubuntu20] Pin aliyun to 3.0.174

### DIFF
--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -5,10 +5,18 @@
 ################################################################################
 
 # Source the helpers for use with the script
+source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
 # Install Alibaba Cloud CLI
-downloadUrl="https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz"
+# Pin tool version on ubuntu20 due to issues with GLIBC_2.32 not available
+if isUbuntu20; then
+    toolsetVersion=$(get_toolset_value '.aliyunCli.version')
+    downloadUrl="https://github.com/aliyun/aliyun-cli/releases/download/v$toolsetVersion/aliyun-cli-linux-$toolsetVersion-amd64.tgz"
+else
+    downloadUrl="https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz"
+fi
+
 download_with_retries $downloadUrl "/tmp"
 tar xzf /tmp/aliyun-cli-linux-*-amd64.tgz
 mv aliyun /usr/local/bin

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -361,5 +361,8 @@
     },
     "pwsh": {
         "version": "7.2"
+    },
+    "aliyunCli": {
+        "version": "3.0.174"
     }
 }


### PR DESCRIPTION
# Description
With latest updates, `aliyun` is failing on `ubuntu20` with `GLIBC_2.32` and `GLIBC_2.34` issues.
Pinning version to `3.0.174`

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
