### PR TITLE
[Mac OS] Add missing MacOS Sonoma condition

### DIFF
--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -96,6 +96,8 @@ function Get-MacOSIPSWInstaller {
         $MacOSName = "macOS Monterey"
     } elseif ($MacOSVersion -eq [version] "13.0") {
         $MacOSName = "macOS Ventura"
+    } elseif ($MacOSVersion -eq [version] "14.0") {
+        $MacOSName = "macOS Sonoma"
     } else {
         $MacOSName = $MacOSVersion.ToString()
     }


### PR DESCRIPTION
# Description

This pull request adds a condition for MacOS Sonoma in the `Get-MacOSIPSWInstaller` function.

#### Related issue: https://github.com/actions/runner-images-internal/issues/5569

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
