### PR TITLE
Add gfortran-13 to ubuntu:22.04

### DIFF
--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -277,7 +277,8 @@
         "versions": [
             "gfortran-9",
             "gfortran-10",
-            "gfortran-12"
+            "gfortran-12",
+            "gfortran-13"
         ]
     },
     "php": {


### PR DESCRIPTION
# Description
The GCC 13 toolchain is missing gfortran-13.

This seems to be a recurring theme:

- https://github.com/actions/runner-images/pull/2103
- https://github.com/actions/runner-images/pull/6736

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
