### PR TITLE
[macOS] do not install intel related symlinks on arm64 openssl

### DIFF
--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -4,10 +4,13 @@ source ~/utils/utils.sh
 echo "Install openssl@1.1"
 brew_smart_install "openssl@1.1"
 
-# Symlink brew openssl@1.1 to `/usr/local/bin` as Homebrew refuses
-ln -sf $(brew --prefix openssl@1.1)/bin/openssl /usr/local/bin/openssl
+# Intel-related symlinks, not needed on arm64 for now
+if ! is_VenturaArm64; then
+  # Symlink brew openssl@1.1 to `/usr/local/bin` as Homebrew refuses
+  ln -sf $(brew --prefix openssl@1.1)/bin/openssl /usr/local/bin/openssl
 
-# Most of buildsystems and scripts look up ssl here
-ln -sf $(brew --cellar openssl@1.1)/1.1* /usr/local/opt/openssl
+  # Most of buildsystems and scripts look up ssl here
+  ln -sf $(brew --cellar openssl@1.1)/1.1* /usr/local/opt/openssl
+fi
 
 invoke_tests "OpenSSL"


### PR DESCRIPTION
# Description

These are for intel, could be ignored for M1 for now

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
