### PR TITLE
[macOS] Exclude macOS 13 and 14 from "Stack" test.

### DIFF
--- a/images/macos/tests/Common.Tests.ps1
+++ b/images/macos/tests/Common.Tests.ps1
@@ -66,7 +66,7 @@ Describe "Miniconda" -Skip:($os.IsVentura -or $os.IsSonoma) {
     }
 }
 
-Describe "Stack" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
+Describe "Stack" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "Stack" {
         "stack --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
Exclude macOS 13 and 14 from the "Stack" test.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/5585

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
