### PR TITLE
[Ubuntu] Add helpers to work with checksums

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -95,3 +95,68 @@ get_github_package_download_url() {
     fi
     echo $downloadUrl
 }
+
+get_github_package_hash() {
+    local repo_owner=$1
+    local repo_name=$2
+    local file_name=$3
+    local url=$4
+    local version=${5:-"latest"}
+    local prerelease=${6:-false}
+    local delimiter=${8:-'|'}
+    local word_number=${9:-2}
+
+    if [ -n "$url" ]; then
+        release_url="$url"
+    else
+        if [ "$version" == "latest" ]; then
+            release_url="https://api.github.com/repos/${repo_owner}/${repo_name}/releases/latest"
+        else
+            json=$(curl -s "https://api.github.com/repos/${repo_owner}/${repo_name}/releases?per_page=100")
+            tags=$(echo "$json" | jq -r --arg prerelease "$prerelease" '.[] | select(.prerelease == ($prerelease | test("true"; "i"))) | .tag_name')
+            tag=$(echo "$tags" | grep -o "$version")
+            if [ -z "$tag" ]; then
+                echo "Failed to get a tag name for version $version."
+                exit 1
+            fi
+            release_url="https://api.github.com/repos/${repo_owner}/${repo_name}/releases/tags/$tag"
+        fi
+    fi
+
+    body=$(curl -s "$release_url" | jq -r '.body' | tr -d '`')
+    matching_line=$(echo "$body" | grep "$file_name")
+    if [ -z "$matching_line" ]; then
+        echo "File name '$file_name' not found in release body."
+        exit 1
+    fi
+
+    result=$(echo "$matching_line" | cut -d "$delimiter" -f "$word_number" | tr -d -c '[:alnum:]')
+    if [ -z "$result" ]; then
+        echo "Empty result. Check parameters Delimiter and/or WordNumber for the matching line."
+        exit 1
+    fi
+
+    echo "$result"
+}
+
+use_checksum_comparison() {
+    local file_path=$1
+    local checksum=$2
+    local sha_type=${3-"256"}
+
+    echo "Performing checksum verification"
+
+    if [ ! -f "$file_path" ]; then
+        echo "File not found: $file_path"
+        exit 1
+    fi
+
+    local_file_hash=$(shasum --algorithm "$sha_type" "$file_path" | awk '{print $1}')
+
+    if [ "$local_file_hash" != "$checksum" ]; then
+        echo "Checksum verification failed. Expected hash: $checksum; Actual hash: $local_file_hash."
+        exit 1
+    else
+        echo "Checksum verification passed"
+    fi
+}

--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -106,12 +106,12 @@ get_github_package_hash() {
     local delimiter=${7:-'|'}
     local word_number=${8:-2}
 
-    if [ -z "$file_name" ]; then
+    if [[ -z "$file_name" ]]; then
         echo "File name is not specified."
         exit 1
     fi
 
-    if [ -n "$url" ]; then
+    if [[ -n "$url" ]]; then
         release_url="$url"
     else
         if [ "$version" == "latest" ]; then
@@ -124,7 +124,7 @@ get_github_package_hash() {
                 echo "Multiple tags found matching the version $version. Please specify a more specific version."
                 exit 1
             fi
-            if [ -z "$tag" ]; then
+            if [[ -z "$tag" ]]; then
                 echo "Failed to get a tag name for version $version."
                 exit 1
             fi
@@ -138,13 +138,13 @@ get_github_package_hash() {
         echo "Multiple lines found included the file $file_name. Please specify a more specific file name."
         exit 1
     fi
-    if [ -z "$matching_line" ]; then
+    if [[ -z "$matching_line" ]]; then
         echo "File name '$file_name' not found in release body."
         exit 1
     fi
 
     result=$(echo "$matching_line" | cut -d "$delimiter" -f "$word_number" | tr -d -c '[:alnum:]')
-    if [ -z "$result" ]; then
+    if [[ -z "$result" ]]; then
         echo "Empty result. Check parameters delimiter and/or word_number for the matching line."
         exit 1
     fi
@@ -159,14 +159,14 @@ use_checksum_comparison() {
 
     echo "Performing checksum verification"
 
-    if [ ! -f "$file_path" ]; then
+    if [[ ! -f "$file_path" ]]; then
         echo "File not found: $file_path"
         exit 1
     fi
 
     local_file_hash=$(shasum --algorithm "$sha_type" "$file_path" | awk '{print $1}')
 
-    if [ "$local_file_hash" != "$checksum" ]; then
+    if [[ "$local_file_hash" != "$checksum" ]]; then
         echo "Checksum verification failed. Expected hash: $checksum; Actual hash: $local_file_hash."
         exit 1
     else


### PR DESCRIPTION
# Description

Adding following functions to work with packages hashes:
`get_github_package_hash()` will be used to get package hash from GitHub release body, possible to use with direct release link or with just `repo_owner` and `repo_name` pair.
`use_checksum_comparison()` will be used to compare known checksum with the package hash

#### Related issue:

https://github.com/actions/runner-images-internal/issues/5491

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
