### PR TITLE
Don't create release for every CI run

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -146,25 +146,26 @@ jobs:
                         -PrefixToPathTrim "$(TemplateDirectoryPath)" `
                         -PrintTopNLongest 25
 
-  - task: PowerShell@2
-    displayName: 'Convert managed image to VHD'
-    inputs:
-      targetType: filePath
-      filePath: ./images.CI/linux-and-win/convert-to-vhd.ps1
-      arguments: -SubscriptionId $(AZURE_SUBSCRIPTION) `
-                 -Location $(AZURE_LOCATION) `
-                 -ResourceGroupName $(AZURE_RESOURCE_GROUP) `
-                 -ManagedImageName "$(ManagedImageName)" `
-                 -GalleryName "github_imagegeneration_convert_to_vhd" `
-                 -GalleryImageSku "${{ parameters.image_type }}" `
-                 -GalleryImageVersion "0.0.$(Build.BuildId)" `
-                 -StorageAccountName $(AZURE_STORAGE_ACCOUNT) `
-                 -StorageAccountContainerName "images" `
-                 -VhdName "$(VhdName)" `
-                 -ClientId $(CLIENT_ID) `
-                 -ClientSecret $(CLIENT_SECRET) `
-                 -TenantId $(AZURE_TENANT) `
-                 -RemoveManagedImage
+  - ${{ if eq(parameters.create_release, true) }}:
+    - task: PowerShell@2
+      displayName: 'Convert managed image to VHD'
+      inputs:
+        targetType: filePath
+        filePath: ./images.CI/linux-and-win/convert-to-vhd.ps1
+        arguments: -SubscriptionId $(AZURE_SUBSCRIPTION) `
+                   -Location $(AZURE_LOCATION) `
+                   -ResourceGroupName $(AZURE_RESOURCE_GROUP) `
+                   -ManagedImageName "$(ManagedImageName)" `
+                   -GalleryName "github_imagegeneration_convert_to_vhd" `
+                   -GalleryImageSku "${{ parameters.image_type }}" `
+                   -GalleryImageVersion "0.0.$(Build.BuildId)" `
+                   -StorageAccountName $(AZURE_STORAGE_ACCOUNT) `
+                   -StorageAccountContainerName "images" `
+                   -VhdName "$(VhdName)" `
+                   -ClientId $(CLIENT_ID) `
+                   -ClientSecret $(CLIENT_SECRET) `
+                   -TenantId $(AZURE_TENANT) `
+                   -RemoveManagedImage
 
   - ${{ if eq(parameters.create_release, true) }}:
     - task: PowerShell@2

--- a/images.CI/linux-and-win/azure-pipelines/ubuntu2004.yml
+++ b/images.CI/linux-and-win/azure-pipelines/ubuntu2004.yml
@@ -18,3 +18,4 @@ jobs:
   parameters:
     image_type: ubuntu2004
     image_readme_name: Ubuntu2004-Readme.md
+    create_release: ${{ eq(variables['Build.Reason'], 'Schedule') }}

--- a/images.CI/linux-and-win/azure-pipelines/ubuntu2204.yml
+++ b/images.CI/linux-and-win/azure-pipelines/ubuntu2204.yml
@@ -18,3 +18,4 @@ jobs:
   parameters:
     image_type: ubuntu2204
     image_readme_name: Ubuntu2204-Readme.md
+    create_release: ${{ eq(variables['Build.Reason'], 'Schedule') }}

--- a/images.CI/linux-and-win/azure-pipelines/windows2019.yml
+++ b/images.CI/linux-and-win/azure-pipelines/windows2019.yml
@@ -18,3 +18,4 @@ jobs:
   parameters:
     image_type: windows2019
     image_readme_name: Windows2019-Readme.md
+    create_release: ${{ eq(variables['Build.Reason'], 'Schedule') }}

--- a/images.CI/linux-and-win/azure-pipelines/windows2022.yml
+++ b/images.CI/linux-and-win/azure-pipelines/windows2022.yml
@@ -18,3 +18,4 @@ jobs:
   parameters:
     image_type: windows2022
     image_readme_name: Windows2022-Readme.md
+    create_release: ${{ eq(variables['Build.Reason'], 'Schedule') }}


### PR DESCRIPTION
# Description

Reduce CI build duration by omitting image conversion and release creation.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
