### PR TITLE
Build of ubuntu22 image fails due to mismatch libssl1.1  version

### DIFF
--- a/images/linux/scripts/installers/sqlpackage.sh
+++ b/images/linux/scripts/installers/sqlpackage.sh
@@ -10,8 +10,8 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install libssl1.1 dependency
 if isUbuntu22; then
-    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb" "/tmp"
-    dpkg -i /tmp/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
+    download_with_retries "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb" "/tmp"
+    dpkg -i /tmp/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb
 fi
 
 # Install SqlPackage


### PR DESCRIPTION
Installer script `sqlpackage` requires libssl1.1 dependency. There was hardcoded version `libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb` which is no more available at repository <http://security.ubuntu.com/ubuntu/pool/main/o/openssl> and because of that the build of ubuntu22 image is failing.

This PR fixes this issue to specify version `libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb`, which is available at the repository.

#### Related issue:

#8681

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
