### PR TITLE
[Ubuntu] Add more checksum validations

### DIFF
--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -163,7 +163,7 @@ get_hash_from_remote_file() {
         exit 1
     fi
 
-    matching_line=$(curl -fsSL "$url" | sed 's/ \{1,\}/ /g' | tr -d '`')
+    matching_line=$(curl -fsSL "$url" | sed 's/  */ /g' | tr -d '`')
     for keyword in "${keywords[@]}"; do
         matching_line=$(echo "$matching_line" | grep "$keyword")
     done

--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -163,7 +163,7 @@ get_hash_from_remote_file() {
         exit 1
     fi
 
-    matching_line=$(curl -fsSL "$url" | tr -d '`')
+    matching_line=$(curl -fsSL "$url" | sed 's/  / /g' | tr -d '`')
     for keyword in "${keywords[@]}"; do
         matching_line=$(echo "$matching_line" | grep "$keyword")
     done

--- a/images/linux/scripts/helpers/install.sh
+++ b/images/linux/scripts/helpers/install.sh
@@ -163,7 +163,7 @@ get_hash_from_remote_file() {
         exit 1
     fi
 
-    matching_line=$(curl -fsSL "$url" | sed 's/  / /g' | tr -d '`')
+    matching_line=$(curl -fsSL "$url" | sed 's/ \{1,\}/ /g' | tr -d '`')
     for keyword in "${keywords[@]}"; do
         matching_line=$(echo "$matching_line" | grep "$keyword")
     done

--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -5,6 +5,9 @@
 ##  Supply chain security: Docker Compose v1 - checksum validation
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
 # Install docker-compose v1 from releases
 URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64"
 curl -fsSL "${URL}" -o /tmp/docker-compose-v1

--- a/images/linux/scripts/installers/docker-compose.sh
+++ b/images/linux/scripts/installers/docker-compose.sh
@@ -1,12 +1,17 @@
 #!/bin/bash -e
 ################################################################################
 ##  File:  docker-compose.sh
-##  Desc:  Installs Docker Compose
+##  Desc:  Installs Docker Compose v1
+##  Supply chain security: Docker Compose v1 - checksum validation
 ################################################################################
 
 # Install docker-compose v1 from releases
 URL="https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64"
-curl -fsSL $URL -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
+curl -fsSL "${URL}" -o /tmp/docker-compose-v1
+
+# Supply chain security - Docker Compose v1
+external_hash=$(get_hash_from_remote_file "${URL}.sha256" "compose-Linux-x86_64")
+use_checksum_comparison "/tmp/docker-compose-v1" "${external_hash}"
+install /tmp/docker-compose-v1 /usr/local/bin/docker-compose
 
 invoke_tests "Tools" "Docker-compose v1"

--- a/images/linux/scripts/installers/github-cli.sh
+++ b/images/linux/scripts/installers/github-cli.sh
@@ -3,14 +3,20 @@
 ##  File:  github-cli.sh
 ##  Desc:  Installs GitHub CLI
 ##         Must be run as non-root user after homebrew
+##  Supply chain security: GitHub CLI - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
+# Download GitHub CLI
+URL=$(get_github_package_download_url "cli/cli" "contains(\"linux\") and contains(\"amd64\") and contains(\".deb\")")
+download_with_retries "${URL}" "/tmp" "gh_cli_linux_amd64.deb"
+# Supply chain security - GitHub CLI
+hash_url=$(get_github_package_download_url "cli/cli" "contains(\"checksums.txt\")")
+external_hash=$(get_hash_from_remote_file "${hash_url}" "linux_amd64.deb")
+use_checksum_comparison "/tmp/gh_cli_linux_amd64.deb" "${external_hash}"
 # Install GitHub CLI
-downloadUrl=$(get_github_package_download_url "cli/cli" "contains(\"linux\") and contains(\"amd64\") and contains(\".deb\")")
-download_with_retries $downloadUrl "/tmp"
-apt install /tmp/gh_*_linux_amd64.deb
+apt install /tmp/gh_cli_linux_amd64.deb
 
 invoke_tests "CLI.Tools" "GitHub CLI"

--- a/images/linux/scripts/installers/kubernetes-tools.sh
+++ b/images/linux/scripts/installers/kubernetes-tools.sh
@@ -2,16 +2,20 @@
 ################################################################################
 ##  File:  kubernetes-tools.sh
 ##  Desc:  Installs kubectl, helm, kustomize
-##  Supply chain security: minikube - checksum validation
+##  Supply chain security: KIND, minikube - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
+# Download KIND
+kind_url=$(get_github_package_download_url "kubernetes-sigs/kind" "contains(\"kind-linux-amd64\")")
+curl -fsSL -o /tmp/kind "${kind_url}"
+# Supply chain security - KIND
+kind_external_hash=$(get_hash_from_remote_file "${kind_url}.sha256sum" "kind-linux-amd64")
+use_checksum_comparison "/tmp/kind" "${kind_external_hash}"
 # Install KIND
-URL=$(get_github_package_download_url "kubernetes-sigs/kind" "contains(\"kind-linux-amd64\")")
-curl -fsSL -o /usr/local/bin/kind $URL
-chmod +x /usr/local/bin/kind
+sudo install /tmp/kind /usr/local/bin/kind
 
 ## Install kubectl
 KUBECTL_MINOR_VERSION=$(curl -fsSL "https://dl.k8s.io/release/stable.txt" | cut -d'.' -f1,2 )
@@ -23,13 +27,12 @@ rm -f /etc/apt/sources.list.d/kubernetes.list
 # Install Helm
 curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
-# Install minikube
+# Download minikube
 curl -fsSL -O https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-
 # Supply chain security - minikube
 minikube_hash=$(get_github_package_hash "kubernetes" "minikube" "linux-amd64" "" "latest" "false" ":" 2)
-use_checksum_comparison "minikube-linux-amd64" "$minikube_hash"
-
+use_checksum_comparison "minikube-linux-amd64" "${minikube_hash}"
+# Install minikube
 sudo install minikube-linux-amd64 /usr/local/bin/minikube
 
 # Install kustomize

--- a/images/linux/scripts/installers/oras-cli.sh
+++ b/images/linux/scripts/installers/oras-cli.sh
@@ -2,17 +2,22 @@
 ################################################################################
 ##  File:  oras-cli.sh
 ##  Desc:  Installs ORAS CLI
+##  Supply chain security: ORAS CLI - checksum validation
 ################################################################################
 
 source $HELPER_SCRIPTS/install.sh
 
 # Determine latest ORAS CLI version
-ORAS_CLI_DOWNLOAD_URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")")
-ORAS_CLI_ARCHIVE=$(basename $ORAS_CLI_DOWNLOAD_URL)
+URL=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")")
+archive_name=$(basename "${URL}")
 
-# Install ORAS CLI
-cd /tmp
-download_with_retries $ORAS_CLI_DOWNLOAD_URL
-tar xzf $ORAS_CLI_ARCHIVE -C /usr/local/bin oras
+# Download ORAS CLI
+download_with_retries "${URL}" "/tmp" "${archive_name}"
+# Supply chain security - ORAS CLI
+hash_url=$(get_github_package_download_url "oras-project/oras" "contains(\"checksums.txt\")")
+external_hash=$(get_hash_from_remote_file "${hash_url}" "linux_amd64.tar.gz")
+use_checksum_comparison "/tmp/${archive_name}" "${external_hash}"
+# Unzip ORAS CLI
+tar xzf "/tmp/${archive_name}" -C /usr/local/bin oras
 
 invoke_tests "CLI.Tools" "Oras CLI"

--- a/images/linux/scripts/installers/pulumi.sh
+++ b/images/linux/scripts/installers/pulumi.sh
@@ -2,15 +2,20 @@
 ################################################################################
 ##  File:  pulumi.sh
 ##  Desc:  Installs Pulumi
+##  Supply chain security: Pulumi - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-# Install Pulumi
-VERSION=$(curl -fsSL "https://www.pulumi.com/latest-version")
-TARBALL_URL="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-linux-x64.tar.gz"
-download_with_retries ${TARBALL_URL} "/tmp" pulumi-v${VERSION}.tar.gz
-tar --strip=1 -xf /tmp/pulumi-v${VERSION}.tar.gz -C /usr/local/bin
+# Dowload Pulumi
+version=$(curl -fsSL "https://www.pulumi.com/latest-version")
+URL="https://get.pulumi.com/releases/sdk/pulumi-v${version}-linux-x64.tar.gz"
+download_with_retries "${URL}" "/tmp" "pulumi-v${version}.tar.gz"
+# Supply chain security - Pulumi
+external_hash=$(get_hash_from_remote_file "https://github.com/pulumi/pulumi/releases/download/v${version}/SHA512SUMS" "linux-x64.tar.gz")
+use_checksum_comparison "/tmp/pulumi-v${version}.tar.gz" "${external_hash}" "512"
+# Unzipping Pulumi
+tar --strip=1 -xf "/tmp/pulumi-v${version}.tar.gz" -C /usr/local/bin
 
 invoke_tests "Tools" "Pulumi"

--- a/images/linux/scripts/installers/yq.sh
+++ b/images/linux/scripts/installers/yq.sh
@@ -2,13 +2,19 @@
 ################################################################################
 ##  File:  yq.sh
 ##  Desc:  Installs YQ
+##  Supply chain security: YQ - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-YQ_URL="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
-download_with_retries "$YQ_URL" "/usr/bin" "yq"
-chmod +x /usr/bin/yq
+# Download YQ
+base_url="https://github.com/mikefarah/yq/releases/latest/download"
+download_with_retries "${base_url}/yq_linux_amd64" "/tmp" "yq"
+# Supply chain security - YQ
+external_hash=$(get_hash_from_remote_file "${base_url}/checksums" "yq_linux_amd64 " "" " " "19")
+use_checksum_comparison "/tmp/yq" "${external_hash}"
+# Install YQ
+sudo install /tmp/yq /usr/bin/yq
 
 invoke_tests "Tools" "yq"

--- a/images/linux/scripts/installers/zstd.sh
+++ b/images/linux/scripts/installers/zstd.sh
@@ -2,16 +2,22 @@
 ################################################################################
 ##  File:  zstd.sh
 ##  Desc:  Installs zstd
+##  Supply chain security: zstd - checksum validation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-apt-get install -y liblz4-dev
+# Download zstd
 release_tag=$(curl -fsSL https://api.github.com/repos/facebook/zstd/releases/latest | jq -r '.tag_name')
 zstd_tar_name=zstd-${release_tag//v}.tar.gz
 URL=https://github.com/facebook/zstd/releases/download/${release_tag}/${zstd_tar_name}
 download_with_retries "${URL}" "/tmp" "${zstd_tar_name}"
+# Supply chain security - zstd
+external_hash=$(get_hash_from_remote_file "${URL}.sha256" "${zstd_tar_name}")
+use_checksum_comparison "/tmp/${zstd_tar_name}" "${external_hash}"
+# Install zstd
+apt-get install -y liblz4-dev
 tar xzf /tmp/$zstd_tar_name -C /tmp
 make -C /tmp/zstd-${release_tag//v}/contrib/pzstd all
 make -C /tmp/zstd-${release_tag//v} zstd-release


### PR DESCRIPTION
# Description

- Add double space check to the `get_hash_from_remote_file()` function
- Fix some typos from previous PRs
- Add checksums for Docker Compose v1, amazon-ecr-credential-helper, GitHub CLI, Kind, ORAS CLI, Pulumi, yq, zstd

#### Related issue:
https://github.com/actions/runner-images-internal/issues/5491

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
