### PR TITLE
[macos] Add Xcode15 RC1

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,7 +3,7 @@
         "default": "14.3.1",
         "x64": {
             "versions": [
-                { "link": "15.0", "version": "15.0.0-Beta.8+15A5229m", "runtimes": [ "visionOS" ] },
+                { "link": "15.0", "version": "15.0.0-Release.Candidate+15A240d"},
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },
                 { "link": "14.1", "version": "14.1.0+14B47b" }
@@ -11,7 +11,7 @@
         },
         "arm64":{
             "versions": [
-                { "link": "15.0", "version": "15.0.0-Beta.8+15A5229m", "runtimes": [ "visionOS" ] },
+                { "link": "15.0", "version": "15.0.0-Release.Candidate+15A240d"},
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },
                 { "link": "14.1", "version": "14.1.0+14B47b" }


### PR DESCRIPTION
# Description
1. Update XCode 15 to Release Candidate 1
2. Remove visionOS, no SDKs for RC1 and could not be installed with `xcodebuild`

#### Related issue: https://github.com/actions/runner-images/issues/8282

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
