### PR TITLE
Fix CI for runners with PowerShell 7

### DIFF
--- a/images.CI/linux-and-win/convert-to-vhd.ps1
+++ b/images.CI/linux-and-win/convert-to-vhd.ps1
@@ -95,8 +95,12 @@ $targetKey = az storage account keys list `
 Write-Host ("Copying VHD blob from '{0}' to 'https://{1}.blob.core.windows.net/{2}/{3}'..." `
     -f $sourceDiskUri.Split('?')[0], $StorageAccountName, $StorageAccountContainerName, $VhdName)
 
+if ($env:OS) {
+  $sourceDiskUri = """{0}""" -f $sourceDiskUri
+}
+
 az storage blob copy start `
-  --source-uri """$sourceDiskUri""" `
+  --source-uri $sourceDiskUri `
   --destination-blob $VhdName `
   --destination-container $StorageAccountContainerName `
   --account-name $StorageAccountName `


### PR DESCRIPTION
# Description
Due to migration, we have found that currently used agents handle AZ CLI commands differently. 
This change mitigates it.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/5385

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
