### PR TITLE
[macOS] pin openssl@1.1.1 in arm64 image

### DIFF
--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -165,6 +165,7 @@ build {
       "./provision/core/powershell.sh",
       "./provision/core/dotnet.sh",
       "./provision/core/azcopy.sh",
+      "./provision/core/openssl.sh",
       "./provision/core/ruby.sh",
       "./provision/core/rubygem.sh",
       "./provision/core/git.sh",


### PR DESCRIPTION
# Description

We need to pin version here as well to avoid backward compatibility issues

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
