### PR TITLE
[Windows] Update functions that get urls and hashes from Github

### DIFF
--- a/images/windows/scripts/build/Install-AWSTools.ps1
+++ b/images/windows/scripts/build/Install-AWSTools.ps1
@@ -26,7 +26,7 @@ $externalHash = Get-GithubReleaseAssetHash `
     -HashType "SHA256"
 
 Install-Binary `
-    -Url "https://github.com/awslabs/aws-sam-cli/releases/latest/download/$packageName" `
+    -Url $downloadUrl `
     -ExpectedSHA256Sum $externalHash
 
 Invoke-PesterTests -TestFile "CLI.Tools" -TestName "AWS"

--- a/images/windows/scripts/build/Install-AWSTools.ps1
+++ b/images/windows/scripts/build/Install-AWSTools.ps1
@@ -9,17 +9,24 @@ Install-ChocoPackage awscli
 
 # Install Session Manager Plugin for the AWS CLI
 Install-Binary `
-  -Url "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe" `
-  -InstallArgs ("/silent", "/install") `
-  -ExpectedSignature "FF457E5732E98A9F156E657F8CC7C4432507C3BB"
+    -Url "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe" `
+    -InstallArgs ("/silent", "/install") `
+    -ExpectedSignature "FF457E5732E98A9F156E657F8CC7C4432507C3BB"
 $env:Path = $env:Path + ";$env:ProgramFiles\Amazon\SessionManagerPlugin\bin"
 
 # Install AWS SAM CLI
-$packageName = "AWS_SAM_CLI_64_PY3.msi"
-$packageUrl = "https://github.com/awslabs/aws-sam-cli/releases/latest/download/$packageName"
-$externalHash = Get-HashFromGitHubReleaseBody -RepoOwner "awslabs" -RepoName "aws-sam-cli" -FileName $packageName
+$downloadUrl = Resolve-GithubReleaseAssetUrl `
+    -Repo "awslabs/aws-sam-cli" `
+    -Version "latest" `
+    -UrlMatchPattern "AWS_SAM_CLI_64_PY3.msi"
+$externalHash = Get-GithubReleaseAssetHash `
+    -Repo "awslabs/aws-sam-cli" `
+    -Version "latest" `
+    -FileName (Split-Path $downloadUrl -Leaf) `
+    -HashType "SHA256"
+
 Install-Binary `
-  -Url $packageUrl `
-  -ExpectedSHA256Sum $externalHash
+    -Url "https://github.com/awslabs/aws-sam-cli/releases/latest/download/$packageName" `
+    -ExpectedSHA256Sum $externalHash
 
 Invoke-PesterTests -TestFile "CLI.Tools" -TestName "AWS"

--- a/images/windows/scripts/build/Install-Git.ps1
+++ b/images/windows/scripts/build/Install-Git.ps1
@@ -5,12 +5,17 @@
 ################################################################################
 
 # Install the latest version of Git for Windows
-$repoURL = "https://api.github.com/repos/git-for-windows/git/releases/latest"
-$gitReleases = Invoke-RestMethod $repoURL
-$downloadUrl = $gitReleases.assets.browser_download_url -match "Git-.+-64-bit.exe" | Select-Object -First 1
 
-$installerFile = Split-Path $downloadUrl -Leaf
-$externalHash = Get-HashFromGitHubReleaseBody -Url $RepoURL -FileName $installerFile
+$downloadUrl = Resolve-GithubReleaseAssetUrl `
+    -Repo "git-for-windows/git" `
+    -Version "latest" `
+    -UrlMatchPattern "Git-*-64-bit.exe"
+
+$externalHash = Get-GithubReleaseAssetHash `
+    -Repo "git-for-windows/git" `
+    -Version "latest" `
+    -FileName (Split-Path $downloadUrl -Leaf) `
+    -HashType "SHA256"
 
 Install-Binary `
     -Url $downloadUrl `

--- a/images/windows/scripts/build/Install-Kotlin.ps1
+++ b/images/windows/scripts/build/Install-Kotlin.ps1
@@ -9,12 +9,16 @@ $kotlinVersion = (Get-ToolsetContent).kotlin.version
 
 $kotlinDownloadUrl = Resolve-GithubReleaseAssetUrl `
     -Repo "JetBrains/kotlin" `
-    -Version $kotlinVersion `
+    -Version "$kotlinVersion" `
     -Asset "kotlin-compiler-*.zip"
 $kotlinArchivePath = Invoke-DownloadWithRetry $kotlinDownloadUrl
 
 #region Supply chain security
-$externalHash = Get-HashFromGitHubReleaseBody -RepoOwner "JetBrains" -RepoName "kotlin" -FileName "$kotlinBinaryName-*.zip" -Version $kotlinVersion -WordNumber 2
+$externalHash = Get-GithubReleaseAssetHash `
+    -Repo "JetBrains/kotlin" `
+    -Version "$kotlinVersion" `
+    -FileName (Split-Path $kotlinDownloadUrl -Leaf) `
+    -HashType "SHA256"
 Test-FileChecksum $kotlinArchivePath -ExpectedSHA256Sum $externalHash
 #endregion
 

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -38,7 +38,7 @@ Export-ModuleMember -Function @(
     'Get-VisualStudioInstance'
     'Get-VisualStudioComponents'
     'Get-WindowsUpdateStates'
-    'Get-HashFromGitHubReleaseBody'
+    'Get-GithubReleaseAssetHash'
     'Test-FileChecksum'
     'Test-FileSignature'
     'Update-Environment'

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -21,7 +21,6 @@ Export-ModuleMember -Function @(
     'Install-VSIXFromFile'
     'Install-VSIXFromUrl'
     'Get-VSExtensionVersion'
-    'Get-WinVersion'
     'Test-IsWin22'
     'Test-IsWin19'
     'Install-ChocoPackage'

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -396,19 +396,66 @@ function Get-TCToolVersionPath {
     return Join-Path $foundVersion $Arch
 }
 
-function Get-WinVersion {
-    (Get-CimInstance -ClassName Win32_OperatingSystem).Caption
-}
-
 function Test-IsWin22 {
-    (Get-WinVersion) -match "2022"
+    <#
+    .SYNOPSIS
+        Checks if the current Windows operating system is Windows Server 2022.
+
+    .DESCRIPTION
+        This function uses the Get-CimInstance cmdlet to retrieve information
+        about the current Windows operating system. It then checks if the Caption
+        property of the Win32_OperatingSystem class contains the string "2022",
+        indicating that the operating system is Windows Server 2022.
+
+    .OUTPUTS
+        Returns $true if the current Windows operating system is Windows Server 2022.
+        Otherwise, returns $false.
+    #>
+    (Get-CimInstance -ClassName Win32_OperatingSystem).Caption -match "2022"
 }
 
 function Test-IsWin19 {
-    (Get-WinVersion) -match "2019"
+    <#
+    .SYNOPSIS
+        Checks if the current Windows operating system is Windows Server 2019.
+
+    .DESCRIPTION
+        This function uses the Get-CimInstance cmdlet to retrieve information
+        about the current Windows operating system. It then checks if the Caption
+        property of the Win32_OperatingSystem class contains the string "2019",
+        indicating that the operating system is Windows Server 2019.
+
+    .OUTPUTS
+        Returns $true if the current Windows operating system is Windows Server 2019.
+        Otherwise, returns $false.
+    #>
+    (Get-CimInstance -ClassName Win32_OperatingSystem).Caption -match "2019"
 }
 
 function Expand-7ZipArchive {
+    <#
+    .SYNOPSIS
+        Extracts files from a 7-Zip archive.
+
+    .DESCRIPTION
+        This function uses the 7z.exe command-line tool to extract files from an archive.
+        The archive path, destination path, and extract method are specified as parameters.
+
+    .PARAMETER Path
+        The path to the archive.
+
+    .PARAMETER DestinationPath
+        The path to the directory where the files will be extracted.
+
+    .PARAMETER ExtractMethod
+        The method used to extract the files.
+        Valid values are "x" (extract with full paths) and "e" (extract without paths).
+
+    .EXAMPLE
+        Expand-7ZipArchive -Path "C:\archive.7z" -DestinationPath "C:\extracted" -ExtractMethod "x"
+
+        Extracts files from the "C:\archive.7z" archive to the "C:\extracted" directory keeping the full paths.
+    #>
     Param
     (
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
# Description

This pull request includes changes to improve the scripts used to fetch data using Github API:
- Implements the `Get-GithubReleasesByVersion` function that retrieves GitHub releases for a specified repository based on version. Also the function caches the results to improve performance and reduce the number of API calls.
- Updates the `Resolve-GithubReleaseAssetUrl` function to use the new function to work with Github API.
- Implements the function that gets hash from Github release body from scratch, utilizing the new function to work with Github API and implementing simplified interface.

Also this request adds some documentation scripts and removes the `Get-WinVersion` function.

#### Related issue: https://github.com/github/compute-products-contractors/issues/44

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
