### PR TITLE
[macOS 13] cleanup yarn cache

### DIFF
--- a/images/macos/provision/configuration/finalize-vm.sh
+++ b/images/macos/provision/configuration/finalize-vm.sh
@@ -28,9 +28,8 @@ rm -rf ~/.fastlane
 npm cache clean --force
 
 # Clean yarn cache
-if ! is_Ventura; then
-    yarn cache clean
-fi
+yarn cache clean
+
 # Clean up temporary directories
 sudo rm -rf ~/utils /tmp/*
 


### PR DESCRIPTION
# Description

As yarn is available on OS13 images now, we must cleanup its cache as well.

#### Related issue: - 

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
