### PR TITLE
README: recommend always using main for custom images

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,9 @@ For some tools, we always install the latest at the time of the deployment; for 
    <summary><b><i>How do I request that a new tool be pre-installed on the image?</b></i></summary>
 Please create an issue and get an approval from us to add this tool to the image before creating the pull request.
 </details>
+
+<details>
+   <summary><b><i>What branch should I use to build custom image?</b></i></summary>
+We strongly encourage customers to build their own images using the main branch.
+This repository contains multiple branches and releases that serve as document milestones to reflect what software is installed in the images at certain point of time. Current builds are not idempotent and if one tries to build a runner image using the specific tag it is not guaranteed that the build will succeed.
+</details>


### PR DESCRIPTION
We should encourage customers to always use main as builds are not idempotent.
