### PR TITLE
[Windows] Implement installation helpers refactoring

### DIFF
--- a/images/windows/scripts/build/Install-AWSTools.ps1
+++ b/images/windows/scripts/build/Install-AWSTools.ps1
@@ -10,7 +10,7 @@ Install-ChocoPackage awscli
 # Install Session Manager Plugin for the AWS CLI
 Install-Binary `
   -Url "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe" `
-  -Args ("/silent", "/install") `
+  -InstallArgs ("/silent", "/install") `
   -ExpectedSignature "FF457E5732E98A9F156E657F8CC7C4432507C3BB"
 $env:Path = $env:Path + ";$env:ProgramFiles\Amazon\SessionManagerPlugin\bin"
 

--- a/images/windows/scripts/build/Install-AWSTools.ps1
+++ b/images/windows/scripts/build/Install-AWSTools.ps1
@@ -5,26 +5,21 @@
 ################################################################################
 
 # Install AWS CLI
-Choco-Install -PackageName awscli
+Install-ChocoPackage awscli
 
 # Install Session Manager Plugin for the AWS CLI
-$sessionManagerName = "SessionManagerPluginSetup.exe"
-$sessionManagerUrl = "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/$sessionManagerName"
-$sessionManagerSignatureThumbprint = "FF457E5732E98A9F156E657F8CC7C4432507C3BB"
-Install-Binary -Url $sessionManagerUrl -Name $sessionManagerName -ArgumentList ("/silent", "/install") -ExpectedSignature $sessionManagerSignatureThumbprint
+Install-Binary `
+  -Url "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe" `
+  -Args ("/silent", "/install") `
+  -ExpectedSignature "FF457E5732E98A9F156E657F8CC7C4432507C3BB"
 $env:Path = $env:Path + ";$env:ProgramFiles\Amazon\SessionManagerPlugin\bin"
 
 # Install AWS SAM CLI
 $packageName = "AWS_SAM_CLI_64_PY3.msi"
 $packageUrl = "https://github.com/awslabs/aws-sam-cli/releases/latest/download/$packageName"
-$packagePath = Start-DownloadWithRetry -Url $packageUrl -Name $packageName
-
-#region Supply chain security - AWS SAM CLI
-$fileHash = (Get-FileHash -Path $packagePath -Algorithm SHA256).Hash
 $externalHash = Get-HashFromGitHubReleaseBody -RepoOwner "awslabs" -RepoName "aws-sam-cli" -FileName $packageName
-Use-ChecksumComparison $fileHash $externalHash
-#endregion
-
-Install-Binary -FilePath $packagePath
+Install-Binary `
+  -Url $packageUrl `
+  -ExpectedSHA256Sum $externalHash
 
 Invoke-PesterTests -TestFile "CLI.Tools" -TestName "AWS"

--- a/images/windows/scripts/build/Install-Apache.ps1
+++ b/images/windows/scripts/build/Install-Apache.ps1
@@ -8,7 +8,7 @@ Stop-Service -Name w3svc | Out-Null
 
 # Install latest apache in chocolatey
 $installDir = "C:\tools"
-Choco-Install -PackageName apache-httpd -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
+Install-ChocoPackage apache-httpd -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
 
 # Stop and disable Apache service
 Stop-Service -Name Apache

--- a/images/windows/scripts/build/Install-AzureCli.ps1
+++ b/images/windows/scripts/build/Install-AzureCli.ps1
@@ -11,9 +11,9 @@ $azureCliConfigPath = 'C:\azureCli'
 # make variable to be available in the current session
 ${env:AZURE_CONFIG_DIR} = $azureCliConfigPath
 
-$azCliUrl = 'https://aka.ms/installazurecliwindowsx64'
-$azCliSignatureThumbprint = "72105B6D5F370B62FD5C82F1512F7AD7DEE5F2C0"
-Install-Binary -Url $azCliUrl -Name 'azure-cli.msi' -ExpectedSignature $azCliSignatureThumbprint
+Install-Binary -Type MSI `
+   -Url 'https://aka.ms/installazurecliwindowsx64' `
+   -ExpectedSignature '72105B6D5F370B62FD5C82F1512F7AD7DEE5F2C0'
 
 $azureCliExtensionPath = Join-Path $Env:CommonProgramFiles 'AzureCliExtensionDirectory'
 $null = New-Item -ItemType 'Directory' -Path $azureCliExtensionPath

--- a/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
+++ b/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
@@ -3,10 +3,8 @@
 ##  Desc:  Install Azure CosmosDb Emulator
 ####################################################################################
 
-$InstallerName = "AzureCosmosDBEmulator.msi"
-$InstallerUrl = "https://aka.ms/cosmosdb-emulator"
-$SignatureThumbprint = "F372C27F6E052A6BE8BAB3112B465C692196CD6F"
-
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ExpectedSignature $SignatureThumbprint
+Install-Binary -Type MSI `
+  -Url "https://aka.ms/cosmosdb-emulator" `
+  -ExpectedSignature "F372C27F6E052A6BE8BAB3112B465C692196CD6F"
 
 Invoke-PesterTests -TestFile "Tools" -TestName "Azure Cosmos DB Emulator"

--- a/images/windows/scripts/build/Install-Bazel.ps1
+++ b/images/windows/scripts/build/Install-Bazel.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Install Bazel and Bazelisk (A user-friendly launcher for Bazel)
 ################################################################################
 
-Choco-Install -PackageName bazel
+Install-ChocoPackage bazel
 
 npm install -g @bazel/bazelisk
 

--- a/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
+++ b/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
@@ -3,86 +3,29 @@
 ##  Desc:  Install BizTalk Project Build Component
 ################################################################################
 
-function Install-Msi
-{
-    <#
-    .SYNOPSIS
-        A helper function to install executables.
+$BuildComponentUri = "https://aka.ms/BuildComponentSetup.EN"
+$BuildComponentSignatureThumbprint = "8740DF4ACB749640AD318E4BE842F72EC651AD80"
 
-    .DESCRIPTION
-        install .exe or .msi binaries from specified Path.
+Write-Host "Downloading BizTalk Project Build Component archive..."
+$setupZipFile = Start-DownloadWithRetry -Url $BuildComponentUri -Name "BuildComponentSetup.EN.zip"
 
-    .PARAMETER MsiPath
-        Msi or exe path. Required parameter.
-
-    .PARAMETER LogPath
-        The log file path where installation will write log to. Required parameter.
-
-    .EXAMPLE
-        Install-Msi -MsiPath "c:\temp\abc.msi" -LogPath "c:\abc.log"
-    #>
-
-    Param
-    (
-        [Parameter(Mandatory)]
-        [String] $MsiPath,
-        [Parameter(Mandatory)]
-        [String] $LogPath
-    )
-
-    try
-    {
-        $filePath = "msiexec.exe"
-
-        Write-Host "Starting Install $MsiPath..."
-        $ArgumentList = ('/i', $MsiPath, '/QN', '/norestart', "/l*v",$LogPath)
-        $process = Start-Process -FilePath $filePath -ArgumentList $ArgumentList -Wait -PassThru -Verb runAs
-
-        $exitCode = $process.ExitCode
-        if ($exitCode -eq 0 -or $exitCode -eq 3010)
-        {
-            Write-Host "Installation for $MsiPath is successful."
-        }
-        else
-        {
-            Write-Host "Non zero exit code returned by $MsiPath installation process: $exitCode"
-            Get-Content  $LogPath | Write-Host
-            exit $exitCode
-        }
-    }
-    catch
-    {
-        Write-Host "Failed to install $MsiPath : $($_.Exception.Message)"
-        exit 1
-    }
-}
-
-$bizTalkBuildComponentUri = "https://aka.ms/BuildComponentSetup.EN"
-
-# Download
-Write-Host "BizTalk Project Build Component download..."
-$setupZipFile = Start-DownloadWithRetry -Url $bizTalkBuildComponentUri -Name "BuildComponentSetup.EN.zip"
-
-# Unzip
-$setupPath = "C:\BizTalkBuildComponent"
+$setupPath = Join-Path $env:TEMP "BizTalkBuildComponent"
 if (-not (Test-Path -Path $setupPath)) {
     $null = New-Item -Path $setupPath -ItemType Directory -Force
 }
-
-Write-Host "Unzip $setupZipFile to $setupPath..."
 Extract-7Zip -Path $setupZipFile -DestinationPath $setupPath
+
+Write-Host "Installing BizTalk Project Build Component..."
+Install-Binary `
+    -LocalPath "$setupPath\Bootstrap.msi" `
+    -ExtraArgs ("/l*v", "$setupPath\bootstrap.log") `
+    -ExpectedSignature $BuildComponentSignatureThumbprint
+Install-Binary `
+    -LocalPath "$setupPath\BuildComponentSetup.msi" `
+    -ExtraArgs ("/l*v", "$setupPath\buildComponentSetup.log") `
+    -ExpectedSignature $BuildComponentSignatureThumbprint
+
 Remove-Item $setupZipFile
-
-# Verify signature
-$BuildComponentSignatureThumbprint = "8740DF4ACB749640AD318E4BE842F72EC651AD80"
-Test-FileSignature -FilePath "$setupPath\Bootstrap.msi" -ExpectedThumbprint $BuildComponentSignatureThumbprint
-Test-FileSignature -FilePath "$setupPath\BuildComponentSetup.msi" -ExpectedThumbprint $BuildComponentSignatureThumbprint
-
-# Install
-Install-Msi -MsiPath "$setupPath\Bootstrap.msi" -LogPath "$setupPath\bootstrap.log"
-Install-Msi -MsiPath "$setupPath\BuildComponentSetup.msi" -LogPath  "$setupPath\buildComponentSetup.log"
-
 Remove-Item $setupPath -Recurse -Force
 
-# Test
 Invoke-PesterTests -TestFile "BizTalk" -TestName "BizTalk Build Component Setup"

--- a/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
+++ b/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
@@ -18,11 +18,11 @@ Extract-7Zip -Path $setupZipFile -DestinationPath $setupPath
 Write-Host "Installing BizTalk Project Build Component..."
 Install-Binary `
     -LocalPath "$setupPath\Bootstrap.msi" `
-    -ExtraArgs ("/l*v", "$setupPath\bootstrap.log") `
+    -ExtraInstallArgs ("/l*v", "$setupPath\bootstrap.log") `
     -ExpectedSignature $BuildComponentSignatureThumbprint
 Install-Binary `
     -LocalPath "$setupPath\BuildComponentSetup.msi" `
-    -ExtraArgs ("/l*v", "$setupPath\buildComponentSetup.log") `
+    -ExtraInstallArgs ("/l*v", "$setupPath\buildComponentSetup.log") `
     -ExpectedSignature $BuildComponentSignatureThumbprint
 
 Remove-Item $setupZipFile

--- a/images/windows/scripts/build/Install-ChocolateyPackages.ps1
+++ b/images/windows/scripts/build/Install-ChocolateyPackages.ps1
@@ -6,7 +6,7 @@
 $commonPackages = (Get-ToolsetContent).choco.common_packages
 
 foreach ($package in $commonPackages) {
-    Choco-Install -PackageName $package.name -ArgumentList $package.args
+    Install-ChocoPackage $package.name -ArgumentList $package.args
 }
 
 Invoke-PesterTests -TestFile "ChocoPackages"

--- a/images/windows/scripts/build/Install-Chrome.ps1
+++ b/images/windows/scripts/build/Install-Chrome.ps1
@@ -4,10 +4,9 @@
 ################################################################################
 
 # Download and install latest Chrome browser
-$ChromeSignatureThumbprint = "2673EA6CC23BEFFDA49AC715B121544098A1284C"
-$ChromeInstallerFile = "googlechromestandaloneenterprise64.msi"
-$ChromeInstallerUrl = "https://dl.google.com/tag/s/dl/chrome/install/${ChromeInstallerFile}"
-Install-Binary -Url $ChromeInstallerUrl -Name $ChromeInstallerFile -ArgumentList @() -ExpectedSignature $ChromeSignatureThumbprint
+Install-Binary `
+    -Url 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi' `
+    -ExpectedSignature '2673EA6CC23BEFFDA49AC715B121544098A1284C'
 
 # Prepare firewall rules
 Write-Host "Adding the firewall rule for Google update blocking..."

--- a/images/windows/scripts/build/Install-DACFx.ps1
+++ b/images/windows/scripts/build/Install-DACFx.ps1
@@ -3,10 +3,8 @@
 ##  Desc:  Install SQL Server® Data-Tier Application Framework (DacFx) for Windows
 ####################################################################################
 
-$InstallerName = "DacFramework.msi"
-$InstallerUrl = "https://aka.ms/dacfx-msi"
-$SignatureThumbprint = "72105B6D5F370B62FD5C82F1512F7AD7DEE5F2C0"
-
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ExpectedSignature $SignatureThumbprint
+Install-Binary -Type MSI `
+  -Url 'https://aka.ms/dacfx-msi' `
+  -ExpectedSignature '72105B6D5F370B62FD5C82F1512F7AD7DEE5F2C0'
 
 Invoke-PesterTests -TestFile "Tools" -TestName "DACFx"

--- a/images/windows/scripts/build/Install-DockerCompose.ps1
+++ b/images/windows/scripts/build/Install-DockerCompose.ps1
@@ -5,8 +5,8 @@
 ################################################################################
 
 Write-Host "Install-Package Docker-Compose v1"
-$versionToInstall = Get-LatestChocoPackageVersion -TargetVersion "1.29" -PackageName "docker-compose"
-Choco-Install -PackageName docker-compose -ArgumentList "--version=$versionToInstall"
+$versionToInstall = Resolve-ChocoPackageVersion -PackageName "docker-compose" -TargetVersion "1.29"
+Install-ChocoPackage docker-compose -ArgumentList "--version=$versionToInstall"
 
 Write-Host "Install-Package Docker-Compose v2"
 $dockerComposev2Url = "https://github.com/docker/compose/releases/latest/download/docker-compose-windows-x86_64.exe"

--- a/images/windows/scripts/build/Install-Firefox.ps1
+++ b/images/windows/scripts/build/Install-Firefox.ps1
@@ -15,7 +15,7 @@ $externalHash = (Invoke-RestMethod -Uri $hashURL).ToString().Split("`n").Where({
 
 Install-Binary -Type EXE `
     -Url $installerUrl `
-    -Args @("/silent", "/install") `
+    -InstallArgs @("/silent", "/install") `
     -ExpectedSHA256Sum $externalHash
 
 Write-Host "Disable autoupdate..."

--- a/images/windows/scripts/build/Install-Git.ps1
+++ b/images/windows/scripts/build/Install-Git.ps1
@@ -8,7 +8,7 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 # Install the latest version of Git for Windows
 $repoURL = "https://api.github.com/repos/git-for-windows/git/releases/latest"
 $gitReleases = Invoke-RestMethod $repoURL
-$downloadUrl = $gitReleases.assets.browser_download_url -match "Git-.+-64-bit.exe"
+$downloadUrl = $gitReleases.assets.browser_download_url -match "Git-.+-64-bit.exe" | Select-Object -First 1
 
 $installerFile = Split-Path $downloadUrl -Leaf
 $externalHash = Get-HashFromGitHubReleaseBody -Url $RepoURL -FileName $installerFile

--- a/images/windows/scripts/build/Install-Git.ps1
+++ b/images/windows/scripts/build/Install-Git.ps1
@@ -15,7 +15,7 @@ $externalHash = Get-HashFromGitHubReleaseBody -Url $RepoURL -FileName $installer
 
 Install-Binary `
     -Url $downloadUrl `
-    -Args @(`
+    -InstallArgs @(`
         "/VERYSILENT", `
         "/NORESTART", `
         "/NOCANCEL", `

--- a/images/windows/scripts/build/Install-Git.ps1
+++ b/images/windows/scripts/build/Install-Git.ps1
@@ -8,28 +8,25 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 # Install the latest version of Git for Windows
 $repoURL = "https://api.github.com/repos/git-for-windows/git/releases/latest"
 $gitReleases = Invoke-RestMethod $repoURL
-[string]$downloadUrl = $gitReleases.assets.browser_download_url -match "Git-.+-64-bit.exe"
+$downloadUrl = $gitReleases.assets.browser_download_url -match "Git-.+-64-bit.exe"
+
 $installerFile = Split-Path $downloadUrl -Leaf
-$packagePath = Start-DownloadWithRetry -Url $downloadUrl -Name $installerFile
-
-#region Supply chain security - Git
-$fileHash = (Get-FileHash -Path $packagePath -Algorithm SHA256).Hash
 $externalHash = Get-HashFromGitHubReleaseBody -Url $RepoURL -FileName $installerFile
-Use-ChecksumComparison $fileHash $externalHash
-#endregion
 
-Install-Binary  -FilePath $packagePath `
-                -ArgumentList (
-                    "/VERYSILENT", `
-                    "/NORESTART", `
-                    "/NOCANCEL", `
-                    "/SP-", `
-                    "/CLOSEAPPLICATIONS", `
-                    "/RESTARTAPPLICATIONS", `
-                    "/o:PathOption=CmdTools", `
-                    "/o:BashTerminalOption=ConHost", `
-                    "/o:EnableSymlinks=Enabled", `
-                    "/COMPONENTS=gitlfs")
+Install-Binary `
+    -Url $downloadUrl `
+    -Args @(`
+        "/VERYSILENT", `
+        "/NORESTART", `
+        "/NOCANCEL", `
+        "/SP-", `
+        "/CLOSEAPPLICATIONS", `
+        "/RESTARTAPPLICATIONS", `
+        "/o:PathOption=CmdTools", `
+        "/o:BashTerminalOption=ConHost", `
+        "/o:EnableSymlinks=Enabled", `
+        "/COMPONENTS=gitlfs") `
+    -ExpectedSHA256Sum $externalHash
 
 Update-SessionEnvironment
 
@@ -42,7 +39,7 @@ git config --system --add safe.directory "*"
 Add-MachinePathItem "C:\Program Files\Git\bin"
 
 # Add well-known SSH host keys to ssh_known_hosts
-ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
+ssh-keyscan -t rsa, ecdsa, ed25519 github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 ssh-keyscan -t rsa ssh.dev.azure.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 
 Invoke-PesterTests -TestFile "Git"

--- a/images/windows/scripts/build/Install-GitHub-CLI.ps1
+++ b/images/windows/scripts/build/Install-GitHub-CLI.ps1
@@ -7,19 +7,15 @@
 Write-Host "Get the latest gh version..."
 
 $repoUrl = "https://api.github.com/repos/cli/cli/releases/latest"
-$installerFile = "gh_windows_amd64.msi"
 $assets = (Invoke-RestMethod -Uri $repoUrl).assets
 $downloadUrl = ($assets.browser_download_url -match "windows_amd64.msi") | Select-Object -First 1
-$packagePath = Start-DownloadWithRetry -Url $downloadUrl -Name $installerFile
 
-#region Supply chain security - GitHub CLI
-$fileHash = (Get-FileHash -Path $packagePath -Algorithm SHA256).Hash
 $hashUrl = ($assets.browser_download_url -match "checksums.txt") | Select-Object -First 1
 $externalHash = (Invoke-RestMethod -Uri $hashURL).ToString().Split("`n").Where({ $_ -ilike "*windows_amd64.msi*" }).Split(' ')[0]
-Use-ChecksumComparison $fileHash $externalHash
-#endregion
 
-Install-Binary -FilePath $packagePath
+Install-Binary `
+  -Url $downloadUrl `
+  -ExpectedSHA256Sum $externalHash
 
 Add-MachinePathItem "C:\Program Files (x86)\GitHub CLI"
 

--- a/images/windows/scripts/build/Install-GoogleCloudCLI.ps1
+++ b/images/windows/scripts/build/Install-GoogleCloudCLI.ps1
@@ -4,10 +4,9 @@
 ################################################################################
 
 # https://cloud.google.com/sdk/docs/downloads-interactive
-$googleCloudCLIInstaller = "https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe"
-$argumentList = @("/S", "/allusers", "/noreporting")
-$googleCloudCLISignatureThumbprint = "2673EA6CC23BEFFDA49AC715B121544098A1284C"
-
-Install-Binary -Url $googleCloudCLIInstaller -Name "GoogleCloudSDKInstaller.exe" -ArgumentList $argumentList -ExpectedSignature $googleCloudCLISignatureThumbprint
+Install-Binary `
+  -Url 'https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe' `
+  -Args @("/S", "/allusers", "/noreporting") `
+  -ExpectedSignature '2673EA6CC23BEFFDA49AC715B121544098A1284C'
 
 Invoke-PesterTests -TestFile "Tools" -TestName "GoogleCloudCLI"

--- a/images/windows/scripts/build/Install-GoogleCloudCLI.ps1
+++ b/images/windows/scripts/build/Install-GoogleCloudCLI.ps1
@@ -6,7 +6,7 @@
 # https://cloud.google.com/sdk/docs/downloads-interactive
 Install-Binary `
   -Url 'https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe' `
-  -Args @("/S", "/allusers", "/noreporting") `
+  -InstallArgs @("/S", "/allusers", "/noreporting") `
   -ExpectedSignature '2673EA6CC23BEFFDA49AC715B121544098A1284C'
 
 Invoke-PesterTests -TestFile "Tools" -TestName "GoogleCloudCLI"

--- a/images/windows/scripts/build/Install-JavaTools.ps1
+++ b/images/windows/scripts/build/Install-JavaTools.ps1
@@ -114,13 +114,13 @@ foreach ($jdkVersionToInstall in $jdkVersionsToInstall) {
 
 # Install Java tools
 # Force chocolatey to ignore dependencies on Ant and Maven or else they will download the Oracle JDK
-Choco-Install -PackageName ant -ArgumentList "-i"
+Install-ChocoPackage ant -ArgumentList "--ignore-dependencies"
 # Maven 3.9.x has multiple compatibilities problems
 $toolsetMavenVersion = (Get-ToolsetContent).maven.version
-$versionToInstall = Get-LatestChocoPackageVersion -TargetVersion $toolsetMavenVersion -PackageName "maven"
+$versionToInstall = Resolve-ChocoPackageVersion -PackageName "maven" -TargetVersion $toolsetMavenVersion
 
-Choco-Install -PackageName maven -ArgumentList "--version=$versionToInstall"
-Choco-Install -PackageName gradle
+Install-ChocoPackage maven -ArgumentList "--version=$versionToInstall"
+Install-ChocoPackage gradle
 
 # Add maven env variables to Machine
 [string]$m2 = (Get-MachinePath).Split(";") -match "maven"

--- a/images/windows/scripts/build/Install-KubernetesTools.ps1
+++ b/images/windows/scripts/build/Install-KubernetesTools.ps1
@@ -23,12 +23,12 @@ Use-ChecksumComparison $fileHash $externalHash
 Add-MachinePathItem $destFilePath
 
 Write-Host "Install Kubectl"
-Choco-Install -PackageName kubernetes-cli
+Install-ChocoPackage kubernetes-cli
 
 Write-Host "Install Helm"
-Choco-Install -PackageName kubernetes-helm
+Install-ChocoPackage kubernetes-helm
 
 Write-Host "Install Minikube"
-Choco-Install -PackageName minikube
+Install-ChocoPackage minikube
 
 Invoke-PesterTests -TestFile "Tools" -TestName "KubernetesTools"

--- a/images/windows/scripts/build/Install-LLVM.ps1
+++ b/images/windows/scripts/build/Install-LLVM.ps1
@@ -4,7 +4,7 @@
 ################################################################################
 
 $llvmVersion = (Get-ToolsetContent).llvm.version
-$latestChocoVersion = Get-LatestChocoPackageVersion -TargetVersion $llvmVersion -PackageName "llvm"
-Choco-Install -PackageName llvm -ArgumentList '--version', $latestChocoVersion
+$latestChocoVersion = Resolve-ChocoPackageVersion -PackageName "llvm" -TargetVersion $llvmVersion
+Install-ChocoPackage llvm -ArgumentList '--version', $latestChocoVersion
 
 Invoke-PesterTests -TestFile "LLVM"

--- a/images/windows/scripts/build/Install-Mercurial.ps1
+++ b/images/windows/scripts/build/Install-Mercurial.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Install Mercurial
 ################################################################################
 
-Choco-Install -PackageName hg -ArgumentList "--version", "5.0.0"
+Install-ChocoPackage hg -ArgumentList "--version", "5.0.0"
 
 $hgPath = "${env:ProgramFiles}\Mercurial\"
 Add-MachinePathItem $hgPath

--- a/images/windows/scripts/build/Install-Miniconda.ps1
+++ b/images/windows/scripts/build/Install-Miniconda.ps1
@@ -5,28 +5,28 @@
 ################################################################################
 
 $CondaDestination = "C:\Miniconda"
-
-# Install the latest Miniconda
 $InstallerName = "Miniconda3-latest-Windows-x86_64.exe"
-$InstallerUrl = "https://repo.anaconda.com/miniconda/${InstallerName}"
-$ArgumentList = ("/S", "/AddToPath=0", "/RegisterPython=0", "/D=$CondaDestination")
-
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList
-[System.Environment]::SetEnvironmentVariable("CONDA", $CondaDestination, "Machine")
 
 #region Supply chain security
-$localFileHash = (Get-FileHash -Path (Join-Path ${env:TEMP} $installerName) -Algorithm SHA256).Hash
 $distributorFileHash = $null
-
 $checksums = (Invoke-RestMethod -Uri 'https://repo.anaconda.com/miniconda/' | ConvertFrom-HTML).SelectNodes('//html/body/table/tr')
 
-ForEach($node in $checksums) {
+foreach ($node in $checksums) {
     if ($node.ChildNodes[1].InnerText -eq $InstallerName) {
         $distributorFileHash = $node.ChildNodes[7].InnerText
     }
 }
 
-Use-ChecksumComparison -LocalFileHash $localFileHash -DistributorFileHash $distributorFileHash
+if ($null -eq $distributorFileHash) {
+    throw "Unable to find checksum for $InstallerName in https://repo.anaconda.com/miniconda/"
+}
 #endregion
+
+Install-Binary `
+    -Url "https://repo.anaconda.com/miniconda/${InstallerName}" `
+    -Args @("/S", "/AddToPath=0", "/RegisterPython=0", "/D=$CondaDestination") `
+    -ExpectedSHA256Sum $distributorFileHash
+
+[System.Environment]::SetEnvironmentVariable("CONDA", $CondaDestination, "Machine")
 
 Invoke-PesterTests -TestFile "Miniconda"

--- a/images/windows/scripts/build/Install-Miniconda.ps1
+++ b/images/windows/scripts/build/Install-Miniconda.ps1
@@ -24,7 +24,7 @@ if ($null -eq $distributorFileHash) {
 
 Install-Binary `
     -Url "https://repo.anaconda.com/miniconda/${InstallerName}" `
-    -Args @("/S", "/AddToPath=0", "/RegisterPython=0", "/D=$CondaDestination") `
+    -InstallArgs @("/S", "/AddToPath=0", "/RegisterPython=0", "/D=$CondaDestination") `
     -ExpectedSHA256Sum $distributorFileHash
 
 [System.Environment]::SetEnvironmentVariable("CONDA", $CondaDestination, "Machine")

--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -20,12 +20,10 @@ foreach ($release in $TargetReleases) {
 
 $LatestVersion = $MinorVersions[0]
 
-$installDir = "c:\PROGRA~1\MongoDB"
-$binaryName = "mongodb-windows-x86_64-$LatestVersion-signed.msi"
-$downloadURL = "https://fastdl.mongodb.org/windows/$BinaryName"
-$installArg = "INSTALLLOCATION=$installDir ADDLOCAL=all"
-Install-Binary -Url $downloadURL -Name $binaryName -ArgumentList ("/q","/i","${env:Temp}\$binaryName", $installArg) -ExpectedSignature (Get-ToolsetContent).mongodb.signature
-
+Install-Binary `
+  -Url "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-$LatestVersion-signed.msi" `
+  -ExtraArgs @('TARGETDIR=C:\PROGRA~1\MongoDB ADDLOCAL=ALL') `
+  -ExpectedSignature (Get-ToolsetContent).mongodb.signature
 
 # Add mongodb to the PATH
 $mongodbService = "mongodb"

--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -22,7 +22,7 @@ $LatestVersion = $MinorVersions[0]
 
 Install-Binary `
   -Url "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-$LatestVersion-signed.msi" `
-  -ExtraArgs @('TARGETDIR=C:\PROGRA~1\MongoDB ADDLOCAL=ALL') `
+  -ExtraInstallArgs @('TARGETDIR=C:\PROGRA~1\MongoDB ADDLOCAL=ALL') `
   -ExpectedSignature (Get-ToolsetContent).mongodb.signature
 
 # Add mongodb to the PATH

--- a/images/windows/scripts/build/Install-MysqlCli.ps1
+++ b/images/windows/scripts/build/Install-MysqlCli.ps1
@@ -4,26 +4,26 @@
 ################################################################################
 
 # Installing visual c++ redistibutable package.
-$InstallerName = "vcredist_x64.exe"
-$InstallerURI = "https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/${InstallerName}"
-$ArgumentList = ("/install", "/quiet", "/norestart")
-$InstallerSignatureThumbrint = "3BDA323E552DB1FDE5F4FBEE75D6D5B2B187EEDC"
-
-Install-Binary -Url $InstallerURI -Name $InstallerName -ArgumentList $ArgumentList -ExpectedSignature $InstallerSignatureThumbrint
+Install-Binary `
+    -Url 'https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe' `
+    -Args @("/install", "/quiet", "/norestart") `
+    -ExpectedSignature '3BDA323E552DB1FDE5F4FBEE75D6D5B2B187EEDC'
 
 # Downloading mysql
 [version]$MysqlVersion = (Get-ToolsetContent).mysql.version
 $MysqlVersionMajorMinor = $MysqlVersion.ToString(2)
 
 if ($MysqlVersion.Build -lt 0) {
-    $MysqlVersion = (Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html" -Headers @{ 'User-Agent'='curl/8.4.0' } |
-        Select-String -Pattern "${MysqlVersionMajorMinor}\.\d+").Matches.Value
+    $MysqlVersion = (Invoke-RestMethod -Uri "https://dev.mysql.com/downloads/mysql/${MysqlVersionMajorMinor}.html" -Headers @{ 'User-Agent' = 'curl/8.4.0' } |
+            Select-String -Pattern "${MysqlVersionMajorMinor}\.\d+").Matches.Value
 }
 
 $MysqlVersionFull = $MysqlVersion.ToString()
 $MysqlVersionUrl = "https://cdn.mysql.com/Downloads/MySQL-${MysqlVersionMajorMinor}/mysql-${MysqlVersionFull}-winx64.msi"
 
-Install-Binary -Url $MysqlVersionUrl -Name "mysql-${MysqlVersionFull}-winx64.msi" -ExpectedSignature (Get-ToolsetContent).mysql.signature
+Install-Binary `
+    -Url $MysqlVersionUrl `
+    -ExpectedSignature (Get-ToolsetContent).mysql.signature
 
 # Adding mysql in system environment path
 $MysqlPath = $(Get-ChildItem -Path "C:\PROGRA~1\MySQL" -Directory)[0].FullName

--- a/images/windows/scripts/build/Install-MysqlCli.ps1
+++ b/images/windows/scripts/build/Install-MysqlCli.ps1
@@ -6,7 +6,7 @@
 # Installing visual c++ redistibutable package.
 Install-Binary `
     -Url 'https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe' `
-    -Args @("/install", "/quiet", "/norestart") `
+    -InstallArgs @("/install", "/quiet", "/norestart") `
     -ExpectedSignature '3BDA323E552DB1FDE5F4FBEE75D6D5B2B187EEDC'
 
 # Downloading mysql

--- a/images/windows/scripts/build/Install-NET48-devpack.ps1
+++ b/images/windows/scripts/build/Install-NET48-devpack.ps1
@@ -6,7 +6,7 @@
 # .NET 4.8 Dev pack
 Install-Binary `
   -Url 'https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/0307177e14752e359fde5423ab583e43/ndp48-devpack-enu.exe' `
-  -Args @("Setup", "/passive", "/norestart") `
+  -InstallArgs @("Setup", "/passive", "/norestart") `
   -ExpectedSignature 'C82273A065EC470FB1EBDE846A91E6FFB29E9C12'
 
 Invoke-PesterTests -TestFile "Tools" -TestName "NET48"

--- a/images/windows/scripts/build/Install-NET48-devpack.ps1
+++ b/images/windows/scripts/build/Install-NET48-devpack.ps1
@@ -4,11 +4,9 @@
 ################################################################################
 
 # .NET 4.8 Dev pack
-$InstallerName = "ndp48-devpack-enu.exe"
-$InstallerUrl = "https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/0307177e14752e359fde5423ab583e43/${InstallerName}"
-$InstallerSignatureThumbprint = "C82273A065EC470FB1EBDE846A91E6FFB29E9C12"
-$ArgumentList = ("Setup", "/passive", "/norestart")
-
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList -ExpectedSignature $InstallerSignatureThumbprint
+Install-Binary `
+  -Url 'https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/0307177e14752e359fde5423ab583e43/ndp48-devpack-enu.exe' `
+  -Args @("Setup", "/passive", "/norestart") `
+  -ExpectedSignature 'C82273A065EC470FB1EBDE846A91E6FFB29E9C12'
 
 Invoke-PesterTests -TestFile "Tools" -TestName "NET48"

--- a/images/windows/scripts/build/Install-NET48.ps1
+++ b/images/windows/scripts/build/Install-NET48.ps1
@@ -4,9 +4,7 @@
 ################################################################################
 
 # .NET 4.8 Dev pack
-$InstallerName = "ndp48-x86-x64-allos-enu.exe"
-$InstallerUrl = "https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/${InstallerName}"
-$InstallerSignatureThumbprint = "ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B"
-$ArgumentList = ("Setup", "/passive", "/norestart")
-
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList -ExpectedSignature $InstallerSignatureThumbprint
+Install-Binary `
+  -Url 'https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe' `
+  -Args @("Setup", "/passive", "/norestart") `
+  -ExpectedSignature 'ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B'

--- a/images/windows/scripts/build/Install-NET48.ps1
+++ b/images/windows/scripts/build/Install-NET48.ps1
@@ -6,5 +6,5 @@
 # .NET 4.8 Dev pack
 Install-Binary `
   -Url 'https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe' `
-  -Args @("Setup", "/passive", "/norestart") `
+  -InstallArgs @("Setup", "/passive", "/norestart") `
   -ExpectedSignature 'ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B'

--- a/images/windows/scripts/build/Install-NSIS.ps1
+++ b/images/windows/scripts/build/Install-NSIS.ps1
@@ -6,7 +6,7 @@
 
 $NsisVersion = (Get-ToolsetContent).nsis.version
 
-Choco-Install -PackageName nsis -ArgumentList "--version", "$NsisVersion"
+Install-ChocoPackage nsis -ArgumentList "--version", "$NsisVersion"
 
 $NsisPath = "${env:ProgramFiles(x86)}\NSIS\"
 Add-MachinePathItem $NsisPath

--- a/images/windows/scripts/build/Install-Nginx.ps1
+++ b/images/windows/scripts/build/Install-Nginx.ps1
@@ -8,7 +8,7 @@ Stop-Service -Name w3svc | Out-Null
 
 # Install latest nginx in chocolatey
 $installDir = "C:\tools"
-Choco-Install -PackageName nginx -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
+Install-ChocoPackage nginx -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
 
 # Stop and disable Nginx service
 Stop-Service -Name nginx

--- a/images/windows/scripts/build/Install-NodeJS.ps1
+++ b/images/windows/scripts/build/Install-NodeJS.ps1
@@ -11,9 +11,9 @@ New-Item -Path $PrefixPath -Force -ItemType Directory
 New-Item -Path $CachePath -Force -ItemType Directory
 
 $defaultVersion = (Get-ToolsetContent).node.default
-$versionToInstall = Get-LatestChocoPackageVersion -TargetVersion $defaultVersion -PackageName "nodejs"
+$versionToInstall = Resolve-ChocoPackageVersion -PackageName "nodejs" -TargetVersion $defaultVersion
 
-Choco-Install -PackageName nodejs -ArgumentList "--version=$versionToInstall"
+Install-ChocoPackage nodejs -ArgumentList "--version=$versionToInstall"
 
 Add-MachinePathItem $PrefixPath
 $env:Path = Get-MachinePath

--- a/images/windows/scripts/build/Install-OpenSSL.ps1
+++ b/images/windows/scripts/build/Install-OpenSSL.ps1
@@ -7,7 +7,7 @@
 $arch = 'INTEL'
 $bits = '64'
 $light = $false
-$installer = "exe"
+$installerType = "exe"
 $version = (Get-ToolsetContent).openssl.version
 $installDir = "$Env:ProgramFiles\OpenSSL"
 
@@ -22,7 +22,7 @@ $installerHash = $null
 
 foreach ($key in $installerNames) {
     $installer = $installersAvailable.$key
-    if (($installer.light -eq $light) -and ($installer.arch -eq $arch) -and ($installer.bits -eq $bits) -and ($installer.installer -eq $installer) -and ($installer.basever -eq $version)) {
+    if (($installer.light -eq $light) -and ($installer.arch -eq $arch) -and ($installer.bits -eq $bits) -and ($installer.installer -eq $installerType) -and ($installer.basever -eq $version)) {
         $installerUrl = $installer.url
         $installerHash = $installer.sha512
     }

--- a/images/windows/scripts/build/Install-OpenSSL.ps1
+++ b/images/windows/scripts/build/Install-OpenSSL.ps1
@@ -15,35 +15,27 @@ $installDir = "$Env:ProgramFiles\OpenSSL"
 $jsonUrl = 'https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json'
 
 $installersAvailable = (Invoke-RestMethod $jsonUrl).files
+$installerNames = $installersAvailable | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
 
-$distributor_file_hash = $null
 $installerUrl = $null
-$installerName = $null
+$installerHash = $null
 
-$installersAvailable | Get-Member -MemberType NoteProperty | ForEach-Object {
-  $key = $_.Name
-  if(($installersAvailable.$key.light -eq $light) -and ($installersAvailable.$key.arch -eq $arch) -and ($installersAvailable.$key.bits -eq $bits) -and ($installersAvailable.$key.installer -eq $installer) -and ($installersAvailable.$key.basever -eq $version)) {
-    $installerUrl = $installersAvailable.$key.url
-    $installerName = $key
-    $distributor_file_hash = $installersAvailable.$key.sha512
-  }
+foreach ($key in $installerNames) {
+    $installer = $installersAvailable.$key
+    if (($installer.light -eq $light) -and ($installer.arch -eq $arch) -and ($installer.bits -eq $bits) -and ($installer.installer -eq $installer) -and ($installer.basever -eq $version)) {
+        $installerUrl = $installer.url
+        $installerHash = $installer.sha512
+    }
 }
 
-# Invoke installation
-
-$installerArgs = '/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`""
-Install-Binary -Url "$installerUrl" -Name "$installerName" -ArgumentList $installerArgs
-
-#region Supply chain security
-Write-Verbose "Performing checksum verification"
-$local_file_hash = (Get-FileHash -Path (Join-Path ${env:TEMP} $installerName) -Algorithm SHA512).Hash
-
-if ($local_file_hash -ne $distributor_file_hash) {
-        Write-Host "hash must be equal to: ${distributor_file_hash}"
-        Write-Host "actual hash is: ${local_file_hash}"
-        throw 'Checksum verification failed, please rerun install'
+if ($null -eq $installerUrl) {
+    throw "Installer not found for version $version"
 }
-#endregion
+
+Install-Binary `
+    -Url $installerUrl `
+    -Args @('/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`"") `
+    -ExpectedSHA512Sum $installerHash
 
 # Update PATH
 Add-MachinePathItem "$installDir\bin"

--- a/images/windows/scripts/build/Install-OpenSSL.ps1
+++ b/images/windows/scripts/build/Install-OpenSSL.ps1
@@ -34,7 +34,7 @@ if ($null -eq $installerUrl) {
 
 Install-Binary `
     -Url $installerUrl `
-    -Args @('/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`"") `
+    -InstallArgs @('/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`"") `
     -ExpectedSHA512Sum $installerHash
 
 # Update PATH

--- a/images/windows/scripts/build/Install-PHP.ps1
+++ b/images/windows/scripts/build/Install-PHP.ps1
@@ -6,11 +6,11 @@
 # Install latest PHP in chocolatey
 $installDir = "c:\tools\php"
 $phpMajorMinor = (Get-ToolsetContent).php.version
-$phpVersionToInstall = Get-LatestChocoPackageVersion -TargetVersion $phpMajorMinor -PackageName "php"
-Choco-Install -PackageName php -ArgumentList "--params", "/InstallDir:$installDir", "--version=$phpVersionToInstall"
+$phpVersionToInstall = Resolve-ChocoPackageVersion -PackageName "php" -TargetVersion $phpMajorMinor
+Install-ChocoPackage php -ArgumentList "--params", "/InstallDir:$installDir", "--version=$phpVersionToInstall"
 
 # Install latest Composer in chocolatey
-Choco-Install -PackageName composer -ArgumentList "--ia", "/DEV=$installDir /PHP=$installDir"
+Install-ChocoPackage composer -ArgumentList "--install-args", "/DEV=$installDir /PHP=$installDir"
 
 # update path to extensions and enable curl and mbstring extensions, and enable php openssl extensions.
 ((Get-Content -path $installDir\php.ini -Raw) -replace ';extension=curl','extension=curl' -replace ';extension=mbstring','extension=mbstring' -replace ';extension_dir = "ext"','extension_dir = "ext"' -replace ';extension=openssl','extension=openssl') | Set-Content -Path $installDir\php.ini

--- a/images/windows/scripts/build/Install-PostgreSQL.ps1
+++ b/images/windows/scripts/build/Install-PostgreSQL.ps1
@@ -50,7 +50,7 @@ $ErrorActionPreference = $ErrorActionOldValue
 $InstallerArgs = @("--install_runtimes 0", "--superpassword root", "--enable_acledit 1", "--unattendedmodeui none", "--mode unattended")
 Install-Binary `
     -Url $InstallerUrl `
-    -Args $InstallerArgs `
+    -InstallArgs $InstallerArgs `
     -ExpectedSignature (Get-ToolsetContent).postgresql.signature
 
 # Get Path to pg_ctl.exe

--- a/images/windows/scripts/build/Install-PostgreSQL.ps1
+++ b/images/windows/scripts/build/Install-PostgreSQL.ps1
@@ -44,11 +44,14 @@ do {
         $increment--
     }
 } while (!$response)
+
 # Return the previous value of ErrorAction and invoke Install-Binary function
 $ErrorActionPreference = $ErrorActionOldValue
-$InstallerName = $InstallerUrl.Split('/')[-1]
-$ArgumentList = ("--install_runtimes 0", "--superpassword root", "--enable_acledit 1", "--unattendedmodeui none", "--mode unattended")
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList -ExpectedSignature (Get-ToolsetContent).postgresql.signature
+$InstallerArgs = @("--install_runtimes 0", "--superpassword root", "--enable_acledit 1", "--unattendedmodeui none", "--mode unattended")
+Install-Binary `
+    -Url $InstallerUrl `
+    -Args $InstallerArgs `
+    -ExpectedSignature (Get-ToolsetContent).postgresql.signature
 
 # Get Path to pg_ctl.exe
 $pgPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'postgresql-%'").PathName

--- a/images/windows/scripts/build/Install-R.ps1
+++ b/images/windows/scripts/build/Install-R.ps1
@@ -3,8 +3,8 @@
 ##  Desc:  Install R for Windows
 ################################################################################
 
-Choco-Install R.Project
-Choco-Install rtools
+Install-ChocoPackage R.Project
+Install-ChocoPackage rtools
 
 $rscriptPath = Resolve-Path "C:\Program Files\R\*\bin\x64"
 Add-MachinePathItem $rscriptPath

--- a/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
+++ b/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
@@ -5,5 +5,5 @@
 
 Install-Binary -Type MSI `
     -Url "https://go.microsoft.com/fwlink/?linkid=2242656" `
-    -ExtraArgs @("ADDLOCAL=ALL", "IACCEPTMSOLEDBSQLLICENSETERMS=YES") `
+    -ExtraInstallArgs @("ADDLOCAL=ALL", "IACCEPTMSOLEDBSQLLICENSETERMS=YES") `
     -ExpectedSignature '6E78B3DCE2998F6C2457C3E54DA90A01034916AE'

--- a/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
+++ b/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
@@ -3,7 +3,7 @@
 ##  Desc:  Install OLE DB Driver for SQL Server
 ################################################################################
 
-$binaryDownloadPath = Start-DownloadWithRetry "https://go.microsoft.com/fwlink/?linkid=2242656" "msoledbsql.msi"
-$binarySignatureThumbprint = "6E78B3DCE2998F6C2457C3E54DA90A01034916AE"
-$ArgumentList = ("/i", "$binaryDownloadPath", "ADDLOCAL=ALL", "IACCEPTMSOLEDBSQLLICENSETERMS=YES", "/qn")
-Install-Binary -FilePath $binaryDownloadPath -ArgumentList $ArgumentList -ExpectedSignature $binarySignatureThumbprint
+Install-Binary -Type MSI `
+    -Url "https://go.microsoft.com/fwlink/?linkid=2242656" `
+    -ExtraArgs @("ADDLOCAL=ALL", "IACCEPTMSOLEDBSQLLICENSETERMS=YES") `
+    -ExpectedSignature '6E78B3DCE2998F6C2457C3E54DA90A01034916AE'

--- a/images/windows/scripts/build/Install-SQLPowerShellTools.ps1
+++ b/images/windows/scripts/build/Install-SQLPowerShellTools.ps1
@@ -3,18 +3,18 @@
 ##  Desc:  Install SQL PowerShell tool
 ################################################################################
 
-$BaseUrl = "https://download.microsoft.com/download/B/1/7/B1783FE9-717B-4F78-A39A-A2E27E3D679D/ENU/x64"
-$SignatureThumbrint = "9ACA9419E53D3C9E56396DD2335FF683A8B0B8F3"
+$baseUrl = "https://download.microsoft.com/download/B/1/7/B1783FE9-717B-4F78-A39A-A2E27E3D679D/ENU/x64"
+$signatureThumbrint = "9ACA9419E53D3C9E56396DD2335FF683A8B0B8F3"
 
 # install required MSIs
-$SQLSysClrTypesName = "SQLSysClrTypes.msi"
-$SQLSysClrTypesUrl = "${BaseUrl}/${SQLSysClrTypesName}"
-Install-Binary -Url $SQLSysClrTypesUrl -Name $SQLSysClrTypesName -ExpectedSignature $SignatureThumbrint
+Install-Binary `
+  -Url "${baseUrl}/SQLSysClrTypes.msi" `
+  -ExpectedSignature $signatureThumbrint
 
-$SharedManagementObjectsName = "SharedManagementObjects.msi"
-$SharedManagementObjectsUrl = "${BaseUrl}/${SharedManagementObjectsName}"
-Install-Binary -Url $SharedManagementObjectsUrl -Name $SharedManagementObjectsName -ExpectedSignature $SignatureThumbrint
+Install-Binary `
+  -Url "${baseUrl}/SharedManagementObjects.msi" `
+  -ExpectedSignature $signatureThumbrint
 
-$PowerShellToolsName = "PowerShellTools.msi"
-$PowerShellToolsUrl = "${BaseUrl}/${PowerShellToolsName}"
-Install-Binary -Url $PowerShellToolsUrl -Name $PowerShellToolsName -ExpectedSignature $SignatureThumbrint
+Install-Binary `
+  -Url "${baseUrl}/PowerShellTools.msi" `
+  -ExpectedSignature $signatureThumbrint

--- a/images/windows/scripts/build/Install-Sbt.ps1
+++ b/images/windows/scripts/build/Install-Sbt.ps1
@@ -5,7 +5,7 @@
 
 # Install the latest version of sbt.
 # See https://chocolatey.org/packages/sbt
-Choco-Install -PackageName sbt
+Install-ChocoPackage sbt
 
 $env:SBT_HOME="${env:ProgramFiles(x86)}\sbt"
 

--- a/images/windows/scripts/build/Install-ServiceFabricSDK.ps1
+++ b/images/windows/scripts/build/Install-ServiceFabricSDK.ps1
@@ -8,18 +8,19 @@
 New-Item -Path 'C:\Windows\Installer' -ItemType Directory -Force
 
 # Get Service Fabric components versions
-$serviceFabricRuntimeVersion = (Get-ToolsetContent).serviceFabric.runtime.version
-$serviceFabricSDKVersion = (Get-ToolsetContent).serviceFabric.sdk.version
+$runtimeVersion = (Get-ToolsetContent).serviceFabric.runtime.version
+$sdkVersion = (Get-ToolsetContent).serviceFabric.sdk.version
+$urlBase = "https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856"
 
 # Install Service Fabric Runtime for Windows
-$InstallerName = "MicrosoftServiceFabric.${serviceFabricRuntimeVersion}.exe"
-$InstallerUrl = "https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/${InstallerName}"
-$ArgumentList = ("/accepteula ","/quiet","/force")
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ArgumentList $ArgumentList -ExpectedSignature (Get-ToolsetContent).serviceFabric.runtime.signature
+Install-Binary `
+  -Url "${urlBase}/MicrosoftServiceFabric.${runtimeVersion}.exe" `
+  -Args @("/accepteula ", "/quiet", "/force") `
+  -ExpectedSignature (Get-ToolsetContent).serviceFabric.runtime.signature
 
 # Install Service Fabric SDK
-$InstallerName = "MicrosoftServiceFabricSDK.${serviceFabricSDKVersion}.msi"
-$InstallerUrl = "https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be98-9d8b5abf7856/${InstallerName}"
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ExpectedSignature (Get-ToolsetContent).serviceFabric.sdk.signature
+Install-Binary `
+  -Url "${urlBase}/MicrosoftServiceFabricSDK.${sdkVersion}.msi" `
+  -ExpectedSignature (Get-ToolsetContent).serviceFabric.sdk.signature
 
 Invoke-PesterTests -TestFile "Tools" -TestName "ServiceFabricSDK" 

--- a/images/windows/scripts/build/Install-ServiceFabricSDK.ps1
+++ b/images/windows/scripts/build/Install-ServiceFabricSDK.ps1
@@ -15,7 +15,7 @@ $urlBase = "https://download.microsoft.com/download/b/8/a/b8a2fb98-0ec1-41e5-be9
 # Install Service Fabric Runtime for Windows
 Install-Binary `
   -Url "${urlBase}/MicrosoftServiceFabric.${runtimeVersion}.exe" `
-  -Args @("/accepteula ", "/quiet", "/force") `
+  -InstallArgs @("/accepteula ", "/quiet", "/force") `
   -ExpectedSignature (Get-ToolsetContent).serviceFabric.runtime.signature
 
 # Install Service Fabric SDK

--- a/images/windows/scripts/build/Install-VCRedist.ps1
+++ b/images/windows/scripts/build/Install-VCRedist.ps1
@@ -9,12 +9,12 @@ $signatureThumbrint = "ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B"
 
 Install-Binary `
   -Url "${baseUrl}/vcredist_x86.exe" `
-  -Args $argumentList `
+  -InstallArgs $argumentList `
   -ExpectedSignature $signatureThumbrint
 
 Install-Binary `
   -Url "${baseUrl}/vcredist_x64.exe" `
-  -Args $argumentList `
+  -InstallArgs $argumentList `
   -ExpectedSignature $signatureThumbrint
 
 Invoke-PesterTests -TestFile "Tools" -TestName "VCRedist"

--- a/images/windows/scripts/build/Install-VCRedist.ps1
+++ b/images/windows/scripts/build/Install-VCRedist.ps1
@@ -3,14 +3,18 @@
 ##  Desc:  Install Visual C++ Redistributable
 ################################################################################
 
-$vc2010x86Name = "vcredist_x86.exe"
-$vc2010x86URI = "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/${vc2010x86Name}"
-$vc2010x64Name = "vcredist_x64.exe"
-$vc2010x64URI = "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/${Vc2010x64Name}"
+$baseUrl = "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC"
 $argumentList = ("/install", "/quiet", "/norestart")
-$vcSignatureThumbprint = "ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B"
+$signatureThumbrint = "ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B"
 
-Install-Binary -Url $vc2010x86URI -Name $vc2010x86Name -ArgumentList $argumentList -ExpectedSignature $vcSignatureThumbprint
-Install-Binary -Url $vc2010x64URI -Name $vc2010x64Name -ArgumentList $argumentList -ExpectedSignature $vcSignatureThumbprint
+Install-Binary `
+  -Url "${baseUrl}/vcredist_x86.exe" `
+  -Args $argumentList `
+  -ExpectedSignature $signatureThumbrint
+
+Install-Binary `
+  -Url "${baseUrl}/vcredist_x64.exe" `
+  -Args $argumentList `
+  -ExpectedSignature $signatureThumbrint
 
 Invoke-PesterTests -TestFile "Tools" -TestName "VCRedist"

--- a/images/windows/scripts/build/Install-VSExtensions.ps1
+++ b/images/windows/scripts/build/Install-VSExtensions.ps1
@@ -18,7 +18,7 @@ $vsixPackagesList | ForEach-Object {
     } else {
         Install-Binary `
             -Url $vsixPackage.DownloadUri `
-            -Args @('/install', '/quiet', '/norestart')
+            -InstallArgs @('/install', '/quiet', '/norestart')
     }
 }
 

--- a/images/windows/scripts/build/Install-VSExtensions.ps1
+++ b/images/windows/scripts/build/Install-VSExtensions.ps1
@@ -16,8 +16,9 @@ $vsixPackagesList | ForEach-Object {
     if ($vsixPackage.FileName.EndsWith(".vsix")) {
         Install-VsixExtension -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName
     } else {
-        $argumentList = ('/install', '/quiet', '/norestart')
-        Install-Binary -Url $vsixPackage.DownloadUri -Name $vsixPackage.FileName -ArgumentList $argumentList
+        Install-Binary `
+            -Url $vsixPackage.DownloadUri `
+            -Args @('/install', '/quiet', '/norestart')
     }
 }
 

--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -30,29 +30,25 @@ $newContent = '{"Extensions":[{"Key":"1e906ff5-9da8-4091-a299-5c253c55fdc9","Val
 Set-Content -Path "$vsInstallRoot\Common7\IDE\Extensions\MachineState.json" -Value $newContent
 
 if (Test-IsWin19) {
-    
     # Install Windows 10 SDK version 10.0.14393.795
-    $sdkSignatureThumbprint = "C91545B333C52C4465DE8B90A3FAF4E1D9C58DFA"
-    $sdkUrl = "https://go.microsoft.com/fwlink/p/?LinkId=838916"
-    $sdkFileName = "sdksetup14393.exe"
-    $argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit")
-    Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList -ExpectedSignature $sdkSignatureThumbprint
+    Install-Binary -Type EXE `
+        -Url 'https://go.microsoft.com/fwlink/p/?LinkId=838916' `
+        -Args @("/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit") `
+        -ExpectedSignature 'C91545B333C52C4465DE8B90A3FAF4E1D9C58DFA'
     
     # Install Windows 11 SDK version 10.0.22621.0
-    $sdkSignatureThumbprint = "E4C5C5FCDB68B930EE4E19BC25D431EF6D864C51"
-    $sdkUrl = "https://go.microsoft.com/fwlink/p/?linkid=2196241"
-    $sdkFileName = "sdksetup22621.exe"
-    $argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64")
-    Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList -ExpectedSignature $sdkSignatureThumbprint   
+    Install-Binary -Type EXE `
+        -Url 'https://go.microsoft.com/fwlink/p/?linkid=2196241' `
+        -Args @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
+        -ExpectedSignature 'E4C5C5FCDB68B930EE4E19BC25D431EF6D864C51'   
 }
 
 if (Test-IsWin22) {    
     # Install Windows 10 SDK version 10.0.17763
-    $sdkSignatureThumbprint = "7535269B94C1FEA4A5EF6D808E371DA242F27936"
-    $sdkUrl = "https://go.microsoft.com/fwlink/p/?LinkID=2033908"
-    $sdkFileName = "sdksetup17763.exe"
-    $argumentList = ("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64")
-    Install-Binary -Url $sdkUrl -Name $sdkFileName -ArgumentList $argumentList -ExpectedSignature $sdkSignatureThumbprint
+    Install-Binary -Type EXE `
+        -Url 'https://go.microsoft.com/fwlink/p/?LinkID=2033908' `
+        -Args @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
+        -ExpectedSignature '7535269B94C1FEA4A5EF6D808E371DA242F27936'
 }
 
 Invoke-PesterTests -TestFile "VisualStudio"

--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -33,13 +33,13 @@ if (Test-IsWin19) {
     # Install Windows 10 SDK version 10.0.14393.795
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/p/?LinkId=838916' `
-        -Args @("/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit") `
+        -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit") `
         -ExpectedSignature 'C91545B333C52C4465DE8B90A3FAF4E1D9C58DFA'
     
     # Install Windows 11 SDK version 10.0.22621.0
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/p/?linkid=2196241' `
-        -Args @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
+        -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
         -ExpectedSignature 'E4C5C5FCDB68B930EE4E19BC25D431EF6D864C51'   
 }
 
@@ -47,7 +47,7 @@ if (Test-IsWin22) {
     # Install Windows 10 SDK version 10.0.17763
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/p/?LinkID=2033908' `
-        -Args @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
+        -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
         -ExpectedSignature '7535269B94C1FEA4A5EF6D808E371DA242F27936'
 }
 

--- a/images/windows/scripts/build/Install-WDK.ps1
+++ b/images/windows/scripts/build/Install-WDK.ps1
@@ -8,7 +8,7 @@ if (Test-IsWin19) {
     # Install all features without showing the GUI using winsdksetup.exe
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/?linkid=2173743' `
-        -Args @("/features", "+", "/quiet") `
+        -InstallArgs @("/features", "+", "/quiet") `
         -ExpectedSignature '44796EB5BD439B4BFB078E1DC2F8345AE313CBB1'
 
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2166289"
@@ -26,7 +26,7 @@ if (Test-IsWin19) {
 # Install all features without showing the GUI using wdksetup.exe
 Install-Binary -Type EXE `
     -Url $wdkUrl `
-    -Args @("/features", "+", "/quiet") `
+    -InstallArgs @("/features", "+", "/quiet") `
     -ExpectedSignature $wdkSignatureThumbprint
 
 # Need to install the VSIX to get the build targets when running VSBuild

--- a/images/windows/scripts/build/Install-WDK.ps1
+++ b/images/windows/scripts/build/Install-WDK.ps1
@@ -31,6 +31,6 @@ Install-Binary -Type EXE `
 
 # Need to install the VSIX to get the build targets when running VSBuild
 $wdkExtensionPath = Resolve-Path -Path $wdkExtensionPath
-Install-VsixExtension -wdkExtensionPath $wdkExtensionPath -Name "WDK.vsix" -InstallOnly
+Install-VsixExtension -FilePath $wdkExtensionPath -Name "WDK.vsix" -InstallOnly
 
 Invoke-PesterTests -TestFile "WDK"

--- a/images/windows/scripts/build/Install-WebPlatformInstaller.ps1
+++ b/images/windows/scripts/build/Install-WebPlatformInstaller.ps1
@@ -3,10 +3,8 @@
 ##  Desc:  Install WebPlatformInstaller
 ################################################################################
 
-# Download and install WebPlatformInstaller
-$webPlatformInstallerFile = "WebPlatformInstaller_x64_en-US.msi"
-$webPlatformInstallerUrl = "http://go.microsoft.com/fwlink/?LinkId=287166"
-$webPlatformInstallerSignatureThumbprint = "C3A3D43788E7ABCD287CB4F5B6583043774F99D2"
-Install-Binary -Url $webPlatformInstallerUrl -Name $webPlatformInstallerFile -ExpectedSignature $webPlatformInstallerSignatureThumbprint
+Install-Binary -Type MSI `
+  -Url 'http://go.microsoft.com/fwlink/?LinkId=287166' `
+  -ExpectedSignature 'C3A3D43788E7ABCD287CB4F5B6583043774F99D2'
 
 Invoke-PesterTests -TestFile "Tools" -TestName "WebPlatformInstaller"

--- a/images/windows/scripts/build/Install-WinAppDriver.ps1
+++ b/images/windows/scripts/build/Install-WinAppDriver.ps1
@@ -3,12 +3,13 @@
 ##  Desc:  Install Windows Application Driver (WinAppDriver)
 ####################################################################################
 
-$LatestReleaseUrl = 'https://api.github.com/repos/microsoft/WinAppDriver/releases/latest'
-$InstallerUrl = (Invoke-RestMethod -Uri $LatestReleaseUrl).assets.browser_download_url
-$InstallerName = "WindowsApplicationDriver.msi"
-$InstallerSignatureThumbprint = "2485A7AFA98E178CB8F30C9838346B514AEA4769"
-
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Install-Binary -Url $InstallerUrl -Name $InstallerName -ExpectedSignature $InstallerSignatureThumbprint
+
+$latestReleaseUrl = 'https://api.github.com/repos/microsoft/WinAppDriver/releases/latest'
+$installerUrl = (Invoke-RestMethod -Uri $latestReleaseUrl).assets.browser_download_url
+
+Install-Binary `
+  -Url $installerUrl `
+  -ExpectedSignature '2485A7AFA98E178CB8F30C9838346B514AEA4769'
 
 Invoke-PesterTests -TestFile "WinAppDriver" -TestName "WinAppDriver"

--- a/images/windows/scripts/build/Install-Wix.ps1
+++ b/images/windows/scripts/build/Install-Wix.ps1
@@ -3,6 +3,6 @@
 ##  Desc:  Install WIX.
 ################################################################################
 
-Choco-Install -PackageName wixtoolset -ArgumentList "--force"
+Install-ChocoPackage wixtoolset -ArgumentList "--force"
 
 Invoke-PesterTests -TestFile "Wix"

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -34,7 +34,7 @@ Export-ModuleMember -Function @(
     'Get-WinVersion'
     'Test-IsWin22'
     'Test-IsWin19'
-    'Choco-Install'
+    'Install-ChocoPackage'
     'Send-RequestToCocolateyPackages'
     'Get-LatestChocoPackageVersion'
     'Get-GitHubPackageDownloadUrl'

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -36,7 +36,7 @@ Export-ModuleMember -Function @(
     'Test-IsWin19'
     'Install-ChocoPackage'
     'Send-RequestToCocolateyPackages'
-    'Get-LatestChocoPackageVersion'
+    'Resolve-ChocoPackageVersion'
     'Get-GitHubPackageDownloadUrl'
     'Extract-7Zip'
     'Invoke-SBWithRetry'

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -45,8 +45,8 @@ function Install-Binary {
         [String[]] $InstallArgs,
         [String[]] $ExtraInstallArgs,
         [String[]] $ExpectedSignature,
-        [String[]] $ExpectedSHA256Sum,
-        [String[]] $ExpectedSHA512Sum
+        [String] $ExpectedSHA256Sum,
+        [String] $ExpectedSHA512Sum
     )
 
     if ($PSCmdlet.ParameterSetName -eq "LocalPath") {
@@ -79,22 +79,14 @@ function Install-Binary {
         }
     }
 
-    if ($PSBoundParameters.ContainsKey('ExpectedSHA256Sum')) {
-        if ($ExpectedSHA256Sum) {
-            $fileHash = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
-            Use-ChecksumComparison $fileHash $ExpectedSHA256Sum
-        } else {
-            throw "ExpectedSHA256Sum parameter is specified, but no hash is provided."
-        }
+    if ($ExpectedSHA256Sum) {
+        $fileHash = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
+        Use-ChecksumComparison $fileHash $ExpectedSHA256Sum
     }
 
-    if ($PSBoundParameters.ContainsKey('ExpectedSHA512Sum')) {
-        if ($ExpectedSHA512Sum) {
-            $fileHash = (Get-FileHash -Path $filePath -Algorithm SHA512).Hash
-            Use-ChecksumComparison $fileHash $ExpectedSHA512Sum
-        } else {
-            throw "ExpectedSHA512Sum parameter is specified, but no hash is provided."
-        }
+    if ($ExpectedSHA512Sum) {
+        $fileHash = (Get-FileHash -Path $filePath -Algorithm SHA512).Hash
+        Use-ChecksumComparison $fileHash $ExpectedSHA512Sum
     }
 
     if ($ExtraInstallArgs -and $InstallArgs) {

--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -66,14 +66,19 @@ Function Install-VisualStudio {
         $responseDataPath = "$env:TEMP\vs_install_response.json"
         $responseData | ConvertTo-Json | Out-File -FilePath $responseDataPath
 
+        $installStartTime = Get-Date
         Write-Host "Starting Install ..."
         $bootstrapperArgumentList = ('/c', $bootstrapperFilePath, '--in', $responseDataPath, $ExtraArgs, '--quiet', '--norestart', '--wait', '--nocache' )
         Write-Host "Bootstrapper arguments: $bootstrapperArgumentList"
         $process = Start-Process -FilePath cmd.exe -ArgumentList $bootstrapperArgumentList -Wait -PassThru
 
         $exitCode = $process.ExitCode
-        if ($exitCode -eq 0 -or $exitCode -eq 3010) {
-            Write-Host "Installation successful"
+        $installCompleteTime = [math]::Round(($(Get-Date) - $installStartTime).TotalSeconds, 2)
+        if ($exitCode -eq 0) {
+            Write-Host "Installation successful in $installCompleteTime seconds"
+            return $exitCode
+        } elseif ($exitCode -eq 3010) {
+            Write-Host "Installation successful in $installCompleteTime seconds. Reboot is required."
             return $exitCode
         } else {
             Write-Host "Non zero exit code returned by the installation process : $exitCode"


### PR DESCRIPTION
# Description

This pull request includes a series of changes to improve the installation process for various tools and packages in the Windows build script. The most important changes include:
- refactoring the code of the `Install-Binary` function:
  - introduce new `Type` parameter in place of the `Name` parameter as the latter one were used mainly to infer installer type;
  - rename the `FilePath` parameter to `LocalPath` to better represent its meaning;
  - introduce parameters `InstallArgs` and `ExtraInstallArgs` instead of a single `ArgumentList` to provide more convenient way to pass installation options to MSI installers;
  - add parameters `ExpectedSHA256Sum` and `ExpectedSHA512Sum` to allow checking installer checksum before installation;
- simplifying various scripts by utilizing updated `Install-Binary` function;
- renaming the `Choco-Install` command to `Install-ChocoPackage` and the `Get-LatestChocoPackageVersion` to `Resolve-ChocoPackageVersion` in order to follow recommended practices for naming;
- improving error handling in the `Start-DownloadWithRetry` function;
- removing the `Get-PowerShellCoreHash` function from `Install-PowershellCore.ps1` and the `Install-Msi` function from `Install-BizTalkBuildComponent.ps1` as they have been introducing extra complexity only.

#### Related issue: https://github.com/github/compute-products-contractors/issues/44

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
