### PR TITLE
[Ubuntu] Change destination for toolcache assets

### DIFF
--- a/images/linux/scripts/installers/Install-Toolset.ps1
+++ b/images/linux/scripts/installers/Install-Toolset.ps1
@@ -14,7 +14,7 @@ Function Install-Asset {
     wget $ReleaseAsset.download_url -nv --retry-connrefused --tries=10
 
     Write-Host "Extract $($ReleaseAsset.filename) content..."
-    $assetFolderPath = Join-Path $env:INSTALLER_SCRIPT_FOLDER $($ReleaseAsset.filename)
+    $assetFolderPath = Join-Path "/tmp" $($ReleaseAsset.filename)
     New-Item -ItemType Directory -Path $assetFolderPath
     tar -xzf $ReleaseAsset.filename -C $assetFolderPath
 


### PR DESCRIPTION
# Description

Currently we unarchive toolset assets to `INSTALLER_SCRIPT_FOLDER` and those assets remain in final image. We don't need them so this PR changes destination for tar command to `/tmp`. As a result we free 2.6 GB on image disk.

#### Related issue: https://github.com/actions/runner-images-internal/issues/5479

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
