### PR TITLE
[Ubuntu] fix the condition in docker.sh

### DIFF
--- a/images/linux/scripts/installers/docker.sh
+++ b/images/linux/scripts/installers/docker.sh
@@ -73,6 +73,6 @@ rm $gpg_key
 rm $repo_path
 
 invoke_tests "Tools" "Docker"
-if [ "${DOCKERHUB_PULL_IMAGES:-yes}" -eq "yes" ]; then
+if [ "${DOCKERHUB_PULL_IMAGES:-yes}" == "yes" ]; then
     invoke_tests "Tools" "Docker images"
 fi


### PR DESCRIPTION
# Description
Corrected omission in https://github.com/actions/runner-images/pull/7595.

Fix the condition in the file docker.sh
Instead of "-eq" we will use "=="
"==" is for string comparisons and "-eq" is for numeric ones.

#### Related issue:
https://github.com/actions/runner-images/pull/7595

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
