### PR TITLE
Update vscode configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "files.trimFinalNewlines": true,
+  "files.insertFinalNewline": true,
   "powershell.codeFormatting.addWhitespaceAroundPipe": true,
   "powershell.codeFormatting.alignPropertyValuePairs": true,
   "powershell.codeFormatting.autoCorrectAliases": true,
@@ -15,6 +17,9 @@
   "powershell.codeFormatting.whitespaceBetweenParameters": true,
   "powershell.codeFormatting.whitespaceInsideBrace": true,
   "shellcheck.exclude": [
-    "SC1091"
+    "SC1090","SC2096"
+  ],
+  "shellcheck.customArgs": [
+    "-x"
   ]
 }


### PR DESCRIPTION
# Description
This PR adds some settings for VSCode:
- Insert newline to the end of each file and trim redundant newlines
- Ignore [SC2096](https://www.shellcheck.net/wiki/SC2096) as we use complex shebang for mac OS scripts
- Ignore [SC1090](https://www.shellcheck.net/wiki/SC1090) to allow using non-constant sources
- Re-enable [SC1091](https://www.shellcheck.net/wiki/SC1091) as correct file path may be defined using special comment
- Add `-x` flag to allow shellcheck accessing arbitrary files

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
