### PR TITLE
Add PSResourceGet (PowerShellGet replacement) to PowerShell module toolset for all images

### DIFF
--- a/images/linux/Ubuntu2004-Readme.md
+++ b/images/linux/Ubuntu2004-Readme.md
@@ -251,6 +251,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - Az (Cached): 3.1.0.zip, 4.4.0.zip, 5.9.0.zip, 6.6.0.zip, 7.5.0.zip
 - MarkdownPS: 1.9
 - Microsoft.Graph: 2.8.0
+- Microsoft.PowerShell.PSResourceGet: 1.0.1
 - Pester: 5.5.0
 - PSScriptAnalyzer: 1.21.0
 

--- a/images/linux/Ubuntu2204-Readme.md
+++ b/images/linux/Ubuntu2204-Readme.md
@@ -236,6 +236,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - Az: 9.3.0
 - MarkdownPS: 1.9
 - Microsoft.Graph: 2.8.0
+- Microsoft.PowerShell.PSResourceGet: 1.0.1
 - Pester: 5.5.0
 - PSScriptAnalyzer: 1.21.0
 

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -105,7 +105,8 @@
         {"name": "MarkdownPS"},
         {"name": "Microsoft.Graph"},
         {"name": "Pester"},
-        {"name": "PSScriptAnalyzer"}
+        {"name": "PSScriptAnalyzer"},
+        {"name": "Microsoft.PowerShell.PSResourceGet"}
     ],
     "azureModules": [
         {

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -99,7 +99,8 @@
         {"name": "MarkdownPS"},
         {"name": "Microsoft.Graph"},
         {"name": "Pester"},
-        {"name": "PSScriptAnalyzer"}
+        {"name": "PSScriptAnalyzer"},
+        {"name": "Microsoft.PowerShell.PSResourceGet"}
     ],
     "azureModules": [
         {

--- a/images/win/Windows2019-Readme.md
+++ b/images/win/Windows2019-Readme.md
@@ -513,6 +513,7 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 - DockerMsftProvider: 1.0.0.8
 - MarkdownPS: 1.9
 - Microsoft.Graph: 2.8.0
+- Microsoft.PowerShell.PSResourceGet: 1.0.1
 - Pester: 3.4.0, 5.5.0
 - PowerShellGet: 1.0.0.1, 2.2.5
 - PSScriptAnalyzer: 1.21.0

--- a/images/win/Windows2022-Readme.md
+++ b/images/win/Windows2022-Readme.md
@@ -554,6 +554,7 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 - DockerMsftProvider: 1.0.0.8
 - MarkdownPS: 1.9
 - Microsoft.Graph: 2.8.0
+- Microsoft.PowerShell.PSResourceGet: 1.0.1
 - Pester: 3.4.0, 5.5.0
 - PowerShellGet: 1.0.0.1, 2.2.5
 - PSScriptAnalyzer: 1.21.0

--- a/images/win/toolsets/toolset-2019.json
+++ b/images/win/toolsets/toolset-2019.json
@@ -90,7 +90,9 @@
         {"name": "SqlServer"},
         {"name": "VSSetup"},
         {"name": "Microsoft.Graph"},
-        {"name": "AWSPowershell"}
+        {"name": "AWSPowershell"},
+        {"name": "Microsoft.PowerShell.PSResourceGet"}
+
     ],
     "azureModules": [
         {

--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -87,7 +87,8 @@
         { "name": "SqlServer" },
         { "name": "VSSetup" },
         { "name": "Microsoft.Graph" },
-        {"name": "AWSPowershell"}
+        { "name": "AWSPowershell" },
+        { "name": "Microsoft.PowerShell.PSResourceGet" }
     ],
     "azureModules": [
         {


### PR DESCRIPTION
# Description
This PR adds [PSResourceGet](https://github.com/PowerShell/PSResourceGet) - the [recently-GAed](https://devblogs.microsoft.com/powershell/psresourceget-is-generally-available/) successor to PowerShellGet (PowerShell's package manager) - to the PowerShell module portions of all Linux and Windows toolsets.

Per the directions on the contribution guidelines, I've left the MacOS toolsets untouched - as these also have PowerShell modules declared, someone else will need to update the toolsets.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

Documentation has been updated with the _current_ version of PSResourceGet, but I don't see these versions being declared in the toolsets themselves so I don't know how version adherence is being asserted within tests. This module is under active development and has already had a patch release in its first month of GA, so it's possible v1.0.2 will land while this PR is open.

The new module is ~5MB in unpacked size - installation time is going to vary based on connectivity to the PowerShell Gallery and storage media, but is generally less than 10 seconds.

#### Related issue: 
Fixes #8785.

## Check list
- [X] Related issue / work item is attached
- [X] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
