### PR TITLE
[macos13] Fix preimagedata for arm64

### DIFF
--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -2,6 +2,7 @@
 
 source ~/utils/utils.sh
 
+arch=$(get_arch)
 imagedata_file="$HOME/imagedata.json"
 image_version=$(echo $IMAGE_VERSION | cut -d _ -f 2)
 os_name=$(sw_vers -productName)
@@ -9,7 +10,11 @@ os_version=$(sw_vers -productVersion)
 os_build=$(sw_vers -buildVersion)
 label_version=$(echo $os_version | cut -d. -f1)
 
-image_label="macos-${label_version}"
+if [[ $arch == "arm64" ]]; then
+  image_label="macos-${label_version}-arm64"
+else
+  image_label="macos-${label_version}"
+fi
 release_label="macOS-${label_version}"
 
 if is_Ventura; then


### PR DESCRIPTION
# Description
Fix Software and Release URLs in `preimagedata.sh` for macOS 13 arm64 images.

#### Related issue: https://github.com/actions/runner-images-internal/issues/5478

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
