### PR TITLE
[Windows] Simplify ghcup installation

### DIFF
--- a/images/win/scripts/Installers/Install-Haskell.ps1
+++ b/images/win/scripts/Installers/Install-Haskell.ps1
@@ -9,8 +9,20 @@ Write-Host 'Installing ghcup...'
 $msysPath = "C:\msys64"
 $ghcupPrefix = "C:\"
 $cabalDir = "C:\cabal"
-$bootstrapHaskell = Invoke-WebRequest https://www.haskell.org/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing
-Invoke-Command -ScriptBlock ([ScriptBlock]::Create($bootstrapHaskell)) -ArgumentList $false, $true, $true, $false, $true, $false, $false, $ghcupPrefix, "", $msysPath, $cabalDir
+
+$ghcupDownloadURL = "https://downloads.haskell.org/~ghcup/x86_64-mingw64-ghcup.exe"
+
+# If you want to install a specific version of ghcup, uncomment the following lines
+# $ghver = "0.1.19.4"
+# $ghcupDownloadURL = "https://downloads.haskell.org/~ghcup/${ghver}/x86_64-mingw64-ghcup-${ghver}.exe"
+
+# Other option is to download ghcup from GitHub releases:
+# https://github.com/haskell/ghcup-hs/releases/latest
+
+New-Item -Path "$ghcupPrefix\ghcup" -ItemType 'directory' -ErrorAction SilentlyContinue | Out-Null
+New-Item -Path "$ghcupPrefix\ghcup\bin" -ItemType 'directory' -ErrorAction SilentlyContinue | Out-Null
+Start-DownloadWithRetry -Url $ghcupDownloadURL -Name "ghcup.exe" -DownloadPath "$ghcupPrefix\ghcup\bin"
+
 Set-SystemVariable "GHCUP_INSTALL_BASE_PREFIX" $ghcupPrefix
 Set-SystemVariable "GHCUP_MSYS2" $msysPath
 Set-SystemVariable "CABAL_DIR" $cabalDir


### PR DESCRIPTION
# Description

Currently we use bootstrap script to install Haskell on Windows. But we can't validate that it's legit and safe. Since we only use that script to download ghcup utility, we can get rid of it. This PR replaces bootstrapper invocation with simple commands that create required directories and download binary directly.

Manual reference: https://www.haskell.org/ghcup/install/#manual-installation

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
