### PR TITLE
[Ubuntu] Add pigz utility

### DIFF
--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -202,6 +202,7 @@
             "parallel",
             "pass",
             "patchelf",
+            "pigz",
             "pollinate",
             "rsync",
             "shellcheck",

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -192,6 +192,7 @@
             "parallel",
             "pass",
             "patchelf",
+            "pigz",
             "pollinate",
             "rsync",
             "shellcheck",


### PR DESCRIPTION
# Description
Pigz is a parallel implementation of gzip for modern multi-processor and multi-core machines. Previously we had this utility on runners as a dependency for docker, but now we don't. This PR adds `pigz` to the list of packages to install.

#### Related issue: #8205

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
