### PR TITLE
[Windows] Fix Java 21 location

### DIFF
--- a/images/win/scripts/Installers/Install-JavaTools.ps1
+++ b/images/win/scripts/Installers/Install-JavaTools.ps1
@@ -73,6 +73,8 @@ function Install-JavaJDK {
 
     # We have to replace '+' sign in the version to '-' due to the issue with incorrect path in Android builds https://github.com/actions/runner-images/issues/3014
     $fullJavaVersion = $asset.version.semver -replace '\+', '-'
+    # Remove 'LTS' suffix from the version if present
+    $fullJavaVersion = $fullJavaVersion -replace '\.LTS$', ''
     # Create directories in toolcache path
     $javaToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Java_Temurin-Hotspot_jdk"
     $javaVersionPath = Join-Path -Path $javaToolcachePath -ChildPath $fullJavaVersion


### PR DESCRIPTION
# Description

This PR changes directory name that is Java 21 installed to. Currently it has '.LTS' suffix and this difference causes issues.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
