### PR TITLE
[windows] disabling windows defender scheduled task

### DIFF
--- a/images/win/scripts/Installers/Configure-Antivirus.ps1
+++ b/images/win/scripts/Installers/Configure-Antivirus.ps1
@@ -17,6 +17,7 @@ $avPreference = @(
     @{SubmitSamplesConsent = 2}
     @{ScanAvgCPULoadFactor = 5; ExclusionPath = @("D:\", "C:\")}
     @{DisableRealtimeMonitoring = $true}
+    @{ScanScheduleDay = 8}
 )
 
 $avPreference += @(
@@ -28,9 +29,6 @@ $avPreference | Foreach-Object {
     $avParams = $_
     Set-MpPreference @avParams
 }
-
-Write-Host "Disable Windows Defender scheduled tasks"
-Get-ScheduledTask -TaskPath '\Microsoft\Windows\Windows Defender\' | Disable-ScheduledTask | Out-Null
 
 # https://github.com/actions/runner-images/issues/4277
 # https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility?view=o365-worldwide


### PR DESCRIPTION
# Description

let's disable windows defender task by "Set-MpPreference -ScanScheduleDay 8" (otherwise defender creates deleted tasks)

#### Related issue:

https://github.com/actions/runner-images/issues/8164

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
