### PR TITLE
[macOS] Pin bindgen cli version to avoid bug

### DIFF
--- a/images/macos/provision/core/rust.sh
+++ b/images/macos/provision/core/rust.sh
@@ -12,7 +12,8 @@ CARGO_HOME=$HOME/.cargo
 
 echo Install common tools...
 rustup component add rustfmt clippy
-cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
+cargo install --locked bindgen-cli --version 0.68.1 # Temp fix for https://github.com/rust-lang/rust-bindgen/issues/2677
+cargo install --locked cbindgen cargo-audit cargo-outdated
 
 echo Cleanup Cargo registry cached data...
 rm -rf $CARGO_HOME/registry/*


### PR DESCRIPTION
# Description
Latest bindgen release has a bug. We should temporary pin previous release.

#### Related issue:

https://github.com/actions/runner-images/issues/8710

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
