### PR TITLE
[macos] remove vagrant from macos 13

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -142,11 +142,9 @@ if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
     $utilities.AddToolVersion("Subversion (SVN)", $(Get-SVNVersion))
     $utilities.AddToolVersion("Switchaudio-osx", $(Get-SwitchAudioOsxVersion))
 }
-if (-not $os.IsBigSur) {
+if ((-not $os.IsBigSur) -and (-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
     $utilities.AddToolVersion("Vagrant", $(Get-VagrantVersion))
-    if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
-        $utilities.AddToolVersion("VirtualBox", $(Get-VirtualBoxVersion))
-    }
+    $utilities.AddToolVersion("VirtualBox", $(Get-VirtualBoxVersion))
 }
 $utilities.AddToolVersion("yq", $(Get-YqVersion))
 $utilities.AddToolVersion("zstd", $(Get-ZstdVersion))

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -139,7 +139,7 @@ Describe "wget" {
     }
 }
 
-Describe "vagrant" -Skip:($os.IsBigSur) {
+Describe "vagrant" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsVenturaArm64) {
     It "vagrant" {
         "vagrant --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -70,8 +70,7 @@
             "unxip"
         ],
         "cask_packages": [
-            "julia",
-            "vagrant"
+            "julia"
         ]
     },
     "gcc": {


### PR DESCRIPTION
# Description
Remove Vagrant from macOS 13 due to no local "providers" being installed.
We do not install a "virtual box" on macOS 13.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/5401

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
