### PR TITLE
fix: checksum search for Kotlin

### DIFF
--- a/images/linux/scripts/installers/kotlin.sh
+++ b/images/linux/scripts/installers/kotlin.sh
@@ -13,7 +13,7 @@ download_url=$(get_github_package_download_url "JetBrains/kotlin" "contains(\"ko
 download_with_retries "$download_url" "/tmp" "$kotlin_zip_name"
 
 # Supply chain security - Kotlin
-kotlin_hash=$(get_github_package_hash "JetBrains" "kotlin" "kotlin-compiler" "" "latest" "false" "|" 3)
+kotlin_hash=$(get_github_package_hash "JetBrains" "kotlin" "kotlin-compiler-.*\.zip" "" "latest" "false" "|" 3)
 use_checksum_comparison "/tmp/${kotlin_zip_name}" "$kotlin_hash"
 
 unzip -qq /tmp/${kotlin_zip_name} -d $KOTLIN_ROOT

--- a/images/win/scripts/Installers/Install-Kotlin.ps1
+++ b/images/win/scripts/Installers/Install-Kotlin.ps1
@@ -13,7 +13,7 @@ $kotlinInstallerPath = Start-DownloadWithRetry -Url $kotlinDownloadUrl -Name "$k
 
 #region Supply chain security
 $fileHash = (Get-FileHash -Path $kotlinInstallerPath -Algorithm SHA256).Hash
-$externalHash = Get-HashFromGitHubReleaseBody -RepoOwner "JetBrains" -RepoName "kotlin" -FileName "$kotlinBinaryName" -Version $kotlinVersion -WordNumber 2
+$externalHash = Get-HashFromGitHubReleaseBody -RepoOwner "JetBrains" -RepoName "kotlin" -FileName "$kotlinBinaryName-*.zip" -Version $kotlinVersion -WordNumber 2
 Use-ChecksumComparison $fileHash $externalHash
 #endregion
 


### PR DESCRIPTION
The [latest release notes](https://github.com/JetBrains/kotlin/releases/tag/v1.9.20) for Kotlin v1.9.20 includes multiple lines that contain the search string "kotlin-compiler", one of which is not the line that contains the checksum. This tweaks the search string to only look for the filename ending in `.zip`, where the checksum should be present.