### PR TITLE
[Windows] Update version mingw to 12.2

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -151,7 +151,7 @@
         }
     },
     "mingw": {
-	"version": "11.2.0.07112021"
+	"version": "12.2.0.03042023"
     },
     "MsysPackages": {
         "msys2": [],


### PR DESCRIPTION
# Description
Updating version mingw from  to 12.2.0.03042023 to 11.2.0.07112021 for windows-22


<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
https://github.com/actions/runner-images/issues/8266

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
