### PR TITLE
[linux] pin Hashicorp tools due to license change

### DIFF
--- a/images/linux/scripts/installers/packer.sh
+++ b/images/linux/scripts/installers/packer.sh
@@ -7,7 +7,9 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Install Packer
-URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/packer/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+# use 1.9.2 due to https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/packer/1.9.2 | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+
 ZIP_NAME="packer_linux_amd64.zip"
 download_with_retries "${URL}" "/tmp" "${ZIP_NAME}"
 unzip -qq "/tmp/${ZIP_NAME}" -d /usr/local/bin

--- a/images/linux/scripts/installers/terraform.sh
+++ b/images/linux/scripts/installers/terraform.sh
@@ -7,7 +7,8 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Install Terraform
-URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+# use 1.5.5 due to https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/1.5.5 | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
 ZIP_NAME="terraform_linux_amd64.zip"
 download_with_retries "${URL}" "/tmp" "${ZIP_NAME}"
 unzip -qq "/tmp/${ZIP_NAME}" -d /usr/local/bin


### PR DESCRIPTION
# Description

pin Hashicorp utilities due to [license change](https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license).

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5325

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
