### PR TITLE
[macos] Add exclusion for macOS 13 to the Xamarin test

### DIFF
--- a/images/macos/tests/Xamarin.Tests.ps1
+++ b/images/macos/tests/Xamarin.Tests.ps1
@@ -2,10 +2,11 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
-$MONO_VERSIONS = Get-ToolsetValue "xamarin.mono-versions"
-$XAMARIN_IOS_VERSIONS = Get-ToolsetValue "xamarin.ios-versions"
-$XAMARIN_MAC_VERSIONS = Get-ToolsetValue "xamarin.mac-versions"
-$XAMARIN_ANDROID_VERSIONS = Get-ToolsetValue "xamarin.android-versions"
+if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
+    $MONO_VERSIONS = Get-ToolsetValue "xamarin.mono-versions"
+    $XAMARIN_IOS_VERSIONS = Get-ToolsetValue "xamarin.ios-versions"
+    $XAMARIN_MAC_VERSIONS = Get-ToolsetValue "xamarin.mac-versions"
+    $XAMARIN_ANDROID_VERSIONS = Get-ToolsetValue "xamarin.android-versions"
 
 BeforeAll {
     function Get-ShortSymlink {
@@ -297,4 +298,6 @@ Describe "Nuget" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
     It "Nuget config contains nuget.org feed" {
         Get-Content $env:HOME/.config/NuGet/NuGet.Config | Out-String | Should -Match "nuget.org"
     }
+}
+
 }


### PR DESCRIPTION
# Description
Add exclusion for macOS 13 to the Xamarin test

#### Related issue:
https://github.com/actions/runner-images-internal/issues/5401

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
