### PR TITLE
Revert "[macOS] Remove sensitive data from a download log"

### DIFF
--- a/images/macos/provision/bootstrap-provisioner/installNewProvisioner.sh
+++ b/images/macos/provision/bootstrap-provisioner/installNewProvisioner.sh
@@ -37,10 +37,6 @@ aria2c \
   --file-allocation=none \
   -d ${BOOTSTRAP_PATH} "${ProvisionerScriptUri}" >> ${BOOTSTRAP_PATH}/download.log
 
-# Remove sensitive data from logs
-sed -i '' 's/'${ProvisionerPackageUri}'/ProvisionerPackageUri/' ${BOOTSTRAP_PATH}/download.log
-sed -i '' 's/'${ProvisionerScriptUri}'/ProvisionerScriptUri/' ${BOOTSTRAP_PATH}/download.log
-
 chmod +x ${BOOTSTRAP_PATH}/${ScriptName}
 
 # Install Provisioner with provided scripts


### PR DESCRIPTION
Reverts actions/runner-images#7934 due to https://github.com/github/maccloud/issues/2615#issuecomment-1683933670