### PR TITLE
macos: drop Hardware_Accelerated_Execution_Manager

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -93,11 +93,6 @@ do
     echo y | $SDKMANAGER "extras;$extra_name"
 done
 
-# Intel x86 Emulator Accelerator (HAXM installer)
-# The Android Emulator uses the built-in Hypervisor.Framework by default, and falls back to using Intel HAXM if Hypervisor.Framework fails to initialize
-# https://developer.android.com/studio/run/emulator-acceleration#vm-mac
-# The installation doesn't work properly on macOS Big Sur, /dev/HAX is not created
-
 for addon_name in "${ANDROID_ADDON_LIST[@]}"
 do
     echo "Installing add-on $addon_name ..."

--- a/images/macos/software-report/SoftwareReport.Android.psm1
+++ b/images/macos/software-report/SoftwareReport.Android.psm1
@@ -199,11 +199,3 @@ function Get-AndroidNDKVersions {
         $_ + $defaultPostfix
     } | Join-String -Separator "<br>")
 }
-
-function Get-IntelHaxmVersion {
-    kextstat | Where-Object { $_ -match "com.intel.kext.intelhaxm \((?<version>(\d+\.){1,}\d+)\)" } | Out-Null
-    return [PSCustomObject] @{
-        "Package Name" = "Intel HAXM"
-        "Version" = $Matches.Version
-    }
-}

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -160,7 +160,7 @@
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [
-            "android;m2repository", "google;m2repository", "google;google_play_services", "intel;Hardware_Accelerated_Execution_Manager"
+            "android;m2repository", "google;m2repository", "google;google_play_services"
         ],
         "addon-list": [],
         "additional-tools": [

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -147,7 +147,7 @@
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [
-            "android;m2repository", "google;m2repository", "google;google_play_services", "intel;Hardware_Accelerated_Execution_Manager"
+            "android;m2repository", "google;m2repository", "google;google_play_services"
         ],
         "addon-list": [],
         "additional-tools": [

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -32,7 +32,7 @@
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [
-            "android;m2repository", "google;m2repository", "google;google_play_services", "intel;Hardware_Accelerated_Execution_Manager"
+            "android;m2repository", "google;m2repository", "google;google_play_services"
         ],
         "addon-list": [],
         "additional-tools": [


### PR DESCRIPTION
# Description

drop deprecated Hardware_Accelerated_Execution_Manager

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5373

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
