### PR TITLE
[macos] Add activesupport gem workaround for cocoapods

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -12,7 +12,7 @@ if [ -n "$gemsToInstall" ]; then
     done
 fi
 
-# Temporary uninstall public_suffix 5.0 gem as Cocoapods is not compatible with it yet https://github.com/actions/runner-images/issues/6149
-gem uninstall public_suffix -v 5.0.0
+# Temporarily install activesupport 7.0.8 due to compatibility issues with cocoapods https://github.com/CocoaPods/CocoaPods/issues/12081
+gem install activesupport -v 7.0.8 && gem uninstall activesupport -v 7.1.0
 
 invoke_tests "RubyGem"


### PR DESCRIPTION
# Description
`activesupport 7.1.0` gem (`cocoapods` dependency) has bug https://github.com/CocoaPods/CocoaPods/issues/12081, which prevents `cocoapods` installation. Implement workaround until new release

1. `public_suffix` workaround is obsolete and removed
2. `activesupport` temporarily pinned to `7.0.8`

#### Related issue: https://github.com/actions/runner-images-internal/issues/5480

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
