### PR TITLE
[Mac OS] Update Anka Helpers to build Mac OS 14 ARM image

### DIFF
--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -305,9 +305,7 @@ function Invoke-SSHPassCommand {
         "${env:SSHUSER}@${HostName}"
     )
     $sshPassOptions = $sshArg -join " "
-    if ($PSVersionTable.PSVersion.Major -eq 5) {
-        $result = bash -c "$sshPassOptions \""$Command\"" 2>&1"
-    } elseif ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -le 2) {
+    if ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -le 2) {
         $result = bash -c "$sshPassOptions \""$Command\"" 2>&1"
     } else {
         $result = bash -c "$sshPassOptions `"$Command`" 2>&1"


### PR DESCRIPTION
# Description
This pull request modifies `Get-AvailableIPSWVersions` function to return Mac OS Build ID instead of version. It also adds `--compatible` flag to the `mist list firmware` command.

#### Related issue: https://github.com/actions/runner-images-internal/issues/5569

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
