### PR TITLE
[macOS] Add 15.1 Xcode to the macOS 13

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,6 +3,7 @@
         "default": "14.3.1",
         "x64": {
             "versions": [
+                { "link": "15.1", "version": "15.1-Beta+15C5028h"},
                 { "link": "15.0", "version": "15.0.0+15A240d"},
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },
@@ -11,6 +12,7 @@
         },
         "arm64":{
             "versions": [
+                { "link": "15.1", "version": "15.1-Beta+15C5028h"},
                 { "link": "15.0", "version": "15.0.0+15A240d"},
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"] },
                 { "link": "14.2", "version": "14.2.0+14C18" },


### PR DESCRIPTION
# Description
Add 15.1 Xcode to the macOS 13 (intel and m1)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
