### PR TITLE
[Ubuntu] Remove Nodejs 14.x 

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -34,7 +34,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "14.*",
                 "16.*",
                 "18.*",
                 "20.*"
@@ -233,11 +232,9 @@
             "debian:10",
             "debian:11",
             "moby/buildkit:latest",
-            "node:14",
             "node:16",
             "node:18",
             "node:20",
-            "node:14-alpine",
             "node:16-alpine",
             "node:18-alpine",
             "node:20-alpine",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -32,7 +32,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "14.*",
                 "16.*",
                 "18.*",
                 "20.*"
@@ -222,11 +221,9 @@
             "debian:10",
             "debian:11",
             "moby/buildkit:latest",
-            "node:14",
             "node:16",
             "node:18",
             "node:20",
-            "node:14-alpine",
             "node:16-alpine",
             "node:18-alpine",
             "node:20-alpine",


### PR DESCRIPTION
# Description

Remove Nodejs 14.x  from ubuntu images

#### Related issue:

https://github.com/actions/runner-images/issues/8779

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
