### PR TITLE
add $PushToRegistry flag to control when to run anka registry push

### DIFF
--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -19,6 +19,7 @@ param(
     [string] $TemplateName,
 
     [bool] $DownloadLatestVersion = $true,
+    [bool] $PushToRegistry = $true,
     [bool] $BetaSearch = $false,
     [bool] $InstallSoftwareUpdate = $true,
     [bool] $EnableAutoLogon = $true,
@@ -204,6 +205,8 @@ Set-AnkaVMVideoController -VMName $TemplateName -ShortMacOSVersion $ShortMacOSVe
 Write-Host "`t[*] Setting screen resolution to $DisplayResolution for $TemplateName"
 Set-AnkaVMDisplayResolution -VMName $TemplateName -DisplayResolution $DisplayResolution
 
-# Push a VM template (and tag) to the Cloud
-Write-Host "`t[*] Pushing '$TemplateName' image with '$TagName' tag to the '$RegistryUrl' registry..."
-Push-AnkaTemplateToRegistry -RegistryUrl $registryUrl -TagName $TagName -TemplateName $TemplateName
+if ($PushToRegistry) {
+    # Push a VM template (and tag) to the Cloud
+    Write-Host "`t[*] Pushing '$TemplateName' image with '$TagName' tag to the '$RegistryUrl' registry..."
+    Push-AnkaTemplateToRegistry -RegistryUrl $registryUrl -TagName $TagName -TemplateName $TemplateName
+}


### PR DESCRIPTION
# Description
This is an enhancement to add a boolean flag that workflows can use to specify whether or not to push to the Anka registry after a clean image has been generated. This helps separate the build and push stages from each other for easier testing. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
