### PR TITLE
[Linux] Rename github/hub repo

### DIFF
--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -5,7 +5,8 @@
 ################################################################################
 
 # Source the helpers for use with the script
-source $HELPER_SCRIPTS/install.sh
+# shellcheck source=../helpers/install.sh
+source "$HELPER_SCRIPTS/install.sh"
 
 GIT_REPO="ppa:git-core/ppa"
 GIT_LFS_REPO="https://packagecloud.io/install/repositories/github/git-lfs"
@@ -33,8 +34,8 @@ add-apt-repository --remove $GIT_REPO
 rm /etc/apt/sources.list.d/github_git-lfs.list
 
 # Document apt source repo's
-echo "git-core $GIT_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
-echo "git-lfs $GIT_LFS_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
+echo "git-core $GIT_REPO" >> "$HELPER_SCRIPTS/apt-sources.txt"
+echo "git-lfs $GIT_LFS_REPO" >> "$HELPER_SCRIPTS/apt-sources.txt"
 
 #Install hub
 tmp_hub="/tmp/hub"

--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -39,7 +39,7 @@ echo "git-lfs $GIT_LFS_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
 #Install hub
 tmp_hub="/tmp/hub"
 mkdir -p "$tmp_hub"
-downloadUrl=$(get_github_package_download_url "github/hub" "contains(\"hub-linux-amd64\")")
+downloadUrl=$(get_github_package_download_url "mislav/hub" "contains(\"hub-linux-amd64\")")
 download_with_retries "$downloadUrl" "$tmp_hub"
 tar xzf "$tmp_hub"/hub-linux-amd64-*.tgz --strip-components 1 -C "$tmp_hub"
 mv "$tmp_hub"/bin/hub /usr/local/bin


### PR DESCRIPTION
# Description
Repository `github/hub` was recently moved to `mislav/hub`. This PR addresses that change.

Ref: https://github.com/mislav/hub/discussions/3326

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
