### PR TITLE
Adjust MacOs13 arm64 base image generation script

### DIFF
--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -63,11 +63,11 @@ function Get-AvailableIPSWVersions {
     )
 
     if ($IsBeta) {
-        $command = { mist list installer "$MacOSCodeNameOrVersion" --include-betas --latest --export "/Applications/export.json"}
+        $command = { mist list firmware "$MacOSCodeNameOrVersion" --include-betas --latest --export "/Applications/export.json"}
     } elseif ($IsLatest) {
-        $command = { mist list installer "$MacOSCodeNameOrVersion" --latest  --export "/Applications/export.json" }
+        $command = { mist list firmware "$MacOSCodeNameOrVersion" --latest  --export "/Applications/export.json" }
     } else {
-        $command = { mist list installer "$MacOSCodeNameOrVersion"  --export "/Applications/export.json" }
+        $command = { mist list firmware "$MacOSCodeNameOrVersion"  --export "/Applications/export.json" }
     }
 
     $condition = { $LASTEXITCODE -eq 0 }
@@ -76,7 +76,7 @@ function Get-AvailableIPSWVersions {
     $turgetVersion = ($softwareList | ConvertFrom-Json).version
     if ($null -eq $turgetVersion) {
         Write-Host "Requested macOS '$MacOSCodeNameOrVersion' version not found in the list of available installers."
-        $command = { mist list installer "$($MacOSCodeNameOrVersion.split('.')[0])" }
+        $command = { mist list firmware "$($MacOSCodeNameOrVersion.split('.')[0])" }
         Invoke-WithRetry -Command $command -BreakCondition $condition
         exit 1
     }
@@ -133,6 +133,7 @@ function Get-MacOSIPSWInstaller {
     }
     return $result
 }
+
 function Get-MacOSInstaller {
     param (
         [Parameter(Mandatory)]


### PR DESCRIPTION
# Description
According to [mist-cli](https://github.com/ninxsoft/mist-cli#examples), `mist list firmware` should be used for Apple Silicon Macs. PR fixes cases when there are different arm and intel version available by mist.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
