### PR TITLE
[Mac OS] Temporary disable VNC for Mac OS 14

### DIFF
--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -182,6 +182,12 @@ Write-Host "`n[#2] Create a VM template:"
 Write-Host "`t[*] Deleting existed template with name '$TemplateName' before creating a new one"
 Remove-AnkaVM -VMName $TemplateName
 
+# Temporary disable VNC for macOS 14
+# It's probably Anka's bug fixed in 3.3.2
+if ($shortMacOSVersion -eq "14") {
+    $env:ANKA_CREATE_VNC = 0
+}
+
 Write-Host "`t[*] Creating Anka VM template with name '$TemplateName' and '$TemplateUsername' user"
 Write-Host "`t[*] CPU Count: $CPUCount, RamSize: ${RamSizeGb}G, DiskSizeGb: ${DiskSizeGb}G, InstallerPath: $macOSInstaller, TemplateName: $TemplateName"
 New-AnkaVMTemplate -InstallerPath "$macOSInstaller" `


### PR DESCRIPTION
# Description

This PR disables VNC initialization for Mac OS 14 images to be able to start testing base images generation.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
