### PR TITLE
[macOS] Exclude "Stack" from software report for macOS 13 and 14

### DIFF
--- a/images/macos/scripts/docs-gen/SoftwareReport.Generator.ps1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Generator.ps1
@@ -179,8 +179,6 @@ if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $tools.AddToolVersion("GHC", $(Get-GHCVersion))
     $tools.AddToolVersion("GHCup", $(Get-GHCupVersion))
     $tools.AddToolVersion("Jazzy", $(Get-JazzyVersion))
-}
-if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $tools.AddToolVersion("Stack", $(Get-StackVersion))
 }
 $tools.AddToolVersion("SwiftFormat", $(Get-SwiftFormatVersion))


### PR DESCRIPTION
# Description
Exclude "Stack" from software report

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
