### PR TITLE
wrap sourceDiskUri in quotes to account for special characters

### DIFF
--- a/images.CI/linux-and-win/convert-to-vhd.ps1
+++ b/images.CI/linux-and-win/convert-to-vhd.ps1
@@ -95,6 +95,8 @@ $targetKey = az storage account keys list `
 Write-Host ("Copying VHD blob from '{0}' to 'https://{1}.blob.core.windows.net/{2}/{3}'..." `
     -f $sourceDiskUri.Split('?')[0], $StorageAccountName, $StorageAccountContainerName, $VhdName)
 
+$sourceDiskUri = """{0}""" -f $sourceDiskUri
+
 az storage blob copy start `
   --source-uri $sourceDiskUri `
   --destination-blob $VhdName `


### PR DESCRIPTION
# Description
convert-to-vhd.ps1 script fails if there are special characters in the generated SAS URL.
This PR changes the format of the sourceDiskUri variable to account for this.

#### Related issue: https://github.com/actions/runner-images/issues/8392

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
