### PR TITLE
[windows] disable StorSvc for runners

### DIFF
--- a/images/win/scripts/Installers/Finalize-VM.ps1
+++ b/images/win/scripts/Installers/Finalize-VM.ps1
@@ -91,13 +91,14 @@ $regUserServicesToDisables | ForEach-Object {
 
 # Disabled services
 $servicesToDisable = @(
-    "wuauserv"
-    "DiagTrack"
-    "dmwappushservice"
-    "PcaSvc"
-    "SysMain"
-    "gupdate"
-    "gupdatem"
+    'wuauserv'
+    'DiagTrack'
+    'dmwappushservice'
+    'PcaSvc'
+    'SysMain'
+    'gupdate'
+    'gupdatem'
+    'StorSvc'
 )
 
 $servicesToDisable | ForEach-Object {


### PR DESCRIPTION
# Description

StorSvc service wakes up in 700-800 sec and scans all files, which affects runner a lot. Let us try to disable it
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
