### PR TITLE
[macos] pin Hashicorp tools due to license change

### DIFF
--- a/images/macos/provision/core/vagrant.sh
+++ b/images/macos/provision/core/vagrant.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e -o pipefail
+source ~/utils/utils.sh
+
+VAGRANT_VERSION="2.3.7"
+
+arch=$(get_arch)
+
+if [ $arch == "arm64" ]; then
+    VAGRANT_DOWNLOAD_URL="https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_darwin_arm64.dmg"
+else
+    VAGRANT_DOWNLOAD_URL="https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_darwin_amd64.dmg"
+fi
+
+
+echo "Installing Vagrant ${VAGRANT_VERSION}"
+TMPMOUNT=`/usr/bin/mktemp -d /tmp/vagrant.XXXX`
+TMPMOUNT_DOWNLOADS="$TMPMOUNT/downloads"
+mkdir $TMPMOUNT_DOWNLOADS
+
+download_with_retries $VAGRANT_DOWNLOAD_URL $TMPMOUNT_DOWNLOADS
+
+echo "Mounting Vagrant..."
+
+if [ $arch == "arm64" ]; then
+    hdiutil attach "${TMPMOUNT_DOWNLOADS}/vagrant_${VAGRANT_VERSION}_darwin_arm64.dmg" -mountpoint "$TMPMOUNT"
+else
+    hdiutil attach "${TMPMOUNT_DOWNLOADS}/vagrant_${VAGRANT_VERSION}_darwin_amd64.dmg" -mountpoint "$TMPMOUNT"
+fi
+
+
+
+echo "Moving Vagrant to /..."
+sudo installer -pkg "${TMPMOUNT}/vagrant.pkg" -target /
+
+sudo hdiutil detach "$TMPMOUNT"
+sudo rm -rf "$TMPMOUNT"

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -212,6 +212,7 @@ build {
       "./provision/core/android-toolsets.sh",
       "./provision/core/xamarin.sh",
       "./provision/core/vsmac.sh",
+      "./provision/core/vagrant.sh",
       "./provision/core/nvm.sh",
       "./provision/core/apache.sh",
       "./provision/core/nginx.sh",

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -175,6 +175,7 @@ build {
       "./provision/core/git.sh",
       "./provision/core/mongodb.sh",
       "./provision/core/node.sh",
+      "./provision/core/vagrant.sh",
       "./provision/core/commonutils.sh"
     ]
     environment_vars = [
@@ -212,7 +213,6 @@ build {
       "./provision/core/android-toolsets.sh",
       "./provision/core/xamarin.sh",
       "./provision/core/vsmac.sh",
-      "./provision/core/vagrant.sh",
       "./provision/core/nvm.sh",
       "./provision/core/apache.sh",
       "./provision/core/nginx.sh",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -159,6 +159,7 @@
                 "./provision/core/git.sh",
                 "./provision/core/mongodb.sh",
                 "./provision/core/node.sh",
+                "./provision/core/vagrant.sh",
                 "./provision/core/commonutils.sh"
             ],
             "environment_vars": [
@@ -199,7 +200,6 @@
                 "./provision/core/android-toolsets.sh",
                 "./provision/core/xamarin.sh",
                 "./provision/core/vsmac.sh",
-                "./provision/core/vagrant.sh",
                 "./provision/core/nvm.sh",
                 "./provision/core/apache.sh",
                 "./provision/core/nginx.sh",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -199,6 +199,7 @@
                 "./provision/core/android-toolsets.sh",
                 "./provision/core/xamarin.sh",
                 "./provision/core/vsmac.sh",
+                "./provision/core/vagrant.sh",
                 "./provision/core/nvm.sh",
                 "./provision/core/apache.sh",
                 "./provision/core/nginx.sh",

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -170,6 +170,7 @@ build {
       "./provision/core/rubygem.sh",
       "./provision/core/git.sh",
       "./provision/core/node.sh",
+      "./provision/core/vagrant.sh",
       "./provision/core/commonutils.sh"
     ]
     environment_vars = [
@@ -205,7 +206,6 @@ build {
       "./provision/core/cocoapods.sh",
       "./provision/core/android-toolsets.sh",
       "./provision/core/vsmac.sh",
-      "./provision/core/vagrant.sh",
       "./provision/core/apache.sh",
       "./provision/core/vcpkg.sh",
       "./provision/core/safari.sh",

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -205,6 +205,7 @@ build {
       "./provision/core/cocoapods.sh",
       "./provision/core/android-toolsets.sh",
       "./provision/core/vsmac.sh",
+      "./provision/core/vagrant.sh",
       "./provision/core/apache.sh",
       "./provision/core/vcpkg.sh",
       "./provision/core/safari.sh",

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -169,6 +169,7 @@ build {
       "./provision/core/rubygem.sh",
       "./provision/core/git.sh",
       "./provision/core/node.sh",
+      "./provision/core/vagrant.sh",
       "./provision/core/commonutils.sh"
     ]
     environment_vars = [
@@ -197,7 +198,6 @@ build {
       "./provision/core/gcc.sh",
       "./provision/core/cocoapods.sh",
       "./provision/core/vsmac.sh",
-      "./provision/core/vagrant.sh",
       "./provision/core/safari.sh",
       "./provision/core/bicep.sh",
       "./provision/core/codeql-bundle.sh"

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -197,6 +197,7 @@ build {
       "./provision/core/gcc.sh",
       "./provision/core/cocoapods.sh",
       "./provision/core/vsmac.sh",
+      "./provision/core/vagrant.sh",
       "./provision/core/safari.sh",
       "./provision/core/bicep.sh",
       "./provision/core/codeql-bundle.sh"

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -207,7 +207,6 @@
         ],
         "cask_packages": [
             "julia",
-            "vagrant",
             "virtualbox",
             "parallels"
         ]

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -78,8 +78,7 @@
             "unxip"
         ],
         "cask_packages": [
-            "julia",
-            "vagrant"
+            "julia"
         ]
     },
     "gcc": {


### PR DESCRIPTION
more details: https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license

# Description

pin Hashicorp utilities due to [license change](https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license).

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5325

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
