### PR TITLE
Download actions/action-versions latest release on macOS and set ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE

### DIFF
--- a/images/macos/provision/configuration/environment/bashrc
+++ b/images/macos/provision/configuration/environment/bashrc
@@ -12,6 +12,7 @@ export NUNIT3_PATH=/Library/Developer/nunit/3.6.0
 
 export AGENT_TOOLSDIRECTORY=$HOME/hostedtoolcache
 export RUNNER_TOOL_CACHE=$HOME/hostedtoolcache
+export ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=$HOME/actionarchivecache
 
 export PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:$PATH
 export PATH=/Library/Frameworks/Python.framework/Versions/Current/bin:$PATH

--- a/images/macos/provision/core/action-archive-cache.sh
+++ b/images/macos/provision/core/action-archive-cache.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e -o pipefail
+
+source ~/utils/utils.sh
+
+echo "Check if ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE folder exist..."
+if [ ! -d $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE ]; then
+    mkdir -p $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
+fi
+
+downloadUrl=$(get_github_package_download_url "actions/action-versions" "contains(\"action-versions.tar.gz\")" "latest")
+echo "Downloading action-versions $downloadUrl"
+download_with_retries "$downloadUrl" "/tmp" action-versions.tar.gz
+tar -xzf /tmp/action-versions.tar.gz -C $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
+
+invoke_tests "ActionArchiveCache"

--- a/images/macos/provision/core/action-archive-cache.sh
+++ b/images/macos/provision/core/action-archive-cache.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e -o pipefail
 
+################################################################################
+##  File:       action-archive-cache.sh
+##  Desc:       Download latest release from https://github.com/actions/action-verions
+##              and un-tar to $HOME/actionarchivecache
+##  Maintainer: #actions-runtime and @TingluoHuang
+################################################################################
+
 source ~/utils/utils.sh
 
 echo "Check if ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE folder exist..."

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -183,6 +183,7 @@
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
+                "./provision/core/action-archive-cache.sh",
                 "./provision/core/commonutils.sh",
                 "./provision/core/llvm.sh",
                 "./provision/core/golang.sh",

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -198,6 +198,7 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/action-archive-cache.sh",
       "./provision/core/llvm.sh",
       "./provision/core/golang.sh",
       "./provision/core/swiftlint.sh",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -185,6 +185,7 @@
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
+                "./provision/core/action-archive-cache.sh",
                 "./provision/core/llvm.sh",
                 "./provision/core/golang.sh",
                 "./provision/core/swiftlint.sh",

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -194,6 +194,7 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/action-archive-cache.sh",
       "./provision/core/llvm.sh",
       "./provision/core/swiftlint.sh",
       "./provision/core/openjdk.sh",

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -194,6 +194,7 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/action-archive-cache.sh",
       "./provision/core/llvm.sh",
       "./provision/core/openjdk.sh",
       "./provision/core/rust.sh",

--- a/images/macos/tests/ActionArchiveCache.Tests.ps1
+++ b/images/macos/tests/ActionArchiveCache.Tests.ps1
@@ -1,0 +1,15 @@
+Describe "ActionArchiveCache" {
+    Context "Action archive cache directory not empty" {
+        It "$HOME/actionarchivecache not empty" {
+            (Get-ChildItem -Path "$env:HOME/actionarchivecache/*.tar.gz" -Recurse).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context "Action tarball not empty" {
+        $testCases = Get-ChildItem -Path "$env:HOME/actionarchivecache/*.tar.gz" -Recurse | ForEach-Object { @{ ActionTarball = $_.FullName } }
+        It "<ActionTarball>" -TestCases $testCases {
+            param ([string] $ActionTarball)
+            (Get-Item "$ActionTarball").Length | Should -BeGreaterThan 0
+        }
+    }
+}


### PR DESCRIPTION
# Description
New tool

Fetching latest release from https://github.com/actions/action-versions

The latest release contain all tar.gz or zip of all versions of the top 5 used first-party actions (ex: `actions/checkout`).

With these cached on the hosted runner image, the hosted runner won't need to reach out to codeload to download those same assets over and over again.

**For new tools, please provide total size and installation time.**

The asset is about 120MB for both Windows and non-Windows, the download and unzip normally is less than 10s.
Since the assets is an archive of other archive, we only need to unzip the outer layer, after unzip the total size on disk are pretty much the same.

![image](https://github.com/actions/runner-images/assets/1750815/f0a7efe4-5712-4239-a93e-21ae5aeb6c2e)


#### Related issue:

https://github.com/github/actions-broker/issues/17

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
