### PR TITLE
[macOS] Remove AWS cli from macOS 13

### DIFF
--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -159,8 +159,6 @@ if ($os.IsBigSur) {
 }
 if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
     $tools.AddToolVersion("App Center CLI", $(Get-AppCenterCLIVersion))
-}
-if (-not $os.IsVenturaArm64) {
     $tools.AddToolVersion("AWS CLI", $(Get-AWSCLIVersion))
     $tools.AddToolVersion("AWS SAM CLI", $(Get-AWSSAMCLIVersion))
     $tools.AddToolVersion("AWS Session Manager CLI", $(Get-AWSSessionManagerCLIVersion))

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -199,7 +199,6 @@ build {
       "./provision/core/swiftlint.sh",
       "./provision/core/openjdk.sh",
       "./provision/core/php.sh",
-      "./provision/core/aws.sh",
       "./provision/core/rust.sh",
       "./provision/core/gcc.sh",
       "./provision/core/haskell.sh",

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -39,7 +39,7 @@ Describe "vcpkg" -Skip:($os.IsVenturaArm64) {
     }
 }
 
-Describe "AWS" -Skip:($os.IsVenturaArm64) {
+Describe "AWS" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
     It "AWS CLI" {
         "aws --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
Remove AWS cli from macOS 13

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
