### PR TITLE
[ubuntu] split git and git-lfs into separate install scripts

### DIFF
--- a/images/linux/scripts/installers/git-lfs.sh
+++ b/images/linux/scripts/installers/git-lfs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+################################################################################
+##  File:  git-lfs.sh
+##  Desc:  Installs Git-lfs
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
+GIT_LFS_REPO="https://packagecloud.io/install/repositories/github/git-lfs"
+
+# Install git-lfs
+curl -fsSL $GIT_LFS_REPO/script.deb.sh | bash
+apt-get install -y git-lfs
+
+# Remove source repo's
+rm /etc/apt/sources.list.d/github_git-lfs.list
+
+# Document apt source repo's
+echo "git-lfs $GIT_LFS_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
+
+invoke_tests "Tools" "Git-lfs"

--- a/images/linux/scripts/installers/git.sh
+++ b/images/linux/scripts/installers/git.sh
@@ -8,7 +8,6 @@
 source $HELPER_SCRIPTS/install.sh
 
 GIT_REPO="ppa:git-core/ppa"
-GIT_LFS_REPO="https://packagecloud.io/install/repositories/github/git-lfs"
 
 ## Install git
 add-apt-repository $GIT_REPO -y
@@ -21,20 +20,14 @@ cat <<EOF >> /etc/gitconfig
         directory = *
 EOF
 
-# Install git-lfs
-curl -fsSL $GIT_LFS_REPO/script.deb.sh | bash
-apt-get install -y git-lfs
-
 # Install git-ftp
 apt-get install git-ftp -y
 
 # Remove source repo's
 add-apt-repository --remove $GIT_REPO
-rm /etc/apt/sources.list.d/github_git-lfs.list
 
 # Document apt source repo's
 echo "git-core $GIT_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
-echo "git-lfs $GIT_LFS_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
 
 # Add well-known SSH host keys to known_hosts
 ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /etc/ssh/ssh_known_hosts

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -241,12 +241,14 @@ Describe "Git" {
         "git --version" | Should -ReturnZeroExitCode
     }
 
-    It "git-lfs" {
-        "git-lfs --version" | Should -ReturnZeroExitCode
-    }
-
     It "git-ftp" {
         "git-ftp --version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "Git-lfs" {
+    It "git-lfs" {
+        "git-lfs --version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -217,6 +217,7 @@
                 "{{template_dir}}/scripts/installers/gcc.sh",
                 "{{template_dir}}/scripts/installers/gfortran.sh",
                 "{{template_dir}}/scripts/installers/git.sh",
+                "{{template_dir}}/scripts/installers/git-lfs.sh",
                 "{{template_dir}}/scripts/installers/github-cli.sh",
                 "{{template_dir}}/scripts/installers/google-chrome.sh",
                 "{{template_dir}}/scripts/installers/google-cloud-cli.sh",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -300,6 +300,7 @@ build {
                         "${path.root}/scripts/installers/gcc.sh",
                         "${path.root}/scripts/installers/gfortran.sh",
                         "${path.root}/scripts/installers/git.sh",
+                        "${path.root}/scripts/installers/git-lfs.sh",
                         "${path.root}/scripts/installers/github-cli.sh",
                         "${path.root}/scripts/installers/google-chrome.sh",
                         "${path.root}/scripts/installers/google-cloud-cli.sh",

--- a/images/linux/ubuntuminimal.pkr.hcl
+++ b/images/linux/ubuntuminimal.pkr.hcl
@@ -257,6 +257,7 @@ build {
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
                         "${path.root}/scripts/installers/git.sh",
+                        "${path.root}/scripts/installers/git-lfs.sh",
                         "${path.root}/scripts/installers/github-cli.sh",
                         "${path.root}/scripts/installers/zstd.sh"
     ]


### PR DESCRIPTION
# Description

for better observability of integrity validation let us split install script into two

#### Related issue:

https://github.com/github/c2c-actions-akvelon/issues/38

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
