### PR TITLE
[ubuntu] Refactor Common.Helpers

### DIFF
--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -135,7 +135,7 @@ function Get-HomebrewVersion {
 }
 
 function Get-CpanVersion {
-    $result = Get-CommandResult "cpan --version" -ExpectExitCode @(25, 255)
+    $result = Get-CommandResult "cpan --version" -ExpectedExitCode @(25, 255)
     $result.Output -match "version (?<version>\d+\.\d+) " | Out-Null
     return $Matches.version
 }

--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Helpers.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Helpers.psm1
@@ -39,3 +39,16 @@ function Get-AptSourceRepository {
     $sourceUrl = Get-Content "$PSScriptRoot/../helpers/apt-sources.txt" | Select-String -Pattern $PackageName | Take-OutputPart -Part (1..3)
     return $sourceUrl
 }
+
+function Get-OSVersionShort {
+    $(Get-OSVersionFull) | Take-OutputPart -Delimiter '.' -Part 0,1
+}
+
+function Get-OSVersionFull {
+    lsb_release -ds | Take-OutputPart -Part 1, 2
+}
+
+function Get-KernelVersion {
+    $kernelVersion = uname -r
+    return $kernelVersion
+}

--- a/images/ubuntu/scripts/tests/Android.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Android.Tests.ps1
@@ -27,67 +27,76 @@ Describe "Android" {
             $targetPath = Join-Path $env:ANDROID_HOME $PackageName
             $targetPath | Should -Exist
         }
+    }
 
-        function Get-AndroidPackages {
-            <#
-            .SYNOPSIS
-                This function returns a list of available Android packages.
+    function Get-AndroidPackages {
+        <#
+        .SYNOPSIS
+            This function returns a list of available Android packages.
 
-            .DESCRIPTION
-                The Get-AndroidPackages function checks if a list of packages is already available in a file.
-                If not, it uses the sdkmanager to generate a list of available packages and saves it to a file.
-                It then returns the content of this file.
+        .DESCRIPTION
+            The Get-AndroidPackages function checks if a list of packages is already available in a file.
+            If not, it uses the sdkmanager to generate a list of available packages and saves it to a file.
+            It then returns the content of this file.
 
-            .PARAMETER SDKRootPath
-                The root path of the Android SDK installation.
-                If not specified, the function uses the ANDROID_HOME environment variable.
+        .PARAMETER SDKRootPath
+            The root path of the Android SDK installation.
+            If not specified, the function uses the ANDROID_HOME environment variable.
 
-            .EXAMPLE
-                Get-AndroidPackages -SDKRootPath "/usr/local/lib/android/sdk"
+        .EXAMPLE
+            Get-AndroidPackages -SDKRootPath "/usr/local/lib/android/sdk"
 
-                This command returns a list of available Android packages for the specified SDK root path.
+            This command returns a list of available Android packages for the specified SDK root path.
 
-            .NOTES
-                This function requires the Android SDK to be installed.
-            #>
-            param (
-                [Parameter(Mandatory=$false)]
-                [string] $SDKRootPath
-            )
+        .NOTES
+            This function requires the Android SDK to be installed.
+        #>
+        param (
+            [Parameter(Mandatory=$false)]
+            [string] $SDKRootPath
+        )
 
-            if (-not $SDKRootPath) {
-                $SDKRootPath = $env:ANDROID_HOME
-            }
-
-            $packagesListFile = "$SDKRootPath/packages-list.txt"
-
-            if (-not (Test-Path -Path $packagesListFile -PathType Leaf)) {
-                (/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager --list --verbose 2>&1) |
-                    Where-Object { $_ -Match "^[^\s]" } |
-                    Where-Object { $_ -NotMatch "^(Loading |Info: Parsing |---|\[=+|Installed |Available )" } |
-                    Where-Object { $_ -NotMatch "^[^;]*$" } |
-                    Out-File -FilePath $packagesListFile
-
-                Write-Host "Android packages list:"
-                Get-Content $packagesListFile
-            }
-
-            return Get-Content $packagesListFile
+        if (-not $SDKRootPath) {
+            $SDKRootPath = $env:ANDROID_HOME
         }
+
+        $packagesListFile = "$SDKRootPath/packages-list.txt"
+
+        if (-not (Test-Path -Path $packagesListFile -PathType Leaf)) {
+            (/usr/local/lib/android/sdk/cmdline-tools/latest/bin/sdkmanager --list --verbose 2>&1) |
+                Where-Object { $_ -Match "^[^\s]" } |
+                Where-Object { $_ -NotMatch "^(Loading |Info: Parsing |---|\[=+|Installed |Available )" } |
+                Where-Object { $_ -NotMatch "^[^;]*$" } |
+                Out-File -FilePath $packagesListFile
+
+            Write-Host "Android packages list:"
+            Get-Content $packagesListFile
+        }
+
+        return Get-Content $packagesListFile
     }
 
     $androidSdkManagerPackages = Get-AndroidPackages
     [int]$platformMinVersion = Get-ToolsetValue "android.platform_min_version"
     [version]$buildToolsMinVersion = Get-ToolsetValue "android.build_tools_min_version"
     [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
-    $ndkFullVersions = $ndkVersions | ForEach-Object { (Get-ChildItem "/usr/local/lib/android/sdk/ndk/${_}.*" | Select-Object -Last 1).Name } | ForEach-Object { "ndk/${_}" }
+    $ndkFullVersions = $ndkVersions |
+        ForEach-Object { (Get-ChildItem "/usr/local/lib/android/sdk/ndk/${_}.*" |
+        Select-Object -Last 1).Name } | ForEach-Object { "ndk/${_}" }
     # Platforms starting with a letter are the preview versions, which is not installed on the image
-    $platformVersionsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', '' | Where-Object { $_ -match "^\d" } | Sort-Object -Unique
-    $platformsInstalled = $platformVersionsList | Where-Object { [int]($_.Split("-")[0]) -ge $platformMinVersion } | ForEach-Object { "platforms/android-${_}" }
+    $platformVersionsList = ($androidSdkManagerPackages |
+        Where-Object { "$_".StartsWith("platforms;") }) -replace 'platforms;android-', '' |
+        Where-Object { $_ -match "^\d" } | Sort-Object -Unique
+    $platformsInstalled = $platformVersionsList |
+        Where-Object { [int]($_.Split("-")[0]) -ge $platformMinVersion } |
+        ForEach-Object { "platforms/android-${_}" }
 
     $buildToolsList = ($androidSdkManagerPackages | Where-Object { "$_".StartsWith("build-tools;") }) -replace 'build-tools;', ''
-    $buildTools = $buildToolsList | Where-Object { $_ -match "\d+(\.\d+){2,}$"} | Where-Object { [version]$_ -ge $buildToolsMinVersion } | Sort-Object -Unique |
-    ForEach-Object { "build-tools/${_}" }
+    $buildTools = $buildToolsList |
+        Where-Object { $_ -match "\d+(\.\d+){2,}$"} |
+        Where-Object { [version]$_ -ge $buildToolsMinVersion } |
+        Sort-Object -Unique |
+        ForEach-Object { "build-tools/${_}" }
 
     $androidPackages = @(
         $platformsInstalled,

--- a/images/ubuntu/scripts/tests/Java.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Java.Tests.ps1
@@ -8,8 +8,8 @@ Describe "Java" {
     [array]$testCases = $jdkVersions | ForEach-Object { @{Version = $_ } }
 
     It "Java <DefaultJavaVersion> is default" -TestCases @{ DefaultJavaVersion = $defaultVersion } {
-        $actualJavaPath = Get-EnvironmentVariable "JAVA_HOME"
-        $expectedJavaPath = Get-EnvironmentVariable "JAVA_HOME_${DefaultJavaVersion}_X64"
+        $actualJavaPath = [System.Environment]::GetEnvironmentVariable("JAVA_HOME")
+        $expectedJavaPath = [System.Environment]::GetEnvironmentVariable("JAVA_HOME_${DefaultJavaVersion}_X64")
 
         $actualJavaPath | Should -Not -BeNullOrEmpty
         $expectedJavaPath | Should -Not -BeNullOrEmpty
@@ -28,7 +28,7 @@ Describe "Java" {
     It "Gradle" {
         "gradle -version" | Should -ReturnZeroExitCode
 
-        $gradleVariableValue = Get-EnvironmentVariable "GRADLE_HOME"
+        $gradleVariableValue = [System.Environment]::GetEnvironmentVariable("GRADLE_HOME")
         $gradleVariableValue | Should -BeLike "/usr/share/gradle-*"
 
         $gradlePath = Join-Path $env:GRADLE_HOME "bin/gradle"
@@ -36,7 +36,7 @@ Describe "Java" {
     }
 
     It "Java <Version>" -TestCases $testCases {
-        $javaVariableValue = Get-EnvironmentVariable "JAVA_HOME_${Version}_X64"
+        $javaVariableValue = [System.Environment]::GetEnvironmentVariable("JAVA_HOME_${Version}_X64")
         $javaVariableValue | Should -Not -BeNullOrEmpty
         $javaPath = Join-Path $javaVariableValue "bin/java"
 


### PR DESCRIPTION
# Description
This PR adjusts `Common.Helpers.psm1`:
1. Move `Get-OSVersionShort`, `Get-OSVersionFull`, `Get-KernelVersion` functions to `SoftwareReport.Helpers.psm1` - functions are only used in report generation
2. Move `Get-AndroidPackages` function to `Android.Tests.ps1` - function is not used anywhere else
3. Remove `Get-EnvironmentVariable` function - use `[System.Environment]::GetEnvironmentVariable()` directly instead as it is self-explanatory on its own
4. Rename `Validate-AndroidPackage` function to `Test-AndroidPackage` - approved verb
5. Add descriptions of complex functions

#### Related issue: https://github.com/actions/runner-images-internal/issues/5606

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
