### PR TITLE
[Mac OS] Fix logic for retrying AppleScript execution

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -36,16 +36,20 @@ fi
 # System Preferences -> Security & Privacy -> General -> Unlock -> Allow -> Not now
 if is_Monterey; then
     if is_Veertu; then
-        echo "Executing AppleScript to change security preferences (with retries)"
-        retry=5
-        while [ $retry -gt 0 ]; do
+        for retry in {4..0}; do
+            echo "Executing AppleScript to change security preferences. Retries left: $retry"
             {
+                set -e
                 osascript -e 'tell application "System Events" to get application processes where visible is true'
-            }
-            osascript $HOME/utils/confirm-identified-developers.scpt $USER_PASSWORD
+                osascript $HOME/utils/confirm-identified-developers.scpt $USER_PASSWORD
+            } && break
 
-            retry=$((retry-1))
-            echo "retries left "$retry
+            if [ "$retry" -eq 0 ]; then
+                echo "Executing AppleScript failed. No retries left"
+                exit 1
+            fi
+
+            echo "Executing AppleScript failed. Sleeping for 10 seconds and retrying"
             sleep 10
         done
     else


### PR DESCRIPTION
# Description

This PR fixes broken retry logic for AppleScript that confirms identity for 'Parallels International GmbH'

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
