### PR TITLE
[Windows] Add .NET 8 support

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -423,7 +423,8 @@
     "dotnet": {
         "versions": [
             "6.0",
-            "7.0"
+            "7.0",
+            "8.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -364,7 +364,8 @@
     "dotnet": {
         "versions": [
             "6.0",
-            "7.0"
+            "7.0",
+            "8.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }


### PR DESCRIPTION
# Description
This pull request adds .NET 8 support in both windows json definitions. Although mentioned in https://github.com/actions/runner-images/issues/8864#issuecomment-1822301037 that there are new images available, it does not seem to be added to the windows json definitions on main.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: #8864

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
