### PR TITLE
[Ubuntu] Added DotNet 8 to Ubuntu.

### DIFF
--- a/images/linux/Ubuntu2004-Readme.md
+++ b/images/linux/Ubuntu2004-Readme.md
@@ -179,7 +179,7 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 | SELENIUM_JAR_PATH | /usr/share/java/selenium-server.jar   |
 
 ### .NET Tools
-- .NET Core SDK: 6.0.416, 7.0.113, 7.0.203, 7.0.310, 7.0.403
+- .NET Core SDK: 6.0.416, 7.0.113, 7.0.203, 7.0.310, 7.0.403, 8.0.100
 - nbgv 3.6.133+2d32d93cb1
 
 ### Databases

--- a/images/linux/Ubuntu2204-Readme.md
+++ b/images/linux/Ubuntu2204-Readme.md
@@ -172,7 +172,7 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 | SELENIUM_JAR_PATH | /usr/share/java/selenium-server.jar   |
 
 ### .NET Tools
-- .NET Core SDK: 6.0.416, 7.0.113, 7.0.203, 7.0.310, 7.0.403
+- .NET Core SDK: 6.0.416, 7.0.113, 7.0.203, 7.0.310, 7.0.403, 8.0.100
 - nbgv 3.6.133+2d32d93cb1
 
 ### Databases

--- a/images/linux/toolsets/toolset-2004.json
+++ b/images/linux/toolsets/toolset-2004.json
@@ -258,11 +258,13 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0"
+            "dotnet-sdk-7.0",
+            "dotnet-sdk-8.0"
         ],
         "versions": [
             "6.0",
-            "7.0"
+            "7.0",
+            "8.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }

--- a/images/linux/toolsets/toolset-2204.json
+++ b/images/linux/toolsets/toolset-2204.json
@@ -247,11 +247,13 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0"
+            "dotnet-sdk-7.0",
+            "dotnet-sdk-8.0"
         ],
         "versions": [
             "6.0",
-            "7.0"
+            "7.0",
+            "8.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }


### PR DESCRIPTION
# Description
Dear GitHub Team.
The new DotNet 8 was released yesterday. This patch should, allow developers to use the new version.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
