### PR TITLE
[macOS] do not iterate over npm packages on Ventura

### DIFF
--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -10,7 +10,7 @@ brew link node@$defaultVersion --force --overwrite
 echo Installing yarn...
 curl -fsSL https://yarnpkg.com/install.sh | bash
 
-if ! is_Ventura; then
+if ! is_Ventura || ! is_VenturaArm64; then
   npm_global_packages=$(get_toolset_value '.npm.global_packages[].name')
   for module in ${npm_global_packages[@]}; do
     echo "Install $module"

--- a/images/macos/provision/core/node.sh
+++ b/images/macos/provision/core/node.sh
@@ -10,10 +10,12 @@ brew link node@$defaultVersion --force --overwrite
 echo Installing yarn...
 curl -fsSL https://yarnpkg.com/install.sh | bash
 
-npm_global_packages=$(get_toolset_value '.npm.global_packages[].name')
-for module in ${npm_global_packages[@]}; do
-  echo "Install $module"
-  npm install -g $module
+if ! is_Ventura; then
+  npm_global_packages=$(get_toolset_value '.npm.global_packages[].name')
+  for module in ${npm_global_packages[@]}; do
+    echo "Install $module"
+    npm install -g $module
 done
+fi
 
 invoke_tests "Node" "Node.js"


### PR DESCRIPTION
# Description

We do not install any npm packages from within toolset on OS13 (yet)

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
