### PR TITLE
[macos] use mist-cli for downloading OS distribution when generating anka clean vm

### DIFF
--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -180,7 +180,7 @@ Remove-AnkaVM -VMName $TemplateName
 
 Write-Host "`t[*] Creating Anka VM template with name '$TemplateName' and '$TemplateUsername' user"
 Write-Host "`t[*] CPU Count: $CPUCount, RamSize: ${RamSizeGb}G, DiskSizeGb: ${DiskSizeGb}G, InstallerPath: $macOSInstaller, TemplateName: $TemplateName"
-New-AnkaVMTemplate -InstallerPath $macOSInstaller `
+New-AnkaVMTemplate -InstallerPath "$macOSInstaller" `
                    -TemplateName $TemplateName `
                    -TemplateUsername $TemplateUsername `
                    -TemplatePassword $TemplatePassword `


### PR DESCRIPTION
# Description

/usr/sbin/softwareupdate appears not very stable last time. let's try mist-cli 

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5340

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
