### PR TITLE
[Ubuntu] Add checksum validation for Aliyun CLI, CMake, Docker Compose v2

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -152,6 +152,41 @@ get_github_package_hash() {
     echo "$result"
 }
 
+download_hash_from_file() {
+    local url=$1
+    local keyword=$2
+    local optional_keyword=$3
+    local delimiter=${4:-' '}
+    local word_number=${5:-1}
+
+    if [[ -z "$keyword" || -z "$url" ]]; then
+        echo "File name and/or URL is not specified."
+        exit 1
+    fi
+
+    matching_line=$(curl -fsSL "$url" | tr -d '`' | grep "$keyword")
+    if [[ -n "$optional_keyword" ]]; then
+        matching_line=$(echo "$matching_line" | grep "$optional_keyword")
+        keyword="$keyword, $optional_keyword"
+    fi
+    if [[ "$(echo "$matching_line" | wc -l)" -gt 1 ]]; then
+        echo "Multiple lines found included the words: $keyword. Please specify a more specific filter."
+        exit 1
+    fi
+    if [[ -z "$matching_line" ]]; then
+        echo "Keywords ($keyword) not found in file with hashes."
+        exit 1
+    fi
+
+    result=$(echo "$matching_line" | cut -d "$delimiter" -f "$word_number" | tr -d -c '[:alnum:]')
+    if [[ -z "$result" ]]; then
+        echo "Empty result. Check parameters delimiter and/or word_number for the matching line."
+        exit 1
+    fi
+
+    echo "$result"
+}
+
 use_checksum_comparison() {
     local file_path=$1
     local checksum=$2

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -23,7 +23,7 @@ fi
 download_with_retries "$download_url" "/tmp" "aliyun-cli-linux-amd64.tgz"
 
 # Supply chain security - Alibaba Cloud CLI
-external_hash=$(download_hash_from_file "$hash_url" "aliyun-cli-linux" "amd64.tgz")
+external_hash=$(get_hash_from_remote_file "$hash_url" "aliyun-cli-linux" "amd64.tgz")
 use_checksum_comparison "/tmp/aliyun-cli-linux-amd64.tgz" "$external_hash"
 
 tar xzf /tmp/aliyun-cli-linux-amd64.tgz

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -2,6 +2,7 @@
 ################################################################################
 ##  File:  aliyun-cli.sh
 ##  Desc:  Installs Alibaba Cloud CLI
+##  Supply chain security: Alibaba Cloud CLI - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
@@ -11,14 +12,21 @@ source $HELPER_SCRIPTS/install.sh
 # Install Alibaba Cloud CLI
 # Pin tool version on ubuntu20 due to issues with GLIBC_2.32 not available
 if isUbuntu20; then
-    toolsetVersion=$(get_toolset_value '.aliyunCli.version')
-    downloadUrl="https://github.com/aliyun/aliyun-cli/releases/download/v$toolsetVersion/aliyun-cli-linux-$toolsetVersion-amd64.tgz"
+    toolset_version=$(get_toolset_value '.aliyunCli.version')
+    download_url="https://github.com/aliyun/aliyun-cli/releases/download/v$toolset_version/aliyun-cli-linux-$toolset_version-amd64.tgz"
+    hash_url="https://github.com/aliyun/aliyun-cli/releases/download/v$toolset_version/SHASUMS256.txt"
 else
-    downloadUrl="https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz"
+    download_url="https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz"
+    hash_url="https://github.com/aliyun/aliyun-cli/releases/latest/download/SHASUMS256.txt"
 fi
 
-download_with_retries $downloadUrl "/tmp"
-tar xzf /tmp/aliyun-cli-linux-*-amd64.tgz
+download_with_retries "$download_url" "/tmp" "aliyun-cli-linux-amd64.tgz"
+
+# Supply chain security - Alibaba Cloud CLI
+external_hash=$(download_hash_from_file "$hash_url" "aliyun-cli-linux" "amd64.tgz")
+use_checksum_comparison "/tmp/aliyun-cli-linux-amd64.tgz" "$external_hash"
+
+tar xzf /tmp/aliyun-cli-linux-amd64.tgz
 mv aliyun /usr/local/bin
 
 invoke_tests "CLI.Tools" "Aliyun CLI"

--- a/images/linux/scripts/installers/aliyun-cli.sh
+++ b/images/linux/scripts/installers/aliyun-cli.sh
@@ -16,17 +16,18 @@ if isUbuntu20; then
     download_url="https://github.com/aliyun/aliyun-cli/releases/download/v$toolset_version/aliyun-cli-linux-$toolset_version-amd64.tgz"
     hash_url="https://github.com/aliyun/aliyun-cli/releases/download/v$toolset_version/SHASUMS256.txt"
 else
-    download_url="https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz"
+    download_url=$(get_github_package_download_url "aliyun/aliyun-cli" "contains(\"aliyun-cli-linux\") and endswith(\"amd64.tgz\")")
     hash_url="https://github.com/aliyun/aliyun-cli/releases/latest/download/SHASUMS256.txt"
 fi
 
-download_with_retries "$download_url" "/tmp" "aliyun-cli-linux-amd64.tgz"
+package_name="aliyun-cli-linux-amd64.tgz"
+download_with_retries "$download_url" "/tmp" "$package_name"
 
 # Supply chain security - Alibaba Cloud CLI
 external_hash=$(get_hash_from_remote_file "$hash_url" "aliyun-cli-linux" "amd64.tgz")
-use_checksum_comparison "/tmp/aliyun-cli-linux-amd64.tgz" "$external_hash"
+use_checksum_comparison "/tmp/$package_name" "$external_hash"
 
-tar xzf /tmp/aliyun-cli-linux-amd64.tgz
+tar xzf "/tmp/$package_name"
 mv aliyun /usr/local/bin
 
 invoke_tests "CLI.Tools" "Aliyun CLI"

--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -2,6 +2,7 @@
 ################################################################################
 ##  File:  cmake.sh
 ##  Desc:  Installs CMake
+##  Supply chain security: CMake - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
@@ -12,9 +13,15 @@ echo "Checking to see if the installer script has already been run"
 if command -v cmake; then
     echo "cmake is already installed"
 else
-	downloadUrl=$(get_github_package_download_url "Kitware/CMake" "endswith(\"inux-x86_64.sh\")")
-	curl -fsSL ${downloadUrl} -o cmakeinstall.sh \
-	&& chmod +x cmakeinstall.sh \
+	# Download script to install CMake
+	download_url=$(get_github_package_download_url "Kitware/CMake" "endswith(\"inux-x86_64.sh\")")
+	curl -fsSL ${download_url} -o cmakeinstall.sh
+	# Supply chain security - CMake
+	hash_url=$(get_github_package_download_url "Kitware/CMake" "endswith(\"SHA-256.txt\")")
+	external_hash=$(download_hash_from_file "$hash_url" "linux-x86_64.sh")
+	use_checksum_comparison "cmakeinstall.sh" "$external_hash"
+	# Install CMake and remove the install script
+	chmod +x cmakeinstall.sh \
 	&& ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir \
 	&& rm cmakeinstall.sh
 fi

--- a/images/linux/scripts/installers/cmake.sh
+++ b/images/linux/scripts/installers/cmake.sh
@@ -15,10 +15,10 @@ if command -v cmake; then
 else
 	# Download script to install CMake
 	download_url=$(get_github_package_download_url "Kitware/CMake" "endswith(\"inux-x86_64.sh\")")
-	curl -fsSL ${download_url} -o cmakeinstall.sh
+	curl -fsSL "${download_url}" -o cmakeinstall.sh
 	# Supply chain security - CMake
 	hash_url=$(get_github_package_download_url "Kitware/CMake" "endswith(\"SHA-256.txt\")")
-	external_hash=$(download_hash_from_file "$hash_url" "linux-x86_64.sh")
+	external_hash=$(get_hash_from_remote_file "$hash_url" "linux-x86_64.sh")
 	use_checksum_comparison "cmakeinstall.sh" "$external_hash"
 	# Install CMake and remove the install script
 	chmod +x cmakeinstall.sh \

--- a/images/linux/scripts/installers/docker.sh
+++ b/images/linux/scripts/installers/docker.sh
@@ -20,14 +20,13 @@ apt-get install --no-install-recommends docker-ce docker-ce-cli containerd.io do
 
 # Install docker compose v2 from releases
 URL=$(get_github_package_download_url "docker/compose" "contains(\"compose-linux-x86_64\")")
-curl -fsSL $URL -o /tmp/docker-compose
+curl -fsSL "${URL}" -o /tmp/docker-compose
 # Supply chain security - CMake
 hash_url=$(get_github_package_download_url "docker/compose" "contains(\"checksums.txt\")")
-external_hash=$(download_hash_from_file "$hash_url" "compose-linux-x86_64")
+external_hash=$(get_hash_from_remote_file "$hash_url" "compose-linux-x86_64")
 use_checksum_comparison "/tmp/docker-compose" "$external_hash"
-# Move and make docker compose v2 executable
-mv /tmp/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
-chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+install /tmp/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
+
 
 # docker from official repo introduced different GID generation: https://github.com/actions/runner-images/issues/8157
 gid=$(cut -d ":" -f 3 /etc/group | grep "^1..$" | sort -n | tail -n 1 | awk '{ print $1+1 }')

--- a/images/linux/scripts/installers/docker.sh
+++ b/images/linux/scripts/installers/docker.sh
@@ -2,6 +2,7 @@
 ################################################################################
 ##  File:  docker.sh
 ##  Desc:  Installs docker onto the image
+##  Supply chain security: Docker Compose v2 - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
@@ -19,7 +20,13 @@ apt-get install --no-install-recommends docker-ce docker-ce-cli containerd.io do
 
 # Install docker compose v2 from releases
 URL=$(get_github_package_download_url "docker/compose" "contains(\"compose-linux-x86_64\")")
-curl -fsSL $URL -o /usr/libexec/docker/cli-plugins/docker-compose
+curl -fsSL $URL -o /tmp/docker-compose
+# Supply chain security - CMake
+hash_url=$(get_github_package_download_url "docker/compose" "contains(\"checksums.txt\")")
+external_hash=$(download_hash_from_file "$hash_url" "compose-linux-x86_64")
+use_checksum_comparison "/tmp/docker-compose" "$external_hash"
+# Move and make docker compose v2 executable
+mv /tmp/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 
 # docker from official repo introduced different GID generation: https://github.com/actions/runner-images/issues/8157


### PR DESCRIPTION
# Description

Add new helper `get_hash_from_remote_file()`
Update installer scripts with checksum for Aliyun CLI, CMake, Docker Compose v2 using `get_hash_from_remote_file()`

#### Related issue:

[#5491](https://github.com/actions/runner-images-internal/issues/5491)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
