### PR TITLE
[macos] add retries when installing DotNETSDK

### DIFF
--- a/images/macos/provision/core/dotnet.sh
+++ b/images/macos/provision/core/dotnet.sh
@@ -14,7 +14,7 @@ arch=$(get_arch)
 
 # Download installer from dot.net and keep it locally
 DOTNET_INSTALL_SCRIPT="https://dot.net/v1/dotnet-install.sh"
-curl -fsSL -o "dotnet-install.sh" "$DOTNET_INSTALL_SCRIPT"
+download_with_retries $DOTNET_INSTALL_SCRIPT .
 chmod +x ./dotnet-install.sh
 
 ARGS_LIST=()


### PR DESCRIPTION
# Description

use special helper for downloading DotNETSDK installer

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
