### PR TITLE
[Mac OS] Fix Edge Updater configuration steps

### DIFF
--- a/images/macos/provision/core/edge.sh
+++ b/images/macos/provision/core/edge.sh
@@ -38,9 +38,9 @@ popd > /dev/null
 # Configure Edge Updater to prevent auto update
 # https://learn.microsoft.com/en-us/deployedge/edge-learnmore-edgeupdater-for-macos
 
-mkdir "Library/Managed Preferences"
+sudo mkdir "/Library/Managed Preferences"
 
-cat <<EOF > "Library/Managed Preferences/com.microsoft.EdgeUpdater.plist"
+cat <<EOF | sudo tee "/Library/Managed Preferences/com.microsoft.EdgeUpdater.plist" > /dev/null
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -57,6 +57,6 @@ cat <<EOF > "Library/Managed Preferences/com.microsoft.EdgeUpdater.plist"
 </plist>
 EOF
 
-chown root:wheel "/Library/Managed Preferences/com.microsoft.EdgeUpdater.plist"
+sudo chown root:wheel "/Library/Managed Preferences/com.microsoft.EdgeUpdater.plist"
 
 invoke_tests "Browsers" "Edge"


### PR DESCRIPTION
# Description

Edge Updater configuration fails on Mac OS 13 with the following error:
```
chown: /Library/Managed Preferences/com.microsoft.EdgeUpdater.plist: No such file or directory
```

It seems like on Mac OS 13 installation script executes in different directory so relative paths doesn't work as expected. This PR fixes those paths.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
