### PR TITLE
[macos] move license accept out of parallel ForEach

### DIFF
--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -22,6 +22,9 @@ $xcodeVersions | ForEach-Object -ThrottleLimit $threadCount -Parallel {
 
     Install-XcodeVersion -Version $_.version -LinkTo $_.link
     Confirm-XcodeIntegrity -Version $_.link
+}
+
+$xcodeVersions | ForEach-Object {
     Approve-XcodeLicense -Version $_.link
 }
 


### PR DESCRIPTION
# Description

yet another attempt to improve XCode installation robustness

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5339

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
