### PR TITLE
Escape quotes when running in PowerShell 7.0-7.2

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -174,6 +174,10 @@ Function GenerateResourcesAndImage {
                 Write-Verbose "PowerShell 5 detected. Replacing double quotes with escaped double quotes in allowed inbound IP addresses."
                 $AllowedInboundIpAddresses = '[\"{0}\"]' -f $AgentIp
             }
+            elseif ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -le 2) {
+                Write-Verbose "PowerShell 7.0-7.2 detected. Replacing double quotes with escaped double quotes in allowed inbound IP addresses."
+                $AllowedInboundIpAddresses = '[\"{0}\"]' -f $AgentIp
+            }
             else {
                 $AllowedInboundIpAddresses = '["{0}"]' -f $AgentIp
             }
@@ -198,6 +202,10 @@ Function GenerateResourcesAndImage {
     $TagsJson = $Tags | ConvertTo-Json -Compress
     if ($PSVersionTable.PSVersion.Major -eq 5) {
         Write-Verbose "PowerShell 5 detected. Replacing double quotes with escaped double quotes in tags JSON."
+        $TagsJson = $TagsJson -replace '"', '\"'
+    }
+    elseif ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -le 2) {
+        Write-Verbose "PowerShell 7.0-7.2 detected. Replacing double quotes with escaped double quotes in tags JSON."
         $TagsJson = $TagsJson -replace '"', '\"'
     }
     Write-Debug "Tags JSON: $TagsJson."


### PR DESCRIPTION
# Description

Double quotes in command arguments should be escaped when running on PowerShell 7.0-7.2. It's especially important for us because Ubuntu runners still have PowerShell 7.2 installed.

This PR adds additional check for PowerShell version in order to handle double quotes correctly. See also this PR: #7613

#### Related issue: #8703

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
