### PR TITLE
feat: Allow overriding Linux and Windows vm image SKUs via Packer variables

### DIFF
--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -22,6 +22,7 @@
         "managed_image_name": "packer-ubuntu20-dev",
         "image_version": "dev",
         "image_os": "ubuntu20",
+        "image_sku": "20_04-lts",
         "run_validation_diskspace": "false",
         "dockerhub_login": "{{env `DOCKERHUB_LOGIN`}}",
         "dockerhub_password": "{{env `DOCKERHUB_PASSWORD`}}"
@@ -51,7 +52,7 @@
             "os_type": "Linux",
             "image_publisher": "canonical",
             "image_offer": "0001-com-ubuntu-server-focal",
-            "image_sku": "20_04-lts",
+            "image_sku": "{{user `image_sku`}}",
             "os_disk_size_gb": "86"
         }
     ],

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -143,6 +143,11 @@ variable "vm_size" {
   default = "Standard_D4s_v4"
 }
 
+variable "image_sku" {
+  type    = string
+  default = "22_04-lts"
+}
+
 source "azure-arm" "build_image" {
   allowed_inbound_ip_addresses           = "${var.allowed_inbound_ip_addresses}"
   build_resource_group_name              = "${var.build_resource_group_name}"
@@ -151,7 +156,7 @@ source "azure-arm" "build_image" {
   client_cert_path                       = "${var.client_cert_path}"
   image_offer                            = "0001-com-ubuntu-server-jammy"
   image_publisher                        = "canonical"
-  image_sku                              = "22_04-lts"
+  image_sku                              = "${var.image_sku}"
   location                               = "${var.location}"
   os_disk_size_gb                        = "86"
   os_type                                = "Linux"

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -25,7 +25,8 @@
         "install_password": null,
         "managed_image_name": "packer-win19-dev",
         "image_version": "dev",
-        "image_os": "win19"
+        "image_os": "win19",
+        "image_sku": "2019-Datacenter"
     },
     "sensitive-variables": [
         "install_password",
@@ -57,7 +58,7 @@
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",
-            "image_sku": "2019-Datacenter",
+            "image_sku": "{{user `image_sku`}}",
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -25,7 +25,8 @@
         "install_password": null,
         "managed_image_name": "packer-win22-dev",
         "image_version": "dev",
-        "image_os": "win22"
+        "image_os": "win22",
+        "image_sku": "2022-Datacenter"
     },
     "sensitive-variables": [
         "install_password",
@@ -57,7 +58,7 @@
             "os_type": "Windows",
             "image_publisher": "MicrosoftWindowsServer",
             "image_offer": "WindowsServer",
-            "image_sku": "2022-Datacenter",
+            "image_sku": "{{user `image_sku`}}",
             "communicator": "winrm",
             "winrm_use_ssl": "true",
             "winrm_insecure": "true",


### PR DESCRIPTION
# Description

This pull request contains adaptations to the image definitions for Windows and Linux to be able to adjust the image SKU by a packer variable at runtime.

This can be used, for example, to create Gen2 VM images.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
