### PR TITLE
[Mac OS] Remove 'LTS' suffix from OpenJDK version

### DIFF
--- a/images/macos/provision/core/openjdk.sh
+++ b/images/macos/provision/core/openjdk.sh
@@ -40,6 +40,9 @@ installOpenJDK() {
     archivePath=$(echo ${asset} | jq -r '.binary.package.link')
     fullVersion=$(echo ${asset} | jq -r '.version.semver' | tr '+' '-')
 
+    # Remove 'LTS' suffix from the version if present
+    fullVersion="${fullVersion//.LTS/}"
+
     JAVA_TOOLCACHE_PATH=${AGENT_TOOLSDIRECTORY}/Java_Temurin-Hotspot_jdk
     javaToolcacheVersionPath=$JAVA_TOOLCACHE_PATH/${fullVersion}
 


### PR DESCRIPTION
# Description

This pull request removes the 'LTS' suffix from the version if it is present to avoid issues with cached Java.

#### Related issue: -

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
