### PR TITLE
[macOS] do not install xcode-install gem on Ventura

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -96,7 +96,6 @@
     "ruby": {
         "default": "3.0",
         "rubygems": [
-            "xcode-install",
             "cocoapods",
             "xcpretty",
             "bundler",


### PR DESCRIPTION
# Description

This gem is being sunset, lets not install it on macOS starting with 13

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
