### PR TITLE
[Mac OS] Configure template for Mac OS 14 ARM64 image

### DIFF
--- a/images/macos/helpers/Common.Helpers.psm1
+++ b/images/macos/helpers/Common.Helpers.psm1
@@ -30,13 +30,17 @@ function Get-OSVersion {
     $osVersionMajorMinor = $osVersion.Version.ToString(2)
     $processorArchitecture = arch
     return [PSCustomObject]@{
-        Version = $osVersion.Version
-        Platform = $osVersion.Platform
-        IsBigSur = $osVersion.Version.Major -eq "11"
-        IsMonterey = $osVersion.Version.Major -eq "12"
-        IsVentura = $($osVersion.Version.Major -eq "13" -and $processorArchitecture -ne "arm64")
+        Version        = $osVersion.Version
+        Platform       = $osVersion.Platform
+        IsArm64        = $processorArchitecture -eq "arm64"
+        IsBigSur       = $osVersion.Version.Major -eq "11"
+        IsMonterey     = $osVersion.Version.Major -eq "12"
+        IsVentura      = $($osVersion.Version.Major -eq "13")
         IsVenturaArm64 = $($osVersion.Version.Major -eq "13" -and $processorArchitecture -eq "arm64")
+        IsVenturaX64   = $($osVersion.Version.Major -eq "13" -and $processorArchitecture -ne "arm64")
         IsSonoma       = $($osVersion.Version.Major -eq "14")
+        IsSonomaArm64  = $($osVersion.Version.Major -eq "14" -and $processorArchitecture -eq "arm64")
+        IsSonomaX64    = $($osVersion.Version.Major -eq "14" -and $processorArchitecture -ne "arm64")
     }
 }
 

--- a/images/macos/helpers/Xcode.Installer.psm1
+++ b/images/macos/helpers/Xcode.Installer.psm1
@@ -132,7 +132,7 @@ function Approve-XcodeLicense {
     Write-Host "Approving Xcode license for '$XcodeRootPath'..."
     $xcodeBuildPath = Get-XcodeToolPath -XcodeRootPath $XcodeRootPath -ToolName "xcodebuild"
 
-    if ($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+    if ($os.IsVentura -or $os.IsSonoma) {
         Invoke-ValidateCommand -Command "sudo $xcodeBuildPath -license accept" -Timeout 15
     } else {
         Invoke-ValidateCommand -Command "sudo $xcodeBuildPath -license accept"

--- a/images/macos/provision/configuration/preimagedata.sh
+++ b/images/macos/provision/configuration/preimagedata.sh
@@ -17,7 +17,7 @@ else
 fi
 release_label="macOS-${label_version}"
 
-if is_Ventura || is_Sonoma; then
+if is_VenturaX64 || is_SonomaX64; then
   software_url="https://github.com/actions/runner-images/blob/${image_label}/${image_version}/images/macos/${image_label}-Readme.md"
   releaseUrl="https://github.com/actions/runner-images/releases/tag/${image_label}%2F${image_version}"
 else

--- a/images/macos/provision/core/open_windows_check.sh
+++ b/images/macos/provision/core/open_windows_check.sh
@@ -3,7 +3,7 @@
 source ~/utils/utils.sh
 
 # Close System Preferences window because in Ventura arm64 it is opened by default on Apperance tab
-if is_VenturaArm64; then
+if is_Arm64; then
     echo "Close System Preferences window"
     osascript -e 'tell application "System Preferences" to quit'
 fi

--- a/images/macos/provision/core/openssl.sh
+++ b/images/macos/provision/core/openssl.sh
@@ -4,7 +4,7 @@ source ~/utils/utils.sh
 echo "Install openssl@1.1"
 brew_smart_install "openssl@1.1"
 
-if ! is_VenturaArm64; then
+if ! is_Arm64; then
   # Symlink brew openssl@1.1 to `/usr/local/bin` as Homebrew refuses
   ln -sf $(brew --prefix openssl@1.1)/bin/openssl /usr/local/bin/openssl
 else
@@ -12,7 +12,7 @@ else
   ln -sf $(brew --prefix openssl@1.1)/bin/openssl /opt/homebrew/bin/openssl
 fi
 
-if ! is_VenturaArm64; then
+if ! is_Arm64; then
   # Most of buildsystems and scripts look up ssl here
   ln -sf $(brew --cellar openssl@1.1)/1.1* /usr/local/opt/openssl
 fi

--- a/images/macos/provision/core/ruby.sh
+++ b/images/macos/provision/core/ruby.sh
@@ -19,7 +19,7 @@ else
     echo 'export PATH="$GEM_PATH:/usr/local/opt/ruby@'${DEFAULT_RUBY_VERSION}'/bin:$PATH"'  >> "$HOME/.bashrc"
 fi
 
-if ! (is_VenturaArm64 || is_SonomaArm64); then
+if ! is_Arm64; then
     echo "Install Ruby from toolset..."
     [ -n "$API_PAT" ] && authString=(-H "Authorization: token ${API_PAT}")
     PACKAGE_TAR_NAMES=$(curl "${authString[@]}" -fsSL "https://api.github.com/repos/ruby/ruby-builder/releases/latest" | jq -r '.assets[].name')

--- a/images/macos/provision/core/ruby.sh
+++ b/images/macos/provision/core/ruby.sh
@@ -19,7 +19,7 @@ else
     echo 'export PATH="$GEM_PATH:/usr/local/opt/ruby@'${DEFAULT_RUBY_VERSION}'/bin:$PATH"'  >> "$HOME/.bashrc"
 fi
 
-if ! is_VenturaArm64; then
+if ! (is_VenturaArm64 || is_SonomaArm64); then
     echo "Install Ruby from toolset..."
     [ -n "$API_PAT" ] && authString=(-H "Authorization: token ${API_PAT}")
     PACKAGE_TAR_NAMES=$(curl "${authString[@]}" -fsSL "https://api.github.com/repos/ruby/ruby-builder/releases/latest" | jq -r '.assets[].name')

--- a/images/macos/provision/utils/utils.sh
+++ b/images/macos/provision/utils/utils.sh
@@ -46,53 +46,44 @@ download_with_retries() {
     return 1
 }
 
-is_VenturaArm64() {
-    arch=$(get_arch)
-    if [ "$OSTYPE" = "darwin22" ] && [ $arch = "arm64" ]; then
-       true
-    else
-       false
-    fi
+is_Arm64() {
+    [ "$(arch)" = "arm64" ]
 }
 
 is_Sonoma() {
-    if [ "$OSTYPE" = "darwin23" ]; then
-        true
-    else
-        false
-    fi
+    [ "$OSTYPE" = "darwin23" ]
+}
+
+is_SonomaArm64() {
+    is_Sonoma && is_Arm64
+}
+
+is_SonomaX64() {
+    is_Sonoma && ! is_Arm64
 }
 
 is_Ventura() {
-    if [ "$OSTYPE" = "darwin22" ]; then
-        true
-    else
-        false
-    fi
+    [ "$OSTYPE" = "darwin22" ]
+}
+
+is_VenturaArm64() {
+    is_Ventura && is_Arm64
+}
+
+is_VenturaX64() {
+    is_Ventura && ! is_Arm64
 }
 
 is_Monterey() {
-    if [ "$OSTYPE" = "darwin21" ]; then
-        true
-    else
-        false
-    fi
+    [ "$OSTYPE" = "darwin21" ]
 }
 
 is_BigSur() {
-    if [ "$OSTYPE" = "darwin20" ]; then
-        true
-    else
-        false
-    fi
+    [ "$OSTYPE" = "darwin20" ]
 }
 
 is_Veertu() {
-    if [ -d "/Library/Application Support/Veertu" ]; then
-        true
-    else
-        false
-    fi
+    [ -d "/Library/Application Support/Veertu" ]
 }
 
 get_toolset_path() {

--- a/images/macos/software-report/SoftwareReport.Browsers.psm1
+++ b/images/macos/software-report/SoftwareReport.Browsers.psm1
@@ -11,7 +11,7 @@ function Build-BrowserSection {
         [ToolVersionNode]::new("ChromeDriver", $(Get-ChromeDriverVersion))
     )
     
-    if (-not $os.IsVenturaArm64) {
+    if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
         $nodes += @(
             [ToolVersionNode]::new("Microsoft Edge", $(Get-EdgeVersion))
             [ToolVersionNode]::new("Microsoft Edge WebDriver", $(Get-EdgeDriverVersion))
@@ -79,7 +79,7 @@ function Get-GeckodriverVersion {
 
 function Get-SeleniumVersion {
     $os = Get-OSVersion
-    if ($os.IsVenturaArm64) {
+    if ($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         $cellarPath = "/opt/homebrew/Cellar"
     } else {
         $cellarPath = "/usr/local/Cellar"

--- a/images/macos/software-report/SoftwareReport.Generator.ps1
+++ b/images/macos/software-report/SoftwareReport.Generator.ps1
@@ -40,26 +40,26 @@ $languageAndRuntime.AddNodes($(Get-GccVersions))
 $languageAndRuntime.AddNodes($(Get-FortranVersions))
 $languageAndRuntime.AddToolVersion("Julia", $(Get-JuliaVersion))
 $languageAndRuntime.AddToolVersion("Kotlin", $(Get-KotlinVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $languageAndRuntime.AddToolVersion("Go", $(Get-GoVersion))
 }
 $languageAndRuntime.AddToolVersion("Mono", $(Get-MonoVersion))
 $languageAndRuntime.AddToolVersion("Node.js", $(Get-NodeVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $languageAndRuntime.AddToolVersion("MSBuild", $(Get-MSBuildVersion))
     $languageAndRuntime.AddToolVersion("NVM", $(Get-NVMVersion))
     $languageAndRuntime.AddToolVersionsListInline("NVM - Cached node versions", $(Get-NVMNodeVersionList), '^\d+')
 }
 $languageAndRuntime.AddToolVersion("Perl", $(Get-PerlVersion))
-if (-not $os.IsVenturaArm64) {
+if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $languageAndRuntime.AddToolVersion("PHP", $(Get-PHPVersion))
 }
 
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $languageAndRuntime.AddToolVersion("Python", $(Get-PythonVersion))
 }
 
-if (-not $os.IsVenturaArm64) {
+if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $languageAndRuntime.AddToolVersion("Python3", $(Get-Python3Version))
 }
 $languageAndRuntime.AddToolVersion("R", $(Get-RVersion))
@@ -70,31 +70,31 @@ $packageManagement = $installedSoftware.AddHeader("Package Management")
 $packageManagement.AddToolVersion("Bundler", $(Get-BundlerVersion))
 $packageManagement.AddToolVersion("Carthage", $(Get-CarthageVersion))
 $packageManagement.AddToolVersion("CocoaPods", $(Get-CocoaPodsVersion))
-if (-not $os.IsVenturaArm64) {
+if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $packageManagement.AddToolVersion("Composer", $(Get-ComposerVersion))
 }
 $packageManagement.AddToolVersion("Homebrew", $(Get-HomebrewVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $packageManagement.AddToolVersion("Miniconda", $(Get-CondaVersion))
 }
 $packageManagement.AddToolVersion("NPM", $(Get-NPMVersion))
 $packageManagement.AddToolVersion("NuGet", $(Get-NuGetVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $packageManagement.AddToolVersion("Pip", $(Get-PipVersion -Version 2))
 }
 
-if (-not $os.IsVenturaArm64) {
+if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $packageManagement.AddToolVersion("Pip3", $(Get-PipVersion -Version 3))
     $packageManagement.AddToolVersion("Pipx", $(Get-PipxVersion))
 }
 
 $packageManagement.AddToolVersion("RubyGems", $(Get-RubyGemsVersion))
-if (-not $os.IsVenturaArm64) {
+if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $packageManagement.AddToolVersion("Vcpkg", $(Get-VcpkgVersion))
 }
 $packageManagement.AddToolVersion("Yarn", $(Get-YarnVersion))
 
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $packageManagement.AddNode($(Build-PackageManagementEnvironmentTable))
 }
 # Project Management
@@ -102,7 +102,7 @@ $projectManagement = $installedSoftware.AddHeader("Project Management")
 $projectManagement.AddToolVersion("Apache Ant", $(Get-ApacheAntVersion))
 $projectManagement.AddToolVersion("Apache Maven", $(Get-MavenVersion))
 $projectManagement.AddToolVersion("Gradle", $(Get-GradleVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $projectManagement.AddToolVersion("Sbt", $(Get-SbtVersion))
 }
 
@@ -124,11 +124,11 @@ $utilities.AddToolVersion("gpg (GnuPG)", $(Get-GPGVersion))
 if ($os.IsBigSur) {
     $utilities.AddToolVersion("helm", $(Get-HelmVersion))
 }
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $utilities.AddToolVersion("ImageMagick", $(Get-ImageMagickVersion))
 }
 $utilities.AddToolVersion("jq", $(Get-JqVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $utilities.AddToolVersion("mongo", $(Get-MongoVersion))
     $utilities.AddToolVersion("mongod", $(Get-MongodVersion))
 }
@@ -138,7 +138,7 @@ if ($os.IsBigSur) {
 $utilities.AddToolVersion("OpenSSL", $(Get-OpenSSLVersion))
 $utilities.AddToolVersion("Packer", $(Get-PackerVersion))
 $utilities.AddToolVersion("pkg-config", $(Get-PKGConfigVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $utilities.AddToolVersion("PostgreSQL", $(Get-PostgresServerVersion))
     $utilities.AddToolVersion("psql (PostgreSQL)", $(Get-PostgresClientVersion))
     $utilities.AddToolVersion("Sox", $(Get-SoxVersion))
@@ -157,7 +157,7 @@ $tools = $installedSoftware.AddHeader("Tools")
 if ($os.IsBigSur) {
     $tools.AddToolVersion("Aliyun CLI", $(Get-AliyunCLIVersion))
 }
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $tools.AddToolVersion("App Center CLI", $(Get-AppCenterCLIVersion))
 }
 $tools.AddToolVersion("AWS CLI", $(Get-AWSCLIVersion))
@@ -166,7 +166,7 @@ $tools.AddToolVersion("AWS Session Manager CLI", $(Get-AWSSessionManagerCLIVersi
 $tools.AddToolVersion("Azure CLI", $(Get-AzureCLIVersion))
 $tools.AddToolVersion("Azure CLI (azure-devops)", $(Get-AzureDevopsVersion))
 $tools.AddToolVersion("Bicep CLI", $(Get-BicepVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $tools.AddToolVersion("Cabal", $(Get-CabalVersion))
 }
 $tools.AddToolVersion("Cmake", $(Get-CmakeVersion))
@@ -175,26 +175,26 @@ if ($os.IsMonterey) {
     $tools.AddToolVersion("Colima", $(Get-ColimaVersion))
 }
 $tools.AddToolVersion("Fastlane", $(Get-FastlaneVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $tools.AddToolVersion("GHC", $(Get-GHCVersion))
     $tools.AddToolVersion("GHCup", $(Get-GHCupVersion))
     $tools.AddToolVersion("Jazzy", $(Get-JazzyVersion))
 }
-if (-not $os.IsVenturaArm64) {
+if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $tools.AddToolVersion("Stack", $(Get-StackVersion))
 }
 $tools.AddToolVersion("SwiftFormat", $(Get-SwiftFormatVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $tools.AddToolVersion("Swig", $(Get-SwigVersion))
 }
 $tools.AddToolVersion("Xcode Command Line Tools", $(Get-XcodeCommandLineToolsVersion))
 
 # Linters
 $linters = $installedSoftware.AddHeader("Linters")
-if (-not $os.IsVenturaArm64) {
+if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $linters.AddToolVersion("SwiftLint", $(Get-SwiftLintVersion))
 }
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $linters.AddToolVersion("Yamllint", $(Get-YamllintVersion))
 }
 
@@ -220,7 +220,7 @@ if (-not $os.IsSonoma) {
     $rust.AddToolVersion("Rustup", $(Get-RustupVersion))
 
     $rustPackages = $rust.AddHeader("Packages")
-    if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64)) {
+    if (-not $os.IsVentura) {
         $rustPackages.AddToolVersion("Bindgen", $(Get-Bindgen))
         $rustPackages.AddToolVersion("Cargo-audit", $(Get-Cargoaudit))
         $rustPackages.AddToolVersion("Cargo-outdated", $(Get-Cargooutdated))
@@ -238,13 +238,13 @@ $powerShellModules = $powerShell.AddHeader("PowerShell Modules")
 $powerShellModules.AddNodes($(Get-PowerShellModules))
 
 # Web Servers
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $webServers = $installedSoftware.AddHeader("Web Servers")
     $webServers.AddTable($(Build-WebServersSection))
 }
 
 # Xamarin section
-if ((-not $os.IsVentura) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $xamarin = $installedSoftware.AddHeader("Xamarin")
     $vsForMac = $xamarin.AddHeader("Visual Studio for Mac")
     $vsForMac.AddTable($(Build-VSMacTable))

--- a/images/macos/software-report/SoftwareReport.Java.psm1
+++ b/images/macos/software-report/SoftwareReport.Java.psm1
@@ -2,7 +2,7 @@ function Get-JavaVersions {
     $defaultJavaPath = (Get-Item env:JAVA_HOME).value
     
     $os = Get-OSVersion
-    if ($os.IsVenturaArm64) {
+    if ($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         $javaVersions = Get-Item env:JAVA_HOME_*_arm64
     } else {
         $javaVersions = Get-Item env:JAVA_HOME_*_X64

--- a/images/macos/software-report/SoftwareReport.Toolcache.psm1
+++ b/images/macos/software-report/SoftwareReport.Toolcache.psm1
@@ -37,7 +37,7 @@ function Build-ToolcacheSection {
 
     $nodes = @()
 
-    if (-not $os.IsVenturaArm64) {
+    if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
         $nodes += @(
             [ToolVersionsListNode]::new("Ruby", $(Get-ToolcacheRubyVersions), '^\d+\.\d+', "List"),
             [ToolVersionsListNode]::new("PyPy", $(Get-ToolcachePyPyVersions), '^\d+\.\d+', "List")

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -1,0 +1,237 @@
+packer {
+  required_plugins {
+    veertu-anka = {
+      version = ">= v3.2.0"
+      source = "github.com/veertuinc/veertu-anka"
+    }
+  }
+}
+
+variable "source_vm_name" {
+  type = string
+}
+
+variable "source_vm_tag" {
+  type = string
+}
+
+variable "build_id" {
+  type = string
+}
+
+variable "vm_username" {
+  type = string
+  sensitive = true
+}
+
+variable "vm_password" {
+  type = string
+  sensitive = true
+}
+
+variable "github_api_pat" {
+  type = string
+  default = ""
+}
+
+variable "xcode_install_storage_url" {
+  type = string
+  sensitive = true
+}
+
+variable "xcode_install_sas" {
+  type = string
+  sensitive = true
+}
+
+variable "vcpu_count" {
+  type = string
+  default = "6"
+}
+
+variable "ram_size" {
+  type = string
+  default = "8G"
+}
+
+variable "image_os" {
+  type = string
+  default = "macos14"
+}
+
+source "veertu-anka-vm-clone" "template" {
+  vm_name = "${var.build_id}"
+  source_vm_name = "${var.source_vm_name}"
+  source_vm_tag = "${var.source_vm_tag}"
+  vcpu_count = "${var.vcpu_count}"
+  ram_size = "${var.ram_size}"
+  stop_vm = "true"
+  log_level = "debug"
+}
+
+build {
+  sources = [
+    "source.veertu-anka-vm-clone.template"
+  ]
+  provisioner "shell" {
+    inline = [
+      "mkdir ~/image-generation"
+    ]
+  }
+  provisioner "file" {
+    destination = "image-generation/"
+    sources = [
+      "./provision/assets",
+      "./tests",
+      "./software-report",
+      "./helpers"
+    ]
+  }
+  provisioner "file" {
+    destination = "image-generation/software-report/"
+    source = "../../helpers/software-report-base"
+  }
+  provisioner "file" {
+    destination = "image-generation/add-certificate.swift"
+    source = "./provision/configuration/add-certificate.swift"
+  }
+  provisioner "file" {
+    destination = ".bashrc"
+    source = "./provision/configuration/environment/bashrc"
+  }
+  provisioner "file" {
+    destination = ".bash_profile"
+    source = "./provision/configuration/environment/bashprofile"
+  }
+  provisioner "file" {
+    destination = "./"
+    source = "./provision/utils"
+  }
+  provisioner "shell" {
+    inline = [
+      "mkdir ~/bootstrap"
+    ]
+  }
+  provisioner "file" {
+    destination = "bootstrap"
+    source = "./provision/bootstrap-provisioner/"
+  }
+  provisioner "file" {
+    destination = "image-generation/toolset.json"
+    source = "./toolsets/toolset-14.json"
+  }
+  provisioner "shell" {
+    scripts = [
+      "./provision/core/xcode-clt.sh",
+      "./provision/core/homebrew.sh",
+      "./provision/core/rosetta.sh"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    scripts = [
+      "./provision/configuration/configure-tccdb-macos.sh",
+      "./provision/configuration/disable-auto-updates.sh",
+      "./provision/configuration/ntpconf.sh",
+      "./provision/configuration/shell-change.sh"
+    ]
+    environment_vars = [
+      "PASSWORD=${var.vm_password}",
+      "USERNAME=${var.vm_username}"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    scripts = [
+      "./provision/configuration/preimagedata.sh",
+      "./provision/configuration/configure-ssh.sh",
+      "./provision/configuration/configure-machine.sh"
+    ]
+    environment_vars = [
+      "IMAGE_VERSION=${var.build_id}",
+      "IMAGE_OS=${var.image_os}",
+      "PASSWORD=${var.vm_password}"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    script  = "./provision/core/reboot.sh"
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    pause_before = "30s"
+    scripts = [
+      "./provision/core/open_windows_check.sh",
+      "./provision/core/powershell.sh",
+      "./provision/core/mono.sh",
+      "./provision/core/dotnet.sh",
+      "./provision/core/azcopy.sh",
+      "./provision/core/openssl.sh",
+      "./provision/core/ruby.sh",
+      "./provision/core/rubygem.sh",
+      "./provision/core/git.sh",
+      "./provision/core/node.sh",
+      "./provision/core/commonutils.sh"
+    ]
+    environment_vars = [
+      "API_PAT=${var.github_api_pat}",
+      "USER_PASSWORD=${var.vm_password}"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    script = "./provision/core/xcode.ps1"
+    environment_vars = [
+      "XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}",
+      "XCODE_INSTALL_SAS=${var.xcode_install_sas}"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+  }
+  provisioner "shell" {
+    script = "./provision/core/reboot.sh"
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+    expect_disconnect = true
+  }
+  provisioner "shell" {
+    scripts = [
+      "./provision/core/action-archive-cache.sh",
+      "./provision/core/llvm.sh",
+      "./provision/core/openjdk.sh",
+      "./provision/core/aws.sh",
+      "./provision/core/rust.sh",
+      "./provision/core/gcc.sh",
+      "./provision/core/cocoapods.sh",
+      "./provision/core/android-toolsets.sh",
+      "./provision/core/safari.sh",
+      "./provision/core/chrome.sh",
+      "./provision/core/bicep.sh",
+      "./provision/core/codeql-bundle.sh"
+    ]
+    environment_vars = [
+      "API_PAT=${var.github_api_pat}"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "shell" {
+    script = "./provision/core/delete-duplicate-sims.rb"
+    execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
+  }
+  provisioner "shell" {
+    inline = [
+      "pwsh -File \"$HOME/image-generation/software-report/SoftwareReport.Generator.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}"
+    ]
+    execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+  provisioner "file" {
+    destination = "../image-output/"
+    direction = "download"
+    source = "./image-generation/output/"
+  }
+  provisioner "shell" {
+    scripts = [
+      "./provision/configuration/configure-hostname.sh"
+    ]
+    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+  }
+}

--- a/images/macos/tests/BasicTools.Tests.ps1
+++ b/images/macos/tests/BasicTools.Tests.ps1
@@ -25,7 +25,7 @@ Describe "cmake" {
     }
 }
 
-Describe "Subversion" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Subversion" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Subversion" {
         "svn --version" | Should -ReturnZeroExitCode
     }
@@ -61,7 +61,7 @@ Describe "Perl" {
     }
 }
 
-Describe "Helm" -Skip:($os.IsMonterey -or $os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Helm" -Skip:($os.IsMonterey -or $os.IsVentura -or $os.IsSonoma) {
     It "Helm" {
         "helm version --short" | Should -ReturnZeroExitCode
     }
@@ -116,7 +116,7 @@ Describe "bazel" {
     }
 }
 
-Describe "Aliyun CLI" -Skip:($os.IsMonterey -or $os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Aliyun CLI" -Skip:($os.IsMonterey -or $os.IsVentura -or $os.IsSonoma) {
     It "Aliyun CLI" {
         "aliyun --version" | Should -ReturnZeroExitCode
     }
@@ -146,13 +146,13 @@ Describe "wget" {
     }
 }
 
-Describe "vagrant" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "vagrant" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsSonoma) {
     It "vagrant" {
         "vagrant --version" | Should -ReturnZeroExitCode
     }
 }
 
-Describe "virtualbox" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "virtualbox" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsSonoma) {
     It "virtualbox" {
         "vboxmanage -v" | Should -ReturnZeroExitCode
     }
@@ -178,7 +178,7 @@ Describe "Kotlin" {
     }
 }
 
-Describe "sbt" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "sbt" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "sbt" {
         "sbt -version" | Should -ReturnZeroExitCode
     }
@@ -190,7 +190,7 @@ Describe "yq" {
     }
 }
 
-Describe "imagemagick" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "imagemagick" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "imagemagick" {
         "magick -version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Browsers.Tests.ps1
+++ b/images/macos/tests/Browsers.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Chrome" {
 Describe "Selenium server" {
     It "Selenium server" {
         $os = Get-OSVersion
-        if ($os.IsVenturaArm64) {
+        if ($os.IsArm64) {
             $cellarPath = "/opt/homebrew/Cellar"
         } else {
             $cellarPath = "/usr/local/Cellar"
@@ -40,7 +40,7 @@ Describe "Selenium server" {
     }
 }
 
-Describe "Edge" -Skip:($os.IsVenturaArm64) {
+Describe "Edge" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "Microsoft Edge" {
         $edgeLocation = "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
         $edgeLocation | Should -Exist
@@ -52,7 +52,7 @@ Describe "Edge" -Skip:($os.IsVenturaArm64) {
     }
 }
 
-Describe "Firefox" -Skip:($os.IsVenturaArm64) {
+Describe "Firefox" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "Firefox" {
         $firefoxLocation = "/Applications/Firefox.app/Contents/MacOS/firefox"
         $firefoxLocation | Should -Exist

--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -10,7 +10,7 @@ Describe ".NET" {
 }
 
 Describe "GCC" {
-    $testCases = Get-ToolsetValue -KeyPath gcc.versions | ForEach-Object { @{Version = $_} }
+    $testCases = Get-ToolsetValue -KeyPath gcc.versions | ForEach-Object { @{Version = $_ } }
 
     It "GCC <Version>" -TestCases $testCases {
         param (
@@ -33,7 +33,7 @@ Describe "GCC" {
     }
 }
 
-Describe "vcpkg" -Skip:($os.IsVenturaArm64) {
+Describe "vcpkg" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "vcpkg" {
         "vcpkg version" | Should -ReturnZeroExitCode
     }
@@ -58,7 +58,7 @@ Describe "AzCopy" {
     }
 }
 
-Describe "Miniconda" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Miniconda" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Conda" {
         Get-EnvironmentVariable "CONDA" | Should -Not -BeNullOrEmpty
         $condaBinPath = Join-Path $env:CONDA "bin" "conda"
@@ -66,7 +66,7 @@ Describe "Miniconda" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonom
     }
 }
 
-Describe "Stack" -Skip:($os.IsVenturaArm64) {
+Describe "Stack" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "Stack" {
         "stack --version" | Should -ReturnZeroExitCode
     }
@@ -78,7 +78,7 @@ Describe "CocoaPods" {
     }
 }
 
-Describe "VSMac" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "VSMac" -Skip:($os.IsVentura -or $os.IsSonoma) {
     $vsMacVersions = Get-ToolsetValue "xamarin.vsmac.versions"
     $defaultVSMacVersion = Get-ToolsetValue "xamarin.vsmac.default"
 
@@ -105,7 +105,7 @@ Describe "VSMac" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
     }
 }
 
-Describe "Swig" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Swig" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Swig" {
         "swig -version" | Should -ReturnZeroExitCode
     }
@@ -117,13 +117,13 @@ Describe "Bicep" {
     }
 }
 
-Describe "Go" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Go" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Go" {
         "go version" | Should -ReturnZeroExitCode
     }
 }
 
-Describe "VirtualBox" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "VirtualBox" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsSonoma) {
     It "Check kext kernel modules" {
         kextstat | Out-String | Should -Match "org.virtualbox.kext"
     }
@@ -141,7 +141,7 @@ Describe "CodeQL Bundle" {
     }
 }
 
-Describe "Colima" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Colima" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Colima" {
         "colima version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Databases.Tests.ps1
+++ b/images/macos/tests/Databases.Tests.ps1
@@ -2,7 +2,7 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 
 $os = Get-OSVersion
 
-Describe "MongoDB" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "MongoDB" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "<ToolName>" -TestCases @(
         @{ ToolName = "mongo" }
         @{ ToolName = "mongod" }
@@ -12,7 +12,7 @@ Describe "MongoDB" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma)
     }
 }
 
-Describe "PostgreSQL" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "PostgreSQL" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "PostgreSQL version should correspond to the version in the toolset" {
         $toolsetVersion = Get-ToolsetValue 'postgresql.version'
         # Client version

--- a/images/macos/tests/Haskell.Tests.ps1
+++ b/images/macos/tests/Haskell.Tests.ps1
@@ -1,7 +1,7 @@
 Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 $os = Get-OSVersion
 
-Describe "Haskell" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Haskell" -Skip:($os.IsVentura -or $os.IsSonoma) {
     Context "GHCup" {
         It "GHCup" {
             "ghcup --version" | Should -ReturnZeroExitCode

--- a/images/macos/tests/Java.Tests.ps1
+++ b/images/macos/tests/Java.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Java" {
     $defaultVersion = $toolsetJava.$arch.default
     $jdkVersions = $toolsetJava.$arch.versions
 
-    if ($os.IsVenturaArm64) {
+    if ($os.IsArm64) {
         $testCases = $jdkVersions | ForEach-Object { @{ Title = $_; Version = (Get-NativeVersionFormat $_); EnvVariable = "JAVA_HOME_${_}_arm64" } }
     } else {
         $testCases = $jdkVersions | ForEach-Object { @{ Title = $_; Version = (Get-NativeVersionFormat $_); EnvVariable = "JAVA_HOME_${_}_X64" } }
@@ -71,11 +71,11 @@ Describe "Java" {
                 "gradle --version" | Should -ReturnZeroExitCode
             }
 
-            It "Gradle is installed to /usr/local/bin" -Skip:($os.IsVenturaArm64)  {
+            It "Gradle is installed to /usr/local/bin" -Skip:($os.IsArm64) {
                 (Get-Command "gradle").Path | Should -BeExactly "/usr/local/bin/gradle"
             }
 
-            It "Gradle is installed to /opt/homebrew/bin/gradle" -Skip:(-not $os.IsVenturaArm64)  {
+            It "Gradle is installed to /opt/homebrew/bin/gradle" -Skip:(-not $os.IsArm64) {
                 (Get-Command "gradle").Path | Should -BeExactly "/opt/homebrew/bin/gradle"
             }
         }

--- a/images/macos/tests/Linters.Tests.ps1
+++ b/images/macos/tests/Linters.Tests.ps1
@@ -2,7 +2,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "SwiftLint" -Skip:($os.IsVenturaArm64) {
+Describe "SwiftLint" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "SwiftLint" {
         "swiftlint version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Node.Tests.ps1
+++ b/images/macos/tests/Node.Tests.ps1
@@ -21,7 +21,7 @@ Describe "Node.js" {
     }
 }
 
-Describe "nvm" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "nvm" -Skip:($os.IsVentura -or $os.IsSonoma) {
     BeforeAll {
         $nvmPath = Join-Path $env:HOME ".nvm" "nvm.sh"
         $nvmInitCommand = ". $nvmPath > /dev/null 2>&1 || true"

--- a/images/macos/tests/PHP.Tests.ps1
+++ b/images/macos/tests/PHP.Tests.ps1
@@ -2,7 +2,7 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 $os = Get-OSVersion
 
 Describe "PHP" {
-    Context "PHP" -Skip:($os.IsVenturaArm64) {
+    Context "PHP" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         It "PHP Path" {
             Get-WhichTool "php" | Should -Not -BeLike "/usr/bin/php*"
         }
@@ -13,7 +13,7 @@ Describe "PHP" {
         }
     }
 
-    Context "Composer" -Skip:($os.IsVenturaArm64) {
+    Context "Composer" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         It "Composer" {
             "composer --version" | Should -ReturnZeroExitCode
         }

--- a/images/macos/tests/PipxPackages.Tests.ps1
+++ b/images/macos/tests/PipxPackages.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 
 $os = Get-OSVersion
 
-Describe "PipxPackages" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "PipxPackages" -Skip:($os.IsVentura -or $os.IsSonoma) {
     $pipxToolset = Get-ToolsetValue "pipx"
     $testCases = $pipxToolset | ForEach-Object { @{package = $_.package; cmd = $_.cmd} }
     It "<package>" -TestCases $testCases {

--- a/images/macos/tests/Python.Tests.ps1
+++ b/images/macos/tests/Python.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Python3" -Skip:($os.IsVenturaArm64) {
+Describe "Python3" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "Python 3 is available" {
         "python3 --version" | Should -ReturnZeroExitCode
     }
@@ -28,7 +28,7 @@ Describe "Python3" -Skip:($os.IsVenturaArm64) {
 
 }
 
-Describe "Python2" -Skip:($os.IsVenturaArm64 -or $os.IsVentura -or $os.IsSonoma) {
+Describe "Python2" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Python 2 is available" {
         "/Library/Frameworks/Python.framework/Versions/2.7/bin/python --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Ruby.arm64.Tests.ps1
+++ b/images/macos/tests/Ruby.arm64.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Ruby" -Skip:($os.IsBigSur -or $os.IsMonterey -or $os.IsVenturaX64 -or $os.IsSonomaX64) {
+Describe "Ruby" -Skip:(-not $os.IsArm64) {
     It "Ruby is available" {
         "ruby --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Ruby.arm64.Tests.ps1
+++ b/images/macos/tests/Ruby.arm64.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Ruby" -Skip:($os.IsVentura -or $os.IsBigSur -or $os.IsMonterey -or $os.IsSonoma) {
+Describe "Ruby" -Skip:($os.IsBigSur -or $os.IsMonterey -or $os.IsVenturaX64 -or $os.IsSonomaX64) {
     It "Ruby is available" {
         "ruby --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Ruby.x64.Tests.ps1
+++ b/images/macos/tests/Ruby.x64.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Ruby" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
+Describe "Ruby" -Skip:($os.IsArm64) {
     It "Ruby is available" {
         "ruby --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Ruby.x64.Tests.ps1
+++ b/images/macos/tests/Ruby.x64.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
 
-Describe "Ruby" -Skip:($os.IsVenturaArm64) {
+Describe "Ruby" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "Ruby is available" {
         "ruby --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/RubyGem.Tests.ps1
+++ b/images/macos/tests/RubyGem.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Bundler" {
     }
 }
 
-Describe "Nomad shenzhen CLI" -Skip:($os.IsMonterey -or $os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Nomad shenzhen CLI" -Skip:($os.IsMonterey -or $os.IsVentura -or $os.IsSonoma) {
     It "Nomad shenzhen CLI" {
         "ipa --version" | Should -ReturnZeroExitCode
     }
@@ -38,7 +38,7 @@ Describe "xcpretty" {
     }
 }
 
-Describe "jazzy" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "jazzy" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "jazzy" {
         "jazzy --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Rust.Tests.ps1
+++ b/images/macos/tests/Rust.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Rust" {
             "cargo --version" | Should -ReturnZeroExitCode
         }
     }
-    Context "Cargo dependencies" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+    Context "Cargo dependencies" -Skip:($os.IsVentura -or $os.IsSonoma) {
         It "bindgen" {
             "bindgen --version" | Should -ReturnZeroExitCode
         }

--- a/images/macos/tests/System.Tests.ps1
+++ b/images/macos/tests/System.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Certificate" {
     }
 }
 
-Describe "Audio device" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Audio device" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Sox is installed" {
         "sox --version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Toolcache.Tests.ps1
+++ b/images/macos/tests/Toolcache.Tests.ps1
@@ -57,7 +57,7 @@ Describe "Toolcache" {
         }
     }
 
-    Context "Ruby" -Skip:($os.IsVenturaArm64) {
+    Context "Ruby" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         $rubyDirectory = Join-Path $toolcacheDirectory "Ruby"
         $rubyPackage = $packages | Where-Object { $_.ToolName -eq "Ruby" } | Select-Object -First 1
         $testCase = @{ RubyDirectory = $rubyDirectory }
@@ -99,7 +99,7 @@ Describe "Toolcache" {
             }
         }
     }
-    Context "PyPy" -Skip:($os.IsVenturaArm64) {
+    Context "PyPy" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         $pypyDirectory = Join-Path $toolcacheDirectory "PyPy"
         $pypyPackage = $packages | Where-Object { $_.ToolName -eq "pypy" } | Select-Object -First 1
         $testCase = @{ PypyDirectory = $pypyDirectory }

--- a/images/macos/tests/WebServers.Tests.ps1
+++ b/images/macos/tests/WebServers.Tests.ps1
@@ -2,7 +2,7 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 
 $os = Get-OSVersion
 
-Describe "Apache" -Skip:($os.IsVenturaArm64) {
+Describe "Apache" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
     It "Apache CLI" {
         "httpd -v" | Should -ReturnZeroExitCode
     }
@@ -12,7 +12,7 @@ Describe "Apache" -Skip:($os.IsVenturaArm64) {
     }
 }
 
-Describe "Nginx" -Skip:($os.IsVentura -or $os.IsVenturaArm64) {
+Describe "Nginx" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Nginx CLI" {
         "nginx -v" | Should -ReturnZeroExitCode
     }

--- a/images/macos/tests/Xamarin.Tests.ps1
+++ b/images/macos/tests/Xamarin.Tests.ps1
@@ -2,7 +2,7 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 Import-Module "$PSScriptRoot/../helpers/Tests.Helpers.psm1" -DisableNameChecking
 
 $os = Get-OSVersion
-if ($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+if ($os.IsVentura -or $os.IsSonoma) {
     $MONO_VERSIONS = @(Get-ToolsetValue "mono.framework.version")
     $XAMARIN_IOS_VERSIONS = @()
     $XAMARIN_MAC_VERSIONS = @()
@@ -89,7 +89,7 @@ Describe "Mono" {
     }
 }
 
-Describe "Xamarin.iOS" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Xamarin.iOS" -Skip:($os.IsVentura -or $os.IsSonoma) {
     $XAMARIN_IOS_VERSIONS | ForEach-Object {
         Context "$_" {
             $XAMARIN_IOS_VERSIONS_PATH = "/Library/Frameworks/Xamarin.iOS.framework/Versions"
@@ -122,7 +122,7 @@ Describe "Xamarin.iOS" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSon
     }
 }
 
-Describe "Xamarin.Mac" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Xamarin.Mac" -Skip:($os.IsVentura -or $os.IsSonoma) {
     $XAMARIN_MAC_VERSIONS | ForEach-Object {
         Context "$_" {
             $XAMARIN_MAC_VERSIONS_PATH = "/Library/Frameworks/Xamarin.Mac.framework/Versions"
@@ -155,7 +155,7 @@ Describe "Xamarin.Mac" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSon
     }
 }
 
-Describe "Xamarin.Android" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Xamarin.Android" -Skip:($os.IsVentura -or $os.IsSonoma) {
     $XAMARIN_ANDROID_VERSIONS | ForEach-Object {
         Context "$_" {
             $XAMARIN_ANDROID_VERSIONS_PATH = "/Library/Frameworks/Xamarin.Android.framework/Versions"
@@ -195,7 +195,7 @@ Describe "Xamarin.Android" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.I
     }
 }
 
-Describe "Xamarin Bundles" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Xamarin Bundles" -Skip:($os.IsVentura -or $os.IsSonoma) {
     BeforeAll {
         $MONO_VERSIONS_PATH = "/Library/Frameworks/Mono.framework/Versions"
         $XAMARIN_IOS_VERSIONS_PATH = "/Library/Frameworks/Xamarin.iOS.framework/Versions"
@@ -302,7 +302,7 @@ Describe "Xamarin Bundles" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.I
     }
 }
 
-Describe "Nuget" -Skip:($os.IsVentura -or $os.IsVenturaArm64 -or $os.IsSonoma) {
+Describe "Nuget" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Nuget config contains nuget.org feed" {
         Get-Content $env:HOME/.config/NuGet/NuGet.Config | Out-String | Should -Match "nuget.org"
     }


### PR DESCRIPTION
# Description

This PR adds new variables and conditions to support creation of ARM-based macOS 14 Sonoma images.

Also it changes fields of the object that `Get-OSVersion` function returns in order to improve code readability:
- Adds `IsArm64` field;
- Adds `IsSonomaArm64`, `IsSonomaX64` and `IsVenturaX64` fields;
- Makes field `IsVentura` architecture-agnostic.

#### Related issue

Closes https://github.com/actions/runner-images-internal/issues/5570

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
