### PR TITLE
[Ubuntu] Pin bindgen cli version to avoid bug

### DIFF
--- a/images/linux/scripts/installers/rust.sh
+++ b/images/linux/scripts/installers/rust.sh
@@ -20,9 +20,11 @@ source $CARGO_HOME/env
 rustup component add rustfmt clippy
 
 if isUbuntu22; then
-    cargo install bindgen-cli cbindgen cargo-audit cargo-outdated
+    cargo install bindgen-cli --version 0.68.1 # Temp fix for https://github.com/rust-lang/rust-bindgen/issues/2677
+    cargo install cbindgen cargo-audit cargo-outdated
 else
-    cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
+    cargo install --locked bindgen-cli --version 0.68.1 # Temp fix for https://github.com/rust-lang/rust-bindgen/issues/2677
+    cargo install --locked cbindgen cargo-audit cargo-outdated
 fi
 
 # Cleanup Cargo cache


### PR DESCRIPTION
# Description
Latest bindgen release has a bug. We should temporary pin previous release.

#### Related issue:

https://github.com/actions/runner-images/issues/8710

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
