### PR TITLE
[Windows] Remove Android SDK Patch applier v4

### DIFF
--- a/images/linux/scripts/tests/Android.Tests.ps1
+++ b/images/linux/scripts/tests/Android.Tests.ps1
@@ -33,7 +33,6 @@ Describe "Android" {
             # Convert 'm2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta1' ->
             #         'm2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta1'
             #         'cmake;3.6.4111459' -> 'cmake/3.6.4111459'
-            #         'patcher;v4' -> 'patcher/v4'
             $PackageName = $PackageName.Replace(";", "/")
             $targetPath = Join-Path $env:ANDROID_HOME $PackageName
             $targetPath | Should -Exist

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -170,8 +170,7 @@
         "additional_tools": [
             "cmake;3.10.2.4988404",
             "cmake;3.18.1",
-            "cmake;3.22.1",
-            "patcher;v4"
+            "cmake;3.22.1"
         ],
         "ndk": {
             "default": "25",

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -144,8 +144,7 @@
         "addon_list": [],
         "additional_tools": [
             "cmake;3.18.1",
-            "cmake;3.22.1",
-            "patcher;v4"
+            "cmake;3.22.1"
         ],
         "ndk": {
             "default": "25",


### PR DESCRIPTION
# Description

Android SDK Patch applier v4 not found in M2 Repository.

#### Related issue:

https://github.com/actions/runner-images/issues/8737

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
