### PR TITLE
[macos] Adjust Xcode storage Uri

### DIFF
--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -30,7 +30,7 @@ function Invoke-DownloadXcodeArchive {
     $tempXipDirectory = New-Item -Path $DownloadDirectory -Name "Xcode$Version" -ItemType "Directory"
 
     $xcodeFileName = 'Xcode-{0}.xip' -f $Version
-    $xcodeUri = '{0}{1}{2}'-f ${env:XCODE_INSTALL_STORAGE_URL}, $xcodeFileName, ${env:XCODE_INSTALL_SAS}
+    $xcodeUri = '{0}{1}?{2}'-f ${env:XCODE_INSTALL_STORAGE_URL}, $xcodeFileName, ${env:XCODE_INSTALL_SAS}
 
     Start-DownloadWithRetry -Url $xcodeUri -DownloadPath $tempXipDirectory.FullName -Name $xcodeFileName
     return $tempXipDirectory


### PR DESCRIPTION
# Description
Current implementation requires `XCODE_INSTALL_SAS` to be manually suffixed with `?` symbol.
Change allows copying SAS token without symbol additions

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
