### PR TITLE
[macos] Adjust activesupport ruby gem version pinning

### DIFF
--- a/images/macos/provision/core/rubygem.sh
+++ b/images/macos/provision/core/rubygem.sh
@@ -4,6 +4,9 @@ source ~/utils/utils.sh
 echo Updating RubyGems...
 gem update --system
 
+# Temporarily install activesupport 7.0.8 due to compatibility issues with cocoapods https://github.com/CocoaPods/CocoaPods/issues/12081
+gem install activesupport -v 7.0.8
+
 gemsToInstall=$(get_toolset_value '.ruby.rubygems | .[]')
 if [ -n "$gemsToInstall" ]; then
     for gem in $gemsToInstall; do
@@ -11,8 +14,5 @@ if [ -n "$gemsToInstall" ]; then
         gem install $gem
     done
 fi
-
-# Temporarily install activesupport 7.0.8 due to compatibility issues with cocoapods https://github.com/CocoaPods/CocoaPods/issues/12081
-gem install activesupport -v 7.0.8 && gem uninstall activesupport -v 7.1.0
 
 invoke_tests "RubyGem"


### PR DESCRIPTION
# Description
Make cocoapods' `activesupport` gem workaround more resilient to version changes. `activesupport 7.1.1` still not working with cocoapods

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
