### PR TITLE
[Windows] Rollback and pin Strawberry Perl

### DIFF
--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -441,7 +441,10 @@
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
             { "name": "packer" },
-            { "name": "strawberryperl" },
+            {
+                "name": "strawberryperl" ,
+                "args": [ "--version", "5.32.1.1" ]
+            },
             { "name": "pulumi" },
             { "name": "tortoisesvn" },
             { "name": "swig" },

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -381,7 +381,10 @@
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
             { "name": "packer" },
-            { "name": "strawberryperl" },
+            {
+                "name": "strawberryperl" ,
+                "args": [ "--version", "5.32.1.1" ]
+            },
             { "name": "pulumi" },
             { "name": "tortoisesvn" },
             { "name": "swig" },


### PR DESCRIPTION
# Description

Strawberry Perl bundles a lot of software that breaks other packages when appears in PATH. This PR pin it's version to avoid unexpected updates.

#### Related issue: https://github.com/actions/runner-images/issues/8598

CI builds: [Windows 2019](https://github.com/actions/runner-images-ci/actions/runs/6589026134), [Windows 2022](https://github.com/actions/runner-images-ci/actions/runs/6589026141)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
