### PR TITLE
[Ubuntu] Make k8s tools tests consistent across OS

### DIFF
--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -280,19 +280,19 @@ Describe "Julia" {
 
 Describe "Kubernetes tools" {
     It "kind" {
-        "kind --version" | Should -ReturnZeroExitCode
+        "kind version" | Should -ReturnZeroExitCode
     }
 
     It "kubectl" {
-        "kubectl version" | Should -MatchCommandOutput "Client Version: v"
+        "kubectl version --client=true" | Should -MatchCommandOutput "Client Version: v"
     }
 
     It "helm" {
-        "helm version" | Should -ReturnZeroExitCode
+        "helm version --short" | Should -ReturnZeroExitCode
     }
 
     It "minikube" {
-        "minikube version" | Should -ReturnZeroExitCode
+        "minikube version --short" | Should -ReturnZeroExitCode
     }
 
     It "kustomize" {


### PR DESCRIPTION
# Description
Currently commands to test k8s tools in Ubuntu image differ from the same commands in mac OS and Windows. This PR updates tests for Ubuntu to make them work the same way as in other operation systems.

#### Related issue: -
#### Inspired by #8106

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
