### PR TITLE
Fix AzureClientSecret parameter not supporting hyphens

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -249,7 +249,7 @@ Function GenerateResourcesAndImage {
         }
         else {
             Write-Verbose "AzureClientId was provided, will use service principal login."
-            az login --service-principal --username $AzureClientId --password $AzureClientSecret --tenant $AzureTenantId --output none
+            az login --service-principal --username $AzureClientId --password=$AzureClientSecret --tenant $AzureTenantId --output none
         }
         az account set --subscription $SubscriptionId
         if ($LastExitCode -ne 0) {

--- a/images.CI/linux-and-win/cleanup.ps1
+++ b/images.CI/linux-and-win/cleanup.ps1
@@ -6,7 +6,7 @@ param(
     [Parameter (Mandatory=$true)] [string] $TenantId
 )
 
-az login --service-principal --username $ClientId --password $ClientSecret --tenant $TenantId | Out-Null
+az login --service-principal --username $ClientId --password=$ClientSecret --tenant $TenantId | Out-Null
 az account set --subscription $SubscriptionId | Out-Null
 
 $groupExist = az group exists --name $TempResourceGroupName


### PR DESCRIPTION
# Description
Currently the powershell script doesn't support a Service principal which secret contains an hyphen "-".
If someone tries to run the `GenerateResourcesAndImage` script will receive the same error that is exposed [here](https://github.com/Azure/azure-cli/issues/7054).

To fix this I applied the suggestion described in Microsoft documentation [here](https://learn.microsoft.com/en-us/cli/azure/use-cli-effectively?tabs=bash%2Cbash2#use-hyphen-characters-in-parameters).

#### Related issue:
https://github.com/actions/runner-images/issues/8928

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
