### PR TITLE
[macos11] Unlink brew ghc and cabal-install

### DIFF
--- a/images/macos/provision/core/haskell.sh
+++ b/images/macos/provision/core/haskell.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e -o pipefail
 
+source ~/utils/utils.sh
+
+# https://github.com/actions/runner-images/issues/8738
+if is_BigSur; then
+    (brew list ghc > /dev/null 2>&1) && brew unlink ghc
+    (brew list cabal-install > /dev/null 2>&1) && brew unlink cabal-install
+fi
+
 curl --proto '=https' --tlsv1.2 -fsSL https://get-ghcup.haskell.org | sh
 export PATH="$HOME/.ghcup/bin:$PATH"
 echo 'export PATH="$PATH:$HOME/.ghcup/bin"' >> "$HOME/.bashrc"

--- a/images/macos/provision/core/haskell.sh
+++ b/images/macos/provision/core/haskell.sh
@@ -4,8 +4,7 @@ source ~/utils/utils.sh
 
 # https://github.com/actions/runner-images/issues/8738
 if is_BigSur; then
-    (brew list ghc > /dev/null 2>&1) && brew unlink ghc
-    (brew list cabal-install > /dev/null 2>&1) && brew unlink cabal-install
+    brew unlink ghc cabal-install
 fi
 
 curl --proto '=https' --tlsv1.2 -fsSL https://get-ghcup.haskell.org | sh


### PR DESCRIPTION
# Description
With brew deprecation on macos-11, `ghc` and `cabal-install` are installed by brew as dependency of `yq` when building from source. Links cause conflicts with `ghc` from `ghcup`. This PR unlinks brew packages

#### Related issue: https://github.com/actions/runner-images/issues/8738

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
