### PR TITLE
[macos] check exit code in Invoke-SSHPassCommand

### DIFF
--- a/images.CI/macos/anka/Anka.Helpers.psm1
+++ b/images.CI/macos/anka/Anka.Helpers.psm1
@@ -67,7 +67,7 @@ function Invoke-AnkaCommand {
         [string] $Command
     )
 
-    $result = bash -c "$Command 2>&1" | Out-String
+    $result = bash -c "$Command 2>&1"
     if ($LASTEXITCODE -ne 0) {
         Write-Error "There is an error during command execution:`n$result"
         exit 1

--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -45,6 +45,8 @@ function Invoke-EnableAutoLogon {
 
     $ipAddress = Get-AnkaVMIPAddress -VMName $TemplateName
 
+    Wait-AnkaVMSSHService -VMName $TemplateName -Seconds 30
+
     Write-Host "`t[*] Enable AutoLogon"
     Enable-AutoLogon -HostName $ipAddress -UserName $TemplateUsername -Password $TemplatePassword
 

--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -292,7 +292,12 @@ function Invoke-SSHPassCommand {
         "${env:SSHUSER}@${HostName}"
     )
     $sshPassOptions = $sshArg -join " "
-    bash -c "$sshPassOptions \""$Command\"" 2>&1"
+    $result = bash -c "$sshPassOptions \""$Command\"" 2>&1"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "There is an error during command execution:`n$result"
+        exit 1
+    }
+    $result
 }
 
 function Invoke-WithRetry {
@@ -330,7 +335,10 @@ function Restart-VMSSH {
         [string] $HostName
     )
 
-    $command = "sudo reboot"
+    #
+    # https://unix.stackexchange.com/questions/58271/closing-connection-after-executing-reboot-using-ssh-command
+    #
+    $command = '(sleep 1 && sudo reboot &) && exit'
     Invoke-SSHPassCommand -HostName $HostName -Command $command
 }
 


### PR DESCRIPTION
# Description

check external command status in Invoke-SSHPassCommand (used for anka pipelines)

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5356

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
