### PR TITLE
[macOS] Reconsider YQ installation on macOS 11

### DIFF
--- a/images/macos/provision/core/commonutils.sh
+++ b/images/macos/provision/core/commonutils.sh
@@ -1,6 +1,12 @@
 #!/bin/bash -e -o pipefail
 source ~/utils/utils.sh
 
+# Download and install YQ in cases when it is not available in the formulae as for macOS 11: https://formulae.brew.sh/formula/yq
+if is_BigSur; then
+    download_with_retries "https://github.com/mikefarah/yq/releases/latest/download/yq_darwin_amd64" "/tmp" "yq"
+    sudo install /tmp/yq /usr/local/bin/yq
+fi
+
 # Monterey needs future review:
 # aliyun-cli, gnupg, helm have issues with building from the source code.
 # Added gmp for now, because toolcache ruby needs its libs. Remove it when php starts to build from source code.

--- a/images/macos/provision/core/haskell.sh
+++ b/images/macos/provision/core/haskell.sh
@@ -2,11 +2,6 @@
 
 source ~/utils/utils.sh
 
-# https://github.com/actions/runner-images/issues/8738
-if is_BigSur; then
-    brew unlink ghc cabal-install
-fi
-
 curl --proto '=https' --tlsv1.2 -fsSL https://get-ghcup.haskell.org | sh
 export PATH="$HOME/.ghcup/bin:$PATH"
 echo 'export PATH="$PATH:$HOME/.ghcup/bin"' >> "$HOME/.bashrc"

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -220,7 +220,6 @@
             "libxft",
             "tcl-tk",
             "r",
-            "yq",
             "imagemagick"
         ],
         "cask_packages": [


### PR DESCRIPTION
# Description

- Updating YQ installation for macOS Big Sur due to this OS deprecation in Homebrew.
- Reverting previous YQ related changes

#### Related issue:

[#5587](https://github.com/actions/runner-images-internal/issues/5587)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
