### PR TITLE
[windows] missing openssl pester tests

### DIFF
--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -225,8 +225,16 @@ Describe "SQL OLEDB Driver" {
 }
 
 Describe "OpenSSL" {
-    It "OpenSSL" {
+    It "OpenSSL Version" {
         $OpenSSLVersion = (Get-ToolsetContent).openssl.version
         openssl version | Should -BeLike "* ${OpenSSLVersion}*"
+    }
+
+    It "OpenSSL Path" {
+        (Get-Command openssl).Source -eq (Join-Path ${env:ProgramFiles} 'OpenSSL\bin\openssl.exe') | Should -Be $true
+    }
+
+    It "OpenSSL Full package" {
+        Join-Path ${env:ProgramFiles} 'OpenSSL\include' | Should -Exist
     }
 }


### PR DESCRIPTION
# Description

improve OpenSSL test coverage

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5419

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
