### PR TITLE
[windows] introduce user warmup

### DIFF
--- a/images/win/scripts/Installers/Warmup-User.ps1
+++ b/images/win/scripts/Installers/Warmup-User.ps1
@@ -1,0 +1,25 @@
+################################################################################
+##  File:  Warmup-User.ps1
+##  Desc:  Performs user part of warm up and moves data to C:\Users\Default
+################################################################################
+
+#
+# more: https://github.com/actions/runner-images-internal/issues/5320
+#       https://github.com/actions/runner-images/issues/5301#issuecomment-1648292990
+#
+
+Write-Host "Warmup 'devenv.exe /updateconfiguration'"
+
+$vsInstallRoot = (Get-VisualStudioInstance).InstallationPath
+$devEnvPath = "$vsInstallRoot\Common7\IDE\devenv.exe"
+
+cmd.exe /c "`"$devEnvPath`" /updateconfiguration"
+
+Copy-Item ${env:USERPROFILE}\AppData\Local\Microsoft\VisualStudio -Destination c:\users\default\AppData\Local\Microsoft\VisualStudio -Recurse
+
+reg.exe load HKLM\DEFAULT c:\users\default\ntuser.dat
+reg.exe copy HKCU\Software\Microsoft\VisualStudio HKLM\DEFAULT\Software\Microsoft\VisualStudio /s
+reg.exe unload HKLM\DEFAULT
+
+
+Write-Host "Warmup-User.ps1 - completed"

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -339,7 +339,8 @@
             "skip_clean": true,
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Run-NGen.ps1",
-                "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1"
+                "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1",
+                "{{ template_dir }}/scripts/Installers/Warmup-User.ps1"
             ],
             "environment_vars": [
                 "INSTALL_USER={{user `install_user`}}"

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -326,7 +326,8 @@
             "skip_clean": true,
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Run-NGen.ps1",
-                "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1"
+                "{{ template_dir }}/scripts/Installers/Finalize-VM.ps1",
+                "{{ template_dir }}/scripts/Installers/Warmup-User.ps1"
             ],
             "environment_vars": [
                 "INSTALL_USER={{user `install_user`}}"


### PR DESCRIPTION
# Description

some heavy computations/preparation is done in user profile. since we delete user after image generation, we can move warmed up parts to C:\Users\Default

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5320

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
