### PR TITLE
Download actions/action-versions latest release on Linux and set ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE

### DIFF
--- a/images/linux/scripts/installers/action-archive-cache.sh
+++ b/images/linux/scripts/installers/action-archive-cache.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+################################################################################
+##  File:  action-archive-cache.sh
+##  Desc:  Download latest release from https://github.com/actions/action_verions
+##         and un-tar to /opt/actionarchivecache
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/etc-environment.sh
+
+# Prepare directory and env variable for ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
+ACTION_ARCHIVE_CACHE_DIR=/opt/actionarchivecache
+mkdir -p $ACTION_ARCHIVE_CACHE_DIR
+chmod -R 777 $ACTION_ARCHIVE_CACHE_DIR
+echo "Setting up ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE variable to ${ACTION_ARCHIVE_CACHE_DIR}"
+addEtcEnvironmentVariable ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE ${ACTION_ARCHIVE_CACHE_DIR}
+
+# Download latest release from github.com/actions/action-versions and untar to /opt/actionarchivecache
+downloadUrl=$(get_github_package_download_url "actions/action-versions" "contains(\"action-versions.tar.gz\")")
+echo "Downloading action-versions $downloadUrl"
+download_with_retries "$downloadUrl" "/tmp" action-versions.tar.gz
+tar -xzf /tmp/action-versions.tar.gz -C $ACTION_ARCHIVE_CACHE_DIR
+
+invoke_tests "ActionArchiveCache"

--- a/images/linux/scripts/installers/action-archive-cache.sh
+++ b/images/linux/scripts/installers/action-archive-cache.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 ################################################################################
-##  File:  action-archive-cache.sh
-##  Desc:  Download latest release from https://github.com/actions/action_verions
-##         and un-tar to /opt/actionarchivecache
+##  File:       action-archive-cache.sh
+##  Desc:       Download latest release from https://github.com/actions/action-verions
+##              and un-tar to /opt/actionarchivecache
+##  Maintainer: #actions-runtime and @TingluoHuang
 ################################################################################
 
 # Source the helpers for use with the script

--- a/images/linux/scripts/tests/ActionArchiveCache.Tests.ps1
+++ b/images/linux/scripts/tests/ActionArchiveCache.Tests.ps1
@@ -1,0 +1,15 @@
+Describe "ActionArchiveCache" {
+    Context "Action archive cache directory not empty" {
+        It "/opt/actionarchivecache not empty" {
+            (Get-ChildItem -Path "/opt/actionarchivecache/*.tar.gz" -Recurse).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context "Action tarball not empty" {
+        $testCases = Get-ChildItem -Path "/opt/actionarchivecache/*.tar.gz" -Recurse | ForEach-Object { @{ ActionTarball = $_.FullName } }
+        It "<ActionTarball>" -TestCases $testCases {
+            param ([string] $ActionTarball)
+            (Get-Item "$ActionTarball").Length | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -196,6 +196,7 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/action-archive-cache.sh",
                 "{{template_dir}}/scripts/installers/apt-common.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -280,6 +280,7 @@ build {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DEBIAN_FRONTEND=noninteractive"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
+                        "${path.root}/scripts/installers/action-archive-cache.sh",
                         "${path.root}/scripts/installers/apt-common.sh",
                         "${path.root}/scripts/installers/azcopy.sh",
                         "${path.root}/scripts/installers/azure-cli.sh",


### PR DESCRIPTION
# Description
New tool

Fetching latest release from https://github.com/actions/action-versions

The latest release contain all tar.gz or zip of all versions of the top 5 used first-party actions (ex: `actions/checkout`).

With these cached on the hosted runner image, the hosted runner won't need to reach out to codeload to download those same assets over and over again.

**For new tools, please provide total size and installation time.**

The asset is about 120MB for both Windows and non-Windows, the download and unzip normally is less than 10s.
Since the assets is an archive of other archive, we only need to unzip the outer layer, after unzip the total size on disk are pretty much the same.

![image](https://github.com/actions/runner-images/assets/1750815/f0a7efe4-5712-4239-a93e-21ae5aeb6c2e)


#### Related issue:

https://github.com/github/actions-broker/issues/17

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
