### PR TITLE
Download actions/action-versions latest release on Windows and set ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE

### DIFF
--- a/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
+++ b/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
@@ -1,0 +1,18 @@
+################################################################################
+##  File:  Install-ActionArchiveCache.ps1
+##  Desc:  Install Action Archive Cache
+##         from https://github.com/actions/action-versions
+################################################################################
+
+if (-not (Test-Path $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE))
+{
+    Write-Host "Creating action archive cache folder"
+    New-Item -ItemType Directory -Path $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE | Out-Null
+}
+
+$downloadUrl = Get-GitHubPackageDownloadUrl -RepoOwner "actions" -RepoName "action-versions" -Version "latest" -UrlFilter "*action-versions.zip"
+Write-Host "Download Latest action-versions archive from $downloadUrl"
+$actionVersionsArchivePath = Start-DownloadWithRetry -Url $downloadUrl -Name "action-versions.zip"
+
+Write-Host "Expand action-versions archive"
+Extract-7Zip -Path $actionVersionsArchivePath -DestinationPath $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE

--- a/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
+++ b/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
@@ -17,3 +17,5 @@ $actionVersionsArchivePath = Start-DownloadWithRetry -Url $downloadUrl -Name "ac
 
 Write-Host "Expand action-versions archive"
 Extract-7Zip -Path $actionVersionsArchivePath -DestinationPath $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
+
+Invoke-PesterTests -TestFile "ActionArchiveCache"

--- a/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
+++ b/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
@@ -1,7 +1,8 @@
 ################################################################################
-##  File:  Install-ActionArchiveCache.ps1
-##  Desc:  Install Action Archive Cache
-##         from https://github.com/actions/action-versions
+##  File:       Install-ActionArchiveCache.ps1
+##  Desc:       Download latest release from https://github.com/actions/action-versions
+##              and un-zip to C:\actionarchivecache
+##  Maintainer: #actions-runtime and @TingluoHuang
 ################################################################################
 
 if (-not (Test-Path $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE))

--- a/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
+++ b/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
@@ -11,7 +11,7 @@ if (-not (Test-Path $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE))
     New-Item -ItemType Directory -Path $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE | Out-Null
 }
 
-$downloadUrl = Get-GitHubPackageDownloadUrl -RepoOwner "actions" -RepoName "action-versions" -Version "latest" -UrlFilter "*action-versions.zip"
+$downloadUrl = Get-GitHubPackageDownloadUrl -RepoOwner "actions" -RepoName "action-versions" -Version "latest" -UrlFilter "*/v{Version}/action-versions.zip"
 Write-Host "Download Latest action-versions archive from $downloadUrl"
 $actionVersionsArchivePath = Start-DownloadWithRetry -Url $downloadUrl -Name "action-versions.zip"
 

--- a/images/win/scripts/Installers/Update-ImageData.ps1
+++ b/images/win/scripts/Installers/Update-ImageData.ps1
@@ -42,3 +42,4 @@ $json | Out-File -FilePath $imageDataFile
 setx ImageVersion $env:IMAGE_VERSION /m
 setx ImageOS $env:IMAGE_OS /m
 setx AGENT_TOOLSDIRECTORY $env:AGENT_TOOLSDIRECTORY /m
+setx ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE /m

--- a/images/win/scripts/Tests/ActionArchiveCache.Tests.ps1
+++ b/images/win/scripts/Tests/ActionArchiveCache.Tests.ps1
@@ -1,0 +1,15 @@
+Describe "ActionArchiveCache" {
+    Context "Action archive cache directory not empty" {
+        It "C:\actionarchivecache not empty" {
+            (Get-ChildItem -Path "C:\actionarchivecache\*.zip" -Recurse).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context "Action zipball not empty" {
+        $testCases = Get-ChildItem -Path "C:\actionarchivecache\*.zip" -Recurse | ForEach-Object { @{ ActionZipball = $_.FullName } }
+        It "<ActionZipball>" -TestCases $testCases {
+            param ([string] $ActionZipball)
+            (Get-Item "$ActionZipball").Length | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -146,6 +146,7 @@
                 "IMAGE_VERSION={{user `image_version`}}",
                 "IMAGE_OS={{user `image_os`}}",
                 "AGENT_TOOLSDIRECTORY={{user `agent_tools_directory`}}",
+                "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=C:\\actionarchivecache\\",
                 "IMAGEDATA_FILE={{user `imagedata_file`}}"
             ],
             "scripts": [
@@ -225,6 +226,7 @@
         {
             "type": "powershell",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-ActionArchiveCache.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Ruby.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PyPy.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Toolset.ps1",

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -130,6 +130,7 @@
                 "IMAGE_VERSION={{user `image_version`}}",
                 "IMAGE_OS={{user `image_os`}}",
                 "AGENT_TOOLSDIRECTORY={{user `agent_tools_directory`}}",
+                "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=C:\\actionarchivecache\\",
                 "IMAGEDATA_FILE={{user `imagedata_file`}}"
             ],
             "scripts": [
@@ -215,6 +216,7 @@
         {
             "type": "powershell",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-ActionArchiveCache.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Ruby.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PyPy.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Toolset.ps1",


### PR DESCRIPTION
# Description
New tool

Fetching latest release from https://github.com/actions/action-versions

The latest release contain all tar.gz or zip of all versions of the top 5 used first-party actions (ex: `actions/checkout`).

With these cached on the hosted runner image, the hosted runner won't need to reach out to codeload to download those same assets over and over again.

**For new tools, please provide total size and installation time.**

The asset is about 120MB for both Windows and non-Windows, the download and unzip normally is less than 10s.
Since the assets is an archive of other archive, we only need to unzip the outer layer, after unzip the total size on disk are pretty much the same.

![image](https://github.com/actions/runner-images/assets/1750815/f0a7efe4-5712-4239-a93e-21ae5aeb6c2e)


#### Related issue:

https://github.com/github/actions-broker/issues/17

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
