### PR TITLE
[macos] enable android cmdtools on macos-13 arm64

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -31,21 +31,21 @@
         }
     },
     "android": {
-        "cmdline-tools": "commandlinetools-mac-9123335_latest.zip",
-        "platform_min_version": "27",
-        "build_tools_min_version": "27.0.0",
+        "cmdline-tools": "commandlinetools-mac-10406996_latest.zip",
+        "sdk-tools": "sdk-tools-darwin-4333796.zip",
+        "platform_min_version": "33",
+        "build_tools_min_version": "33.0.2",
         "extra-list": [
             "android;m2repository", "google;m2repository", "google;google_play_services"
         ],
         "addon-list": [],
         "additional-tools": [
-            "cmake;3.18.1",
             "cmake;3.22.1"
         ],
         "ndk": {
-            "default": "25",
+            "default": "26",
             "versions": [
-                "23", "24", "25", "26"
+                "24", "25", "26"
             ]
         }
     },


### PR DESCRIPTION
# Description

enable android cmdtools on macos-13 arm64

#### Related issue:

https://github.com/actions/runner-images/issues/8515

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
