### PR TITLE
[Windows] Patch for missing PyPy3.9-7.3.13 SHA

### DIFF
--- a/images/win/scripts/Installers/Install-PyPy.ps1
+++ b/images/win/scripts/Installers/Install-PyPy.ps1
@@ -112,6 +112,11 @@ foreach($toolsetVersion in $toolsetVersions.versions)
                 $distributorFileHash = $node.InnerText.ToString().Split("`n").Where({ $_ -ilike "*${filename}*" }).Split(' ')[0]
             }
         }
+        
+        #Temp patch for pypy3.9-v7.3.13-win64.zip checksum, delete me when pypy.org will be fixed
+        if ($filename -ilike "*pypy3.9-v7.3.13-win64*") {
+            $distributorFileHash = "09EA41154AD1DCD3E8378609A73196A6C108B17AA05EF3CBB240610744102803"
+        }
 
         Use-ChecksumComparison -LocalFileHash $localFileHash -DistributorFileHash $distributorFileHash
         #endregion


### PR DESCRIPTION
# Description

Temporary patch for PyPy installation script. The checksum for the required file is not published on the pypy.org website.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
