### PR TITLE
[macos] introduce additional runtimes for XCode

### DIFF
--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -176,7 +176,7 @@ function Install-AdditionalSimulatorRuntimes {
 
     Write-Host "Installing Simulator Runtimes for Xcode $Version ..."
     $xcodebuildPath = Get-XcodeToolPath -Version $Version -ToolName "xcodebuild"
-    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms | xcpretty"
+    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms"
 }
 
 function Build-XcodeSymlinks {

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -38,6 +38,12 @@ $xcodeVersions | ForEach-Object {
         Install-AdditionalSimulatorRuntimes -Version $_.link
     }
 
+    ForEach($runtime in $_.runtimes) {
+        Write-Host "Installing Additional runtimes for Xcode '$runtime' ..."
+        $xcodebuildPath = Get-XcodeToolPath -Version $_.link -ToolName 'xcodebuild'
+        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $runtime"
+    }
+
 }
 
 Invoke-XcodeRunFirstLaunch -Version $defaultXcode

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,7 +3,7 @@
         "default": "14.3.1",
         "x64": {
             "versions": [
-                { "link": "15.0", "version": "15.0.0-Beta.8+15A5229m" },
+                { "link": "15.0", "version": "15.0.0-Beta.8+15A5229m", "runtimes": [ "visionOS" ] },
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },
                 { "link": "14.1", "version": "14.1.0+14B47b" }
@@ -11,7 +11,7 @@
         },
         "arm64":{
             "versions": [
-                { "link": "15.0", "version": "15.0.0-Beta.8+15A5229m" },
+                { "link": "15.0", "version": "15.0.0-Beta.8+15A5229m", "runtimes": [ "visionOS" ] },
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },
                 { "link": "14.1", "version": "14.1.0+14B47b" }


### PR DESCRIPTION
# Description

add visionOS runtime

#### Related issue:

https://github.com/actions/runner-images/issues/8144

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
