### PR TITLE
[macos] remove redundant "xcode-clt.sh" invocation

### DIFF
--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -121,7 +121,6 @@ build {
   }
   provisioner "shell" {
     scripts = [
-      "./provision/core/xcode-clt.sh",
       "./provision/core/homebrew.sh"
     ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -122,7 +122,6 @@ build {
   }
   provisioner "shell" {
     scripts = [
-      "./provision/core/xcode-clt.sh",
       "./provision/core/homebrew.sh",
       "./provision/core/rosetta.sh"
     ]


### PR DESCRIPTION
# Description

xcode command line tools are installed by homebrew, no need to install ourselves

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
