### PR TITLE
[ubuntu] Fix software report download directory

### DIFF
--- a/images/ubuntu/templates/ubuntu-20.04.json
+++ b/images/ubuntu/templates/ubuntu-20.04.json
@@ -350,13 +350,13 @@
         {
             "type": "file",
             "source": "{{user `image_folder`}}/software-report.md",
-            "destination": "{{template_dir}}/Ubuntu2004-Readme.md",
+            "destination": "{{template_dir}}/../Ubuntu2004-Readme.md",
             "direction": "download"
         },
         {
             "type": "file",
             "source": "{{user `image_folder`}}/software-report.json",
-            "destination": "{{template_dir}}/software-report.json",
+            "destination": "{{template_dir}}/../software-report.json",
             "direction": "download"
         },
         {

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -390,13 +390,13 @@ build {
   }
 
   provisioner "file" {
-    destination = "${path.root}/Ubuntu2204-Readme.md"
+    destination = "${path.root}/../Ubuntu2204-Readme.md"
     direction   = "download"
     source      = "${var.image_folder}/software-report.md"
   }
 
   provisioner "file" {
-    destination = "${path.root}/software-report.json"
+    destination = "${path.root}/../software-report.json"
     direction   = "download"
     source      = "${var.image_folder}/software-report.json"
   }


### PR DESCRIPTION
# Description
PR fixes download location for Software Report and Readme on ubuntu

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
