### PR TITLE
[macos] move android "cmdline-tools" to toolset

### DIFF
--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -37,21 +37,37 @@ ANDROID_NDK_MAJOR_LATEST=$(get_toolset_value '.android.ndk."versions"[-1]')
 # Get the latest command line tools from https://developer.android.com/studio#cmdline-tools
 # Newer version(s) require Java 11 by default
 # See https://github.com/actions/runner-images/issues/6960
-ANDROID_OSX_SDK_URL="https://dl.google.com/android/repository/commandlinetools-mac-9123335_latest.zip"
 ANDROID_HOME=$HOME/Library/Android/sdk
 ANDROID_OSX_SDK_FILE=tools-macosx.zip
 
-pushd $HOME
+# Download the latest command line tools so that we can accept all of the licenses.
+# See https://developer.android.com/studio/#command-tools
+cmdlineToolsVersion=$(get_toolset_value '.android."cmdline-tools"')
+
+if [[ $cmdlineToolsVersion == "latest" ]]; then
+    repositoryXmlUrl="https://dl.google.com/android/repository/repository2-1.xml"
+    download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
+    cmdlineToolsVersion=$(
+    yq -p=xml \
+    '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
+    /tmp/repository2-1.xml
+    )
+
+    if [[ -z $cmdlineToolsVersion ]]; then
+        echo "Failed to parse latest command-line tools version"
+        exit 1
+    fi
+fi
 
 echo "Downloading android command line tools..."
-download_with_retries $ANDROID_OSX_SDK_URL "." $ANDROID_OSX_SDK_FILE
+download_with_retries "https://dl.google.com/android/repository/${cmdlineToolsVersion}" /tmp $ANDROID_OSX_SDK_FILE
 
 echo "Uncompressing android command line tools..."
 mkdir -p $HOME/Library/Android/sdk
-unzip -q $ANDROID_OSX_SDK_FILE -d $HOME/Library/Android/sdk/cmdline-tools
+unzip -q /tmp/$ANDROID_OSX_SDK_FILE -d $HOME/Library/Android/sdk/cmdline-tools
 # Command line tools need to be placed in $HOME/Library/Android/sdk/cmdline-tools/latest to function properly
 mv $HOME/Library/Android/sdk/cmdline-tools/cmdline-tools $HOME/Library/Android/sdk/cmdline-tools/latest
-rm -f $ANDROID_OSX_SDK_FILE
+rm -f /tmp/$ANDROID_OSX_SDK_FILE
 
 echo ANDROID_HOME is $ANDROID_HOME
 export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest:$ANDROID_HOME/cmdline-tools/latest/bin

--- a/images/macos/provision/core/android-toolsets.sh
+++ b/images/macos/provision/core/android-toolsets.sh
@@ -49,7 +49,7 @@ if [[ $cmdlineToolsVersion == "latest" ]]; then
     download_with_retries $repositoryXmlUrl "/tmp" "repository2-1.xml"
     cmdlineToolsVersion=$(
     yq -p=xml \
-    '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
+    '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-mac"))' \
     /tmp/repository2-1.xml
     )
 

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -159,6 +159,7 @@
         }
     },
     "android": {
+        "cmdline-tools": "commandlinetools-mac-9123335_latest.zip",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -146,6 +146,7 @@
         }
     },
     "android": {
+        "cmdline-tools": "commandlinetools-mac-9123335_latest.zip",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -31,6 +31,7 @@
         }
     },
     "android": {
+        "cmdline-tools": "commandlinetools-mac-9123335_latest.zip",
         "platform_min_version": "27",
         "build_tools_min_version": "27.0.0",
         "extra-list": [


### PR DESCRIPTION
# Description

this is a preparation for future enabling android sdk on macos-13 arm64

#### Related issue:

https://github.com/actions/runner-images/issues/8515

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
