### PR TITLE
[windows] warmup "az devops" for the first run

### DIFF
--- a/images/win/scripts/Installers/Install-AzureDevOpsCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureDevOpsCli.ps1
@@ -3,6 +3,40 @@
 ##  Desc:  Install Azure DevOps CLI
 ################################################################################
 
-az extension add -n azure-devops
+# Store azure-devops-cli cache outside of the provisioning user's profile
+[Environment]::SetEnvironmentVariable('AZURE_DEVOPS_EXT_CONFIG_DIR', $azureDevOpsCliConfigPath, [System.EnvironmentVariableTarget]::Machine)
+# make variable to be available in the current session
+${env:AZURE_DEVOPS_EXT_CONFIG_DIR} = $azureDevOpsCliConfigPath
 
-Invoke-PesterTests -TestFile "CLI.Tools" -TestName "Azure DevOps CLI"
+$azureDevOpsCliCachePath = Join-Path $azureDevOpsCliConfigPath 'cache'
+$null = New-Item -ItemType 'Directory' -Path $azureDevOpsCliCachePath
+
+[Environment]::SetEnvironmentVariable('AZURE_DEVOPS_CACHE_DIR', $azureDevOpsCliCachePath, [System.EnvironmentVariableTarget]::Machine)
+# make variable to be available in the current session
+${env:AZURE_DEVOPS_CACHE_DIR} = $azureDevOpsCliCachePath
+
+az extension add -n azure-devops
+if ($LASTEXITCODE -ne 0)
+{
+   throw "Command 'az extension add -n azure-devops' failed"
+}
+
+# Warm-up Azure DevOps CLI
+
+Write-Host "Warmup 'az-devops'"
+@('devops', 'pipelines', 'boards', 'repos', 'artifacts') | ForEach-Object {
+
+    az $_ --help
+    if ($LASTEXITCODE -ne 0)
+    {
+       throw "Command 'az $_ --help' failed"
+    }
+
+}
+
+# calling az devops login to force it to install `keyring`. Login will actually fail, redirecting error to null
+Write-Host 'fake token' | az devops login | Out-Null
+# calling az devops logout to be sure no credentials remain.
+az devops logout | out-null
+
+Invoke-PesterTests -TestFile 'CLI.Tools' -TestName 'Azure DevOps CLI'

--- a/images/win/scripts/Installers/Install-AzureDevOpsCli.ps1
+++ b/images/win/scripts/Installers/Install-AzureDevOpsCli.ps1
@@ -3,6 +3,7 @@
 ##  Desc:  Install Azure DevOps CLI
 ################################################################################
 
+$azureDevOpsCliConfigPath = 'C:\azureDevOpsCli'
 # Store azure-devops-cli cache outside of the provisioning user's profile
 [Environment]::SetEnvironmentVariable('AZURE_DEVOPS_EXT_CONFIG_DIR', $azureDevOpsCliConfigPath, [System.EnvironmentVariableTarget]::Machine)
 # make variable to be available in the current session


### PR DESCRIPTION
as Jesse Houwing has found "az devops" warms up during first run which takes ~40 sec.

warm up is done by running "az devops <subsystem> --help" with config redirected to persistent "C:\" location, also keyring installation requires "fake" login

original PR: https://github.com/actions/runner-images/pull/8294

# Description

warming up "az devops" first invocation.
due to security reasons we cannot accept original PR: https://github.com/actions/runner-images/pull/8294

#### Related issue:

https://github.com/actions/runner-images/issues/8296

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
