### PR TITLE
[macOS] remove Xcode 14.3, default to 14.3.1

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -1,11 +1,10 @@
 {
     "xcode": {
-        "default": "14.2",
+        "default": "14.3.1",
         "x64": {
             "versions": [
                 { "link": "15.0", "version": "15.0.0-Beta.7+15A5229h" },
-                { "link": "14.3.1", "version": "14.3.1+14E300c" },
-                { "link": "14.3", "version": "14.3.0+14E222b" },
+                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },
                 { "link": "14.1", "version": "14.1.0+14B47b" }
                 ]
@@ -13,8 +12,7 @@
         "arm64":{
             "versions": [
                 { "link": "15.0", "version": "15.0.0-Beta.7+15A5229h" },
-                { "link": "14.3.1", "version": "14.3.1+14E300c" },
-                { "link": "14.3", "version": "14.3.0+14E222b" },
+                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },
                 { "link": "14.1", "version": "14.1.0+14B47b" }
             ]


### PR DESCRIPTION
# Description

make 14.3.1 default, remove Xcode 14.3

#### Related issue: n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
