### PR TITLE
[Windows] Move .NET 7.0 to the toolset due to the new Visual Studio version

### DIFF
--- a/images/win/toolsets/toolset-2022.json
+++ b/images/win/toolsets/toolset-2022.json
@@ -177,7 +177,7 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "6E78B3DCE2998F6C2457C3E54DA90A01034916AE",
+        "signature": "72105B6D5F370B62FD5C82F1512F7AD7DEE5F2C0",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",
@@ -346,7 +346,8 @@
     },
     "dotnet": {
         "versions": [
-            "6.0"
+            "6.0",
+            "7.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }


### PR DESCRIPTION
# Description
Move .NET 7.0 to the toolset due to the new Visual Studio version

#### Related issue:
https://github.com/actions/runner-images/issues/8797

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
