### PR TITLE
[windows] switch to Powershell Gallery when preparing Azure modules

### DIFF
--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -96,7 +96,6 @@
     "azureModules": [
         {
             "name": "azurerm",
-            "blob_url": "https://vstsagenttools.blob.core.windows.net/tools/azurepowershellmodules/",
             "versions": [
                 "2.1.0",
                 "6.13.1"
@@ -111,7 +110,6 @@
         },
         {
             "name": "azure",
-            "blob_url": "https://vstsagenttools.blob.core.windows.net/tools/azurepowershellmodules/",
             "versions": [
                 "2.1.0",
                 "5.3.0"
@@ -125,7 +123,6 @@
         },
         {
             "name": "az",
-            "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
                 "9.3.0"
             ],

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -90,7 +90,6 @@
     "azureModules": [
         {
             "name": "azurerm",
-            "blob_url": "https://vstsagenttools.blob.core.windows.net/tools/azurepowershellmodules/",
             "versions": [
                 "2.1.0",
                 "6.13.1"
@@ -105,7 +104,6 @@
         },
         {
             "name": "azure",
-            "blob_url": "https://vstsagenttools.blob.core.windows.net/tools/azurepowershellmodules/",
             "versions": [
                 "2.1.0",
                 "5.3.0"
@@ -119,7 +117,6 @@
         },
         {
             "name": "az",
-            "url" : "https://raw.githubusercontent.com/Azure/az-ps-module-versions/main/versions-manifest.json",
             "versions": [
                 "9.3.0"
             ],


### PR DESCRIPTION
# Description

for custom PowerShell modules kept in C:\Modules (required by some ADO tasks) unify installation method - use Powershell Gallery for all cases. Powershell Gallery is trusted source, integrity is checked during installation

#### Related issue:

https://github.com/github/c2c-actions-akvelon/issues/38

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
