### PR TITLE
[macos] suppress xcodebuild output 

### DIFF
--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -176,7 +176,7 @@ function Install-AdditionalSimulatorRuntimes {
 
     Write-Host "Installing Simulator Runtimes for Xcode $Version ..."
     $xcodebuildPath = Get-XcodeToolPath -Version $Version -ToolName "xcodebuild"
-    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms" | Invoke-ValidateCommand 'xcpretty'
+    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms" | Out-Null
 }
 
 function Build-XcodeSymlinks {

--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -176,7 +176,7 @@ function Install-AdditionalSimulatorRuntimes {
 
     Write-Host "Installing Simulator Runtimes for Xcode $Version ..."
     $xcodebuildPath = Get-XcodeToolPath -Version $Version -ToolName "xcodebuild"
-    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms"
+    Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms" | Invoke-ValidateCommand 'xcpretty'
 }
 
 function Build-XcodeSymlinks {

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -41,7 +41,7 @@ $xcodeVersions | ForEach-Object {
     ForEach($runtime in $_.runtimes) {
         Write-Host "Installing Additional runtimes for Xcode '$runtime' ..."
         $xcodebuildPath = Get-XcodeToolPath -Version $_.link -ToolName 'xcodebuild'
-        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $runtime" | Invoke-ValidateCommand 'xcpretty'
+        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $runtime" | Out-Null
     }
 
 }

--- a/images/macos/provision/core/xcode.ps1
+++ b/images/macos/provision/core/xcode.ps1
@@ -41,7 +41,7 @@ $xcodeVersions | ForEach-Object {
     ForEach($runtime in $_.runtimes) {
         Write-Host "Installing Additional runtimes for Xcode '$runtime' ..."
         $xcodebuildPath = Get-XcodeToolPath -Version $_.link -ToolName 'xcodebuild'
-        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $runtime"
+        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $runtime" | Invoke-ValidateCommand 'xcpretty'
     }
 
 }


### PR DESCRIPTION
# Description

it is cleanup. idea of using "xcpretty" worked bad with pipefail on powershell.
while we are looking for better pipefail handling, let's temporarily suppress output

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
