### PR TITLE
[windows] ignore error on copying user profile warmup

### DIFF
--- a/images/win/scripts/Installers/Warmup-User.ps1
+++ b/images/win/scripts/Installers/Warmup-User.ps1
@@ -15,7 +15,8 @@ $devEnvPath = "$vsInstallRoot\Common7\IDE\devenv.exe"
 
 cmd.exe /c "`"$devEnvPath`" /updateconfiguration"
 
-Copy-Item ${env:USERPROFILE}\AppData\Local\Microsoft\VisualStudio -Destination c:\users\default\AppData\Local\Microsoft\VisualStudio -Recurse
+# we are fine if some file is locked and cannot be copied
+Copy-Item ${env:USERPROFILE}\AppData\Local\Microsoft\VisualStudio -Destination c:\users\default\AppData\Local\Microsoft\VisualStudio -Recurse -ErrorAction SilentlyContinue
 
 reg.exe load HKLM\DEFAULT c:\users\default\ntuser.dat
 reg.exe copy HKCU\Software\Microsoft\VisualStudio HKLM\DEFAULT\Software\Microsoft\VisualStudio /s


### PR DESCRIPTION
# Description

ignore rare error which happens on copying locked files in prepared user profile

==> azure-arm.image: Copy-Item : The process cannot access the file
==> azure-arm.image: 'C:\Users\packer\AppData\Local\Microsoft\VisualStudio\16.0_14229d81\privateregistry.bin.LOG2' because it is being used
==> azure-arm.image: by another process.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
