### PR TITLE
[Windows] Set user agent header to get mysql patch version

### DIFF
--- a/images/win/scripts/Installers/Install-MysqlCli.ps1
+++ b/images/win/scripts/Installers/Install-MysqlCli.ps1
@@ -16,7 +16,7 @@ Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentLi
 $MysqlVersionMajorMinor = $MysqlVersion.ToString(2)
 
 if ($MysqlVersion.Build -lt 0) {
-    $MysqlVersion = (Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html" -Headers @{'Accept'='text/html'} |
+    $MysqlVersion = (Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html" -Headers @{ 'User-Agent'='curl/8.4.0' } |
         Select-String -Pattern "${MysqlVersionMajorMinor}\.\d+").Matches.Value
 }
 


### PR DESCRIPTION
# Description
For those of us building an image from this repo in AWS, the `Invoke-WebRequest` call to https://dev.mysql.com/downloads/mysql/8.0.html has been failing for awhile with a 403 Forbidden, even with the `Accept` header that was added back in #8009. The protection/filtering they have on that page from their CDN provider seems to have greater restrictions on requests coming from EC2 IPs. This issue is easily replicated in the free tier of AWS.

We tested setting various combinations of headers and cookies, including this version which works with pwsh but not PowerShell 5.1 (can't customize the `Connection` header in 5.1)
```
Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/8.0.html" -Headers @{
    'Accept'='text/html';
    'Accept-Encoding'='gzip';
    'Connection'='keep-alive';
    'Accept-Language'='en-US'
}
```

We'd be happy with the above solution too, I could either edit this PR or submit a different one if this is preferred. But the proposed solution here to set the user agent to act as `curl` was the simplest one we could come up with, while also ensuring it can continue to build in Azure/GitHub too.

I know supporting AWS isn't a primary concern of this repository, but my hope here is that it would make builds in Azure/GitHub more resilient in the future too. If this change isn't desired, we are able to override the script coming from this repo, so it isn't a huge deal for us.

#### Related issue:
#8004

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
