### PR TITLE
Update manual to clarify helper script purpose

### DIFF
--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -14,6 +14,22 @@ Packer also attempts to cleanup all the temporary resources it created (unless o
 
 After successful completion of all installation steps Packer creates managed image from the temporary VM's disk and deletes the VM.
 
+- [Build agent preparation](#build-agent-preparation)
+- [Manual image generation](#manual-image-generation)
+- [Manual image generation customization](#manual-image-generation-customization)
+  - [Network security](#network-security)
+  - [Azure subscription authentication](#azure-subscription-authentication)
+- [Generated machine deployment](#generated-machine-deployment)
+- [Automated image generation](#automated-image-generation)
+  - [Required variables](#required-variables)
+  - [Optional variables](#optional-variables)
+- [Builder variables](#builder-variables)
+- [Toolset](#toolset)
+- [Post-generation scripts](#post-generation-scripts)
+  - [Running scripts](#running-scripts)
+  - [Script details: Ubuntu](#script-details-ubuntu)
+  - [Script details: Windows](#script-details-windows)
+
 ## Build agent preparation
 
 Build agent is a machine where Packer process will be started.
@@ -229,7 +245,7 @@ The following variables are optional:
 - `virtual_network_resource_group_name` - If `virtual_network_name` is set, this value may also be set. If `virtual_network_name` is set, and this value is not set the builder attempts to determine the resource group containing the virtual network. If the resource group cannot be found, or it cannot be disambiguated, this value should be set.
 - `virtual_network_subnet_name` - If `virtual_network_name` is set, this value may also be set. If `virtual_network_name` is set, and this value is not set the builder attempts to determine the subnet to use with the virtual network. If the subnet cannot be found, or it cannot be disambiguated, this value should be set.
 
-### Builder variables
+## Builder variables
 
 The `builders` section contains variables for the `azure-arm` builder used in the project. Most of the builder variables are inherited from the `user variables` section, however, the variables can be overwritten to adjust image-generation performance.
 
@@ -239,7 +255,7 @@ The `builders` section contains variables for the `azure-arm` builder used in th
 
 **Detailed Azure builders documentation can be found in [packer documentation](https://www.packer.io/docs/builders/azure).**
 
-### Toolset
+## Toolset
 
 Configuration for some installed software is located in `toolset.json` files. These files define the list of Ruby, Python, Go versions, the list of PowerShell modules and VS components that will be installed to image. They can be changed if these tools are not required to reduce image generation time or image size.
 
@@ -249,7 +265,7 @@ Generated tool versions and details can be found in related projects:
 - [Go](https://github.com/actions/go-versions)
 - [Node](https://github.com/actions/node-versions)
 
-### Post-generation scripts
+## Post-generation scripts
 
 > :warning: These scripts are intended to run on a VM deployed in Azure
 
@@ -265,7 +281,7 @@ The scripts are copied to the image during the generation process to the followi
 - Windows: `C:\post-generation`
 - Linux:  `/opt/post-generation`
 
-#### Running scripts
+### Running scripts
 
 - Ubuntu
 
@@ -279,16 +295,14 @@ The scripts are copied to the image during the generation process to the followi
   Get-ChildItem C:\post-generation -Filter *.ps1 | ForEach-Object { & $_.FullName }
   ```
 
-#### Script details
-
-##### Ubuntu
+### Script details: Ubuntu
 
 - **cleanup-logs.sh** - removes all build process logs from the machine
 - **environment-variables.sh** - replaces `$HOME` with the default user's home directory for environmental variables related to the default user home directory
 - **homebrew-permissions.sh** - Resets homebrew repository directory by running `git reset --hard` to make the working tree clean after chmoding /home and changes the repository directory owner to the current user
 - **rust-permissions.sh** - fixes permissions for the Rust folder. Detailed issue explanation is provided in [runner-images/issues/572](https://github.com/actions/runner-images/issues/572).
 
-##### Windows
+### Script details: Windows
 
 - **GenerateIISExpressCertificate.ps1** - generates and imports a certificate to run applications with IIS Express through HTTPS
 - **InternetExplorerConfiguration** - turns off the Internet Explorer Enhanced Security feature


### PR DESCRIPTION
# Description
It looks like current version of image generation manual is quite confusing as the section describing helper script has title 'Automated image generation' while helper script have been designed mainly for manual generation. This PR changes titles and updates text so the purpose of helper script becomes more clear. Also it adds explicit recommendation to invoke packer directly when building images in an automated workflow.

Also this PR update manual structure and adds table of contents.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
