### PR TITLE
[macos] macos 13: retire VS Mac

### DIFF
--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -204,7 +204,6 @@ build {
       "./provision/core/stack.sh",
       "./provision/core/cocoapods.sh",
       "./provision/core/android-toolsets.sh",
-      "./provision/core/vsmac.sh",
       "./provision/core/apache.sh",
       "./provision/core/vcpkg.sh",
       "./provision/core/safari.sh",

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -196,7 +196,6 @@ build {
       "./provision/core/rust.sh",
       "./provision/core/gcc.sh",
       "./provision/core/cocoapods.sh",
-      "./provision/core/vsmac.sh",
       "./provision/core/safari.sh",
       "./provision/core/bicep.sh",
       "./provision/core/codeql-bundle.sh"

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -18,12 +18,6 @@
             ]
         }
     },
-    "xamarin": {
-        "vsmac": {
-            "default": "2022",
-            "versions": [ "2022" ]
-        }
-    },
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17" ]


### PR DESCRIPTION
# Description

macos-13: retirement of VS for Mac

#### Related issue:

https://github.com/actions/runner-images/discussions/8212

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
