### PR TITLE
[macOS] Add xcodes and xcbeautify to macOS images

### DIFF
--- a/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -626,3 +626,13 @@ function Get-PKGConfigVersion {
     $pkgconfigVersion = Run-Command "pkg-config --version"
     return $pkgconfigVersion
 }
+
+function Get-XcbeautifyVersion {
+    $XcbeautifyVersion = Run-Command "xcbeautify --version"
+    return $XcbeautifyVersion
+}
+
+function Get-XcodesVersion {
+    $XcodesVersion = Run-Command "xcodes version"
+    return $XcodesVersion
+}

--- a/images/macos/scripts/docs-gen/SoftwareReport.Generator.ps1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Generator.ps1
@@ -185,7 +185,13 @@ $tools.AddToolVersion("SwiftFormat", $(Get-SwiftFormatVersion))
 if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $tools.AddToolVersion("Swig", $(Get-SwigVersion))
 }
+if (-not $os.IsBigSur) {
+    $tools.AddToolVersion("Xcbeautify", $(Get-XcbeautifyVersion))
+}
 $tools.AddToolVersion("Xcode Command Line Tools", $(Get-XcodeCommandLineToolsVersion))
+if (-not $os.IsBigSur) {
+    $tools.AddToolVersion("Xcodes", $(Get-XcodesVersion))
+}
 
 # Linters
 $linters = $installedSoftware.AddHeader("Linters")

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -206,7 +206,9 @@
             "r",
             "yq",
             "imagemagick",
-            "unxip"
+            "unxip",
+            "xcbeautify",
+            "xcodes"
         ],
         "cask_packages": [
             "julia",

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -74,7 +74,9 @@
             "gmp",
             "r",
             "yq",
-            "unxip"
+            "unxip",
+            "xcbeautify",
+            "xcodes"
         ],
         "cask_packages": [
             "julia"

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -70,7 +70,9 @@
             "gmp",
             "r",
             "yq",
-            "unxip"
+            "unxip",
+            "xcbeautify",
+            "xcodes"
         ],
         "cask_packages": [
             "julia"


### PR DESCRIPTION
# Description

Adding xcodes and xcbeautify to all images except macOS Big Sur.

#### Related issue:

#8827 

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
