### PR TITLE
Allow use of existing resource group

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -357,18 +357,34 @@ Function GenerateResourcesAndImage {
         Write-Debug "Service principal app id: $ServicePrincipalAppId."
         Write-Debug "Tenant id: $TenantId."
 
-        & $PackerBinary build -on-error="$($OnError)" `
-            -var "client_id=$($ServicePrincipalAppId)" `
-            -var "client_secret=$($ServicePrincipalPassword)" `
-            -var "subscription_id=$($SubscriptionId)" `
-            -var "tenant_id=$($TenantId)" `
-            -var "location=$($AzureLocation)" `
-            -var "managed_image_name=$($ManagedImageName)" `
-            -var "managed_image_resource_group_name=$($ResourceGroupName)" `
-            -var "install_password=$($InstallPassword)" `
-            -var "allowed_inbound_ip_addresses=$($AllowedInboundIpAddresses)" `
-            -var "azure_tags=$($TagsJson)" `
-            $TemplatePath
+        if($ReuseResourceGroup){
+            & $PackerBinary build -on-error="$($OnError)" `
+                -var "client_id=$($ServicePrincipalAppId)" `
+                -var "client_secret=$($ServicePrincipalPassword)" `
+                -var "subscription_id=$($SubscriptionId)" `
+                -var "tenant_id=$($TenantId)" `
+                -var "managed_image_name=$($ManagedImageName)" `
+                -var "managed_image_resource_group_name=$($ResourceGroupName)" `
+                -var "install_password=$($InstallPassword)" `
+                -var "allowed_inbound_ip_addresses=$($AllowedInboundIpAddresses)" `
+                -var "azure_tags=$($TagsJson)" `
+                -var "build_resource_group_name=$($ResourceGroupName)" `
+                $TemplatePath
+            }
+            else{
+            & $PackerBinary build -on-error="$($OnError)" `
+                -var "client_id=$($ServicePrincipalAppId)" `
+                -var "client_secret=$($ServicePrincipalPassword)" `
+                -var "subscription_id=$($SubscriptionId)" `
+                -var "tenant_id=$($TenantId)" `
+                -var "location=$($AzureLocation)" `
+                -var "managed_image_name=$($ManagedImageName)" `
+                -var "managed_image_resource_group_name=$($ResourceGroupName)" `
+                -var "install_password=$($InstallPassword)" `
+                -var "allowed_inbound_ip_addresses=$($AllowedInboundIpAddresses)" `
+                -var "azure_tags=$($TagsJson)" `
+                $TemplatePath
+            }
 
         if ($LastExitCode -ne 0) {
             throw "Failed to build image."


### PR DESCRIPTION
# Description
Allow the reuse of an existing resource group to packer, via adding the `build_resource_group_name` var as parameter to packer build.
As per [documentation says](https://developer.hashicorp.com/packer/integrations/hashicorp/azure/latest/components/builder/arm) this variable is necessary and is mutually exclusive with `location`.

#### Related issue:
Resolves https://github.com/actions/runner-images/issues/8936

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
