### PR TITLE
[Ubuntu] Remove Ubuntu:16.04 & Ubuntu:18.04 docker images

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -241,8 +241,6 @@
             "node:16-alpine",
             "node:18-alpine",
             "node:20-alpine",
-            "ubuntu:16.04",
-            "ubuntu:18.04",
             "ubuntu:20.04"
         ]
     },

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -230,7 +230,6 @@
             "node:16-alpine",
             "node:18-alpine",
             "node:20-alpine",
-            "ubuntu:18.04",
             "ubuntu:20.04",
             "ubuntu:22.04"
         ]


### PR DESCRIPTION
# Description

This PR remove Ubuntu:16.04 & Ubuntu:18.04 docker images from runner-images

#### Related issue:

https://github.com/actions/runner-images/issues/8776

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
