### PR TITLE
report Tool nodes with null or empty versions

### DIFF
--- a/helpers/software-report-base/SoftwareReport.Nodes.psm1
+++ b/helpers/software-report-base/SoftwareReport.Nodes.psm1
@@ -161,6 +161,11 @@ class ToolVersionNode: BaseToolNode {
     [String] $Version
 
     ToolVersionNode([String] $ToolName, [String] $Version): base($ToolName) {
+
+        if ([String]::IsNullOrEmpty($Version)) {
+            throw "ToolVersionNode '$($this.ToolName)' has empty version"
+        }
+
         $this.Version = $Version
     }
 
@@ -196,6 +201,11 @@ class ToolVersionsListNode: BaseToolNode {
 
     ToolVersionsListNode([String] $ToolName, [String[]] $Versions, [String] $MajorVersionRegex, [String] $ListType): base($ToolName) {
         $this.Versions = $Versions
+
+         if ([String]::IsNullOrEmpty($Versions)) {
+            throw "ToolVersionsListNode '$($this.ToolName)' has empty versions list"
+        }
+
         $this.MajorVersionRegex = [Regex]::new($MajorVersionRegex)
         $this.ListType = $ListType
         $this.ValidateMajorVersionRegex()

--- a/helpers/software-report-base/tests/SoftwareReport.Nodes.Unit.Tests.ps1
+++ b/helpers/software-report-base/tests/SoftwareReport.Nodes.Unit.Tests.ps1
@@ -26,7 +26,7 @@ Describe "Nodes.UnitTests" {
 
         It "Deserialization" {
             { [ToolVersionNode]::FromJsonObject(@{ NodeType = "ToolVersionNode"; ToolName = ""; Version = "2.1.3" }) } | Should -Throw '*Exception setting "ToolName": "The argument is null or empty.*'
-            { [ToolVersionNode]::FromJsonObject(@{ NodeType = "ToolVersionNode"; ToolName = "MyTool"; Version = "" }) } | Should -Throw '*Exception setting "Version": "The argument is null or empty.*'
+            { [ToolVersionNode]::FromJsonObject(@{ NodeType = "ToolVersionNode"; ToolName = "MyTool"; Version = "" }) } | Should -Throw 'ToolVersionNode ''MyTool'' has empty version'
             { [ToolVersionNode]::FromJsonObject(@{ NodeType = "ToolVersionNode"; ToolName = "MyTool"; Version = "2.1.3" }) } | Should -Not -Throw
         }
 


### PR DESCRIPTION
# Description

We should report broken nodes to reduce the debug time

#### Related issue: https://github.com/actions/runner-images-internal/issues/4782

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
