### PR TITLE
Fix typo in function name

### DIFF
--- a/images/win/scripts/ImageHelpers/ImageHelpers.psm1
+++ b/images/win/scripts/ImageHelpers/ImageHelpers.psm1
@@ -55,6 +55,6 @@ Export-ModuleMember -Function @(
     'Get-WindowsUpdatesHistory'
     'New-ItemPath'
     'Get-ModuleVersionAsJob'
-    'Use-ChecksumСomparison'
+    'Use-ChecksumComparison'
     'Get-HashFromGitHubReleaseBody'
 )

--- a/images/win/scripts/ImageHelpers/InstallHelpers.ps1
+++ b/images/win/scripts/ImageHelpers/InstallHelpers.ps1
@@ -630,7 +630,7 @@ function Get-GitHubPackageDownloadUrl {
     return $downloadUrl
 }
 
-function Use-ChecksumСomparison {
+function Use-ChecksumComparison {
     param (
         [Parameter(Mandatory=$true)]
         [string]$LocalFileHash,


### PR DESCRIPTION
# Description
Fix typo in Use-ChecksumComparison function name (the second 'С' is Cyrillic letter).

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
