### PR TITLE
[macos] add retries to "brew install"

### DIFF
--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -192,6 +192,7 @@ brew_smart_install() {
 
         for dep in `cat /tmp/$tool_name`; do
 
+            failed=true
             for i in {1..10};
             do
                 brew --cache $dep && failed=false || sleep 60

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -177,8 +177,7 @@ brew_smart_install() {
         # get deps & cache em
 
         failed=true
-        for i in {1..10};
-        do
+        for i in {1..10}; do
             brew deps $tool_name > /tmp/$tool_name && failed=false || sleep 60
             if [ "$failed" = false ]; then
                 break
@@ -193,8 +192,7 @@ brew_smart_install() {
         for dep in `cat /tmp/$tool_name`; do
 
             failed=true
-            for i in {1..10};
-            do
+            for i in {1..10}; do
                 brew --cache $dep && failed=false || sleep 60
                 if [ "$failed" = false ]; then
                     break

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -189,7 +189,7 @@ brew_smart_install() {
            exit 1;
         fi
 
-        for dep in `cat /tmp/$tool_name`; do
+        for dep in $(cat /tmp/$tool_name); do
 
             failed=true
             for i in {1..10}; do

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -173,6 +173,39 @@ brew_smart_install() {
         brew install --build-from-source $tool_name
     else
         echo "Downloading $tool_name..."
+
+        # get deps & cache em
+
+        failed=true
+        for i in {1..10};
+        do
+            brew deps $tool_name > /tmp/$tool_name && failed=false || sleep 60
+            if [ "$failed" = false ]; then
+                break
+            fi
+        done
+
+        if [ "$failed" = true ]; then
+           echo "Failed: brew deps $tool_name"
+           exit 1;
+        fi
+
+        for dep in `cat /tmp/$tool_name`; do
+
+            for i in {1..10};
+            do
+                brew --cache $dep && failed=false || sleep 60
+                if [ "$failed" = false ]; then
+                    break
+                fi
+            done
+
+            if [ "$failed" = true ]; then
+               echo "Failed: brew --cache $dep"
+               exit 1;
+            fi
+        done
+
         brew install $tool_name
     fi
 }


### PR DESCRIPTION
# Description

sometimes "brew install" fails due to network timeout, let's use "brew --cache" with retries to make it more robust

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
