### PR TITLE
[macos] disable VS Tests on macos-13

### DIFF
--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -78,7 +78,7 @@ Describe "CocoaPods" {
     }
 }
 
-Describe "VSMac" {
+Describe "VSMac" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
     $vsMacVersions = Get-ToolsetValue "xamarin.vsmac.versions"
     $defaultVSMacVersion = Get-ToolsetValue "xamarin.vsmac.default"
 


### PR DESCRIPTION
# Description

skip VS Tests for macos-13

#### Related issue:

https://github.com/actions/runner-images/discussions/8212

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
