### PR TITLE
[ubuntu] Fix template names in GenerateResourcesAndImage.ps1

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -24,10 +24,10 @@ Function Get-PackerTemplatePath {
             $relativeTemplatePath = Join-Path "windows" "templates" "windows-2022.json"
         }
         ([ImageType]::Ubuntu2004) {
-            $relativeTemplatePath = Join-Path "ubuntu" "templates" "ubuntu-2004.json"
+            $relativeTemplatePath = Join-Path "ubuntu" "templates" "ubuntu-20.04.json"
         }
         ([ImageType]::Ubuntu2204) {
-            $relativeTemplatePath = Join-Path "ubuntu" "templates" "ubuntu-2204.pkr.hcl"
+            $relativeTemplatePath = Join-Path "ubuntu" "templates" "ubuntu-22.04.pkr.hcl"
         }
         ([ImageType]::UbuntuMinimal) {
             $relativeTemplatePath = Join-Path "ubuntu" "templates" "ubuntu-minimal.pkr.hcl"


### PR DESCRIPTION
# Description
PR fixes incorrect packer template names for ubuntu in GenerateResourcesAndImage.ps1

#### Related issue: https://github.com/actions/runner-images/issues/8813

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
