### PR TITLE
[macOS] Fix java info in toolsets

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -153,8 +153,10 @@
         ]
     },
     "java": {
-        "default": "8",
-        "versions": [ "8", "11", "17" ]
+        "x64": {
+            "default": "8",
+            "versions": [ "8", "11", "17" ]
+        }
     },
     "android": {
         "platform_min_version": "27",

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -140,8 +140,10 @@
         ]
     },
     "java": {
-        "default": "8",
-        "versions": [ "8", "11", "17" ]
+        "x64": {
+            "default": "8",
+            "versions": [ "8", "11", "17" ]
+        }
     },
     "android": {
         "platform_min_version": "27",


### PR DESCRIPTION
# Description

Update toolsets for MacOS 11 and 12 according to changes introduced by https://github.com/actions/runner-images/commit/60963fb52e25c7e731d0c7a16290c03bdf3feb15

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
