### PR TITLE
[macOS] Remove sensitive data from a download log

### DIFF
--- a/images/macos/provision/bootstrap-provisioner/installNewProvisioner.sh
+++ b/images/macos/provision/bootstrap-provisioner/installNewProvisioner.sh
@@ -40,6 +40,8 @@ aria2c \
 # Remove sensitive data from logs
 sed -i '' 's/'${ProvisionerPackageUri}'/ProvisionerPackageUri/' ${BOOTSTRAP_PATH}/download.log
 sed -i '' 's/'${ProvisionerScriptUri}'/ProvisionerScriptUri/' ${BOOTSTRAP_PATH}/download.log
+sed -i '' 's/&sr=b&sig=//' ${BOOTSTRAP_PATH}/download.log
+sed -i '' 's/&se=2023-0//' ${BOOTSTRAP_PATH}/download.log
 
 chmod +x ${BOOTSTRAP_PATH}/${ScriptName}
 


### PR DESCRIPTION
# Description

During the process of downloading the provisioner installer, potentially vulnerable data got into the log. There won't be any more.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
