### PR TITLE
[ubuntu] Change echo to printf for escape sequences

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -29,7 +29,7 @@ fi
 apt-get update
 apt-get -y install ${install_packages[@]}
 mkdir -p /etc/containers
-echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | tee /etc/containers/registries.conf
+printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc/containers/registries.conf
 
 if isUbuntu20; then
     # Remove source repo

--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -60,7 +60,7 @@ IsPackageInstalled() {
 }
 
 verlte() {
-    sortedVersion=$(echo -e "$1\n$2" | sort -V | head -n1)
+    sortedVersion=$(printf "$1\n$2\n" | sort -V | head -n1)
     [  "$1" = "$sortedVersion" ]
 }
 


### PR DESCRIPTION
# Description
PR changes `echo -e` to `printf` as a tool more suited for escape sequences handling

#### Related issue: https://github.com/actions/runner-images-internal/issues/5606

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
