### PR TITLE
[ubuntu] Refactor GitHub package download URL function

### DIFF
--- a/images/ubuntu/scripts/build/install-actions-cache.sh
+++ b/images/ubuntu/scripts/build/install-actions-cache.sh
@@ -17,7 +17,7 @@ echo "Setting up ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE variable to ${ACTION_ARCHIV
 setEtcEnvironmentVariable "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE" "${ACTION_ARCHIVE_CACHE_DIR}"
 
 # Download latest release from github.com/actions/action-versions and untar to /opt/actionarchivecache
-downloadUrl=$(get_github_package_download_url "actions/action-versions" "contains(\"action-versions.tar.gz\")")
+downloadUrl=$(resolve_github_release_asset_url "actions/action-versions" "contains(\"action-versions.tar.gz\")" "latest")
 archive_path=$(download_with_retry "$downloadUrl")
 tar -xzf "$archive_path" -C $ACTION_ARCHIVE_CACHE_DIR
 

--- a/images/ubuntu/scripts/build/install-aliyun-cli.sh
+++ b/images/ubuntu/scripts/build/install-aliyun-cli.sh
@@ -15,7 +15,7 @@ if isUbuntu20; then
     toolset_version=$(get_toolset_value '.aliyunCli.version')
     download_url="https://github.com/aliyun/aliyun-cli/releases/download/v$toolset_version/aliyun-cli-linux-$toolset_version-amd64.tgz"
 else
-    download_url=$(get_github_package_download_url "aliyun/aliyun-cli" "contains(\"aliyun-cli-linux\") and endswith(\"amd64.tgz\")")
+    download_url=$(resolve_github_release_asset_url "aliyun/aliyun-cli" "contains(\"aliyun-cli-linux\") and endswith(\"amd64.tgz\")" "latest")
     hash_url="https://github.com/aliyun/aliyun-cli/releases/latest/download/SHASUMS256.txt"
 fi
 

--- a/images/ubuntu/scripts/build/install-cmake.sh
+++ b/images/ubuntu/scripts/build/install-cmake.sh
@@ -14,10 +14,10 @@ if command -v cmake; then
     echo "cmake is already installed"
 else
 	# Download script to install CMake
-	download_url=$(get_github_package_download_url "Kitware/CMake" "endswith(\"inux-x86_64.sh\")")
+	download_url=$(resolve_github_release_asset_url "Kitware/CMake" "endswith(\"inux-x86_64.sh\")" "latest")
 	curl -fsSL "${download_url}" -o cmakeinstall.sh
 	# Supply chain security - CMake
-	hash_url=$(get_github_package_download_url "Kitware/CMake" "endswith(\"SHA-256.txt\")")
+	hash_url=$(resolve_github_release_asset_url "Kitware/CMake" "endswith(\"SHA-256.txt\")" "latest")
 	external_hash=$(get_hash_from_remote_file "$hash_url" "linux-x86_64.sh")
 	use_checksum_comparison "cmakeinstall.sh" "$external_hash"
 	# Install CMake and remove the install script

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -19,10 +19,10 @@ apt-get update
 apt-get install --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 
 # Download docker compose v2 from releases
-URL=$(get_github_package_download_url "docker/compose" "contains(\"compose-linux-x86_64\")")
+URL=$(resolve_github_release_asset_url "docker/compose" "contains(\"compose-linux-x86_64\")" "latest")
 curl -fsSL "${URL}" -o /tmp/docker-compose
 # Supply chain security - Docker Compose v2
-compose_hash_url=$(get_github_package_download_url "docker/compose" "contains(\"checksums.txt\")")
+compose_hash_url=$(resolve_github_release_asset_url "docker/compose" "contains(\"checksums.txt\")" "latest")
 compose_external_hash=$(get_hash_from_remote_file "${compose_hash_url}" "compose-linux-x86_64")
 use_checksum_comparison "/tmp/docker-compose" "${compose_external_hash}"
 # Install docker compose v2

--- a/images/ubuntu/scripts/build/install-firefox.sh
+++ b/images/ubuntu/scripts/build/install-firefox.sh
@@ -33,7 +33,7 @@ echo "mozillateam $repo_url" >> $HELPER_SCRIPTS/apt-sources.txt
 echo 'pref("intl.locale.requested","en_US");' >> "/usr/lib/firefox/browser/defaults/preferences/syspref.js"
 
 # Download and unpack latest release of geckodriver
-download_url=$(get_github_package_download_url "mozilla/geckodriver" "test(\"linux64.tar.gz$\")")
+download_url=$(resolve_github_release_asset_url "mozilla/geckodriver" "test(\"linux64.tar.gz$\")" "latest")
 driver_archive_path=$(download_with_retry "$download_url")
 
 GECKODRIVER_DIR="/usr/local/share/gecko_driver"

--- a/images/ubuntu/scripts/build/install-github-cli.sh
+++ b/images/ubuntu/scripts/build/install-github-cli.sh
@@ -10,10 +10,10 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Download GitHub CLI
-gh_cli_url=$(get_github_package_download_url "cli/cli" "contains(\"linux\") and contains(\"amd64\") and contains(\".deb\")")
+gh_cli_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"linux\") and contains(\"amd64\") and contains(\".deb\")" "latest")
 gh_cli_deb_path=$(download_with_retry "$gh_cli_url")
 # Supply chain security - GitHub CLI
-hash_url=$(get_github_package_download_url "cli/cli" "contains(\"checksums.txt\")")
+hash_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"checksums.txt\")" "latest")
 external_hash=$(get_hash_from_remote_file "$hash_url" "linux_amd64.deb")
 use_checksum_comparison "$gh_cli_deb_path" "$external_hash"
 # Install GitHub CLI

--- a/images/ubuntu/scripts/build/install-kotlin.sh
+++ b/images/ubuntu/scripts/build/install-kotlin.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 KOTLIN_ROOT="/usr/share"
-download_url=$(get_github_package_download_url "JetBrains/kotlin" "contains(\"kotlin-compiler\")")
+download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"kotlin-compiler\")" "latest")
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - Kotlin

--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -9,7 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Download KIND
-kind_url=$(get_github_package_download_url "kubernetes-sigs/kind" "contains(\"kind-linux-amd64\")")
+kind_url=$(resolve_github_release_asset_url "kubernetes-sigs/kind" "contains(\"kind-linux-amd64\")" "latest")
 curl -fsSL -o /tmp/kind "${kind_url}"
 # Supply chain security - KIND
 kind_external_hash=$(get_hash_from_remote_file "${kind_url}.sha256sum" "kind-linux-amd64")

--- a/images/ubuntu/scripts/build/install-oras-cli.sh
+++ b/images/ubuntu/scripts/build/install-oras-cli.sh
@@ -8,13 +8,13 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Determine latest ORAS CLI version
-download_url=$(get_github_package_download_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")")
+download_url=$(resolve_github_release_asset_url "oras-project/oras" "endswith(\"linux_amd64.tar.gz\")" "latest")
 
 # Download ORAS CLI
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - ORAS CLI
-hash_url=$(get_github_package_download_url "oras-project/oras" "contains(\"checksums.txt\")")
+hash_url=$(resolve_github_release_asset_url "oras-project/oras" "contains(\"checksums.txt\")" "latest")
 external_hash=$(get_hash_from_remote_file "${hash_url}" "linux_amd64.tar.gz")
 use_checksum_comparison "$archive_path" "${external_hash}"
 

--- a/images/ubuntu/scripts/build/install-runner-package.sh
+++ b/images/ubuntu/scripts/build/install-runner-package.sh
@@ -7,7 +7,7 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-download_url=$(get_github_package_download_url "actions/runner" 'test("actions-runner-linux-x64-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz")')
+download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-linux-x64-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz")' "latest")
 archive_name="${download_url##*/}"
 archive_path=$(download_with_retry "$download_url")
 

--- a/images/ubuntu/scripts/build/install-sbt.sh
+++ b/images/ubuntu/scripts/build/install-sbt.sh
@@ -7,7 +7,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Install latest sbt release
-download_url=$(get_github_package_download_url "sbt/sbt" "endswith(\".tgz\")")
+download_url=$(resolve_github_release_asset_url "sbt/sbt" "endswith(\".tgz\")" "latest")
 archive_path=$(download_with_retry "$download_url")
 tar zxf "$archive_path" -C /usr/share
 ln -s /usr/share/sbt/bin/sbt /usr/bin/sbt

--- a/images/ubuntu/scripts/build/install-selenium.sh
+++ b/images/ubuntu/scripts/build/install-selenium.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/etc-environment.sh
 SELENIUM_MAJOR_VERSION=$(get_toolset_value '.selenium.version')
 
 # Download Selenium server
-SELENIUM_DOWNLOAD_URL=$(resolve_github_release_asset_url "SeleniumHQ/selenium" "contains(\"selenium-server-\") and endswith(\".jar\")" "$SELENIUM_MAJOR_VERSION\.")
+SELENIUM_DOWNLOAD_URL=$(resolve_github_release_asset_url "SeleniumHQ/selenium" "contains(\"selenium-server-\") and endswith(\".jar\")" "$SELENIUM_MAJOR_VERSION\.*")
 SELENIUM_JAR_PATH=$(download_with_retry "$SELENIUM_DOWNLOAD_URL" "/usr/share/java/selenium-server.jar")
 
 # Create an epmty file to retrive selenium version

--- a/images/ubuntu/scripts/build/install-selenium.sh
+++ b/images/ubuntu/scripts/build/install-selenium.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/etc-environment.sh
 SELENIUM_MAJOR_VERSION=$(get_toolset_value '.selenium.version')
 
 # Download Selenium server
-SELENIUM_DOWNLOAD_URL=$(get_github_package_download_url "SeleniumHQ/selenium" "contains(\"selenium-server-${SELENIUM_MAJOR_VERSION}\") and endswith(\".jar\")")
+SELENIUM_DOWNLOAD_URL=$(resolve_github_release_asset_url "SeleniumHQ/selenium" "contains(\"selenium-server-\") and endswith(\".jar\")" "$SELENIUM_MAJOR_VERSION\.")
 SELENIUM_JAR_PATH=$(download_with_retry "$SELENIUM_DOWNLOAD_URL" "/usr/share/java/selenium-server.jar")
 
 # Create an epmty file to retrive selenium version

--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -86,11 +86,11 @@ resolve_github_release_asset_url() {
     fi
 
     if [[ $version == "latest" ]]; then
-        tag_name=$(echo $json | jq -r '.tag_name' | sort --unique --version-sort | tail -n 1)
+        tag_name=$(echo $json | jq -r '.tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]|beta" | tail -n 1)
     elif [[ $version == *"*"* ]]; then
-        tag_name=$(echo $json | jq -r '.tag_name' | sort --unique --version-sort | egrep "${version}" | tail -n 1)
+        tag_name=$(echo $json | jq -r '.tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]|beta" | egrep "${version}" | tail -n 1)
     else
-        tag_names=$(echo $json | jq -r '.tag_name' | sort --unique --version-sort | egrep "${version}")
+        tag_names=$(echo $json | jq -r '.tag_name' | sort --unique --version-sort | egrep -v ".*-[a-z]|beta" | egrep "${version}")
 
         for element in $tag_names; do
             semver=$(echo "$element" | awk 'match($0, /[0-9]+\.[0-9]+\.[0-9]+/) {print substr($0, RSTART, RLENGTH)}')

--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -92,7 +92,7 @@ resolve_github_release_asset_url() {
     else
         tag_names=$(echo $json | jq -r '.tag_name' | sort --unique --version-sort | egrep "${version}")
 
-        for element in "${tag_names[@]}"; do
+        for element in $tag_names; do
             semver=$(echo "$element" | awk 'match($0, /[0-9]+\.[0-9]+\.[0-9]+/) {print substr($0, RSTART, RLENGTH)}')
 
             if [[ $semver == $version ]]; then


### PR DESCRIPTION
# Description
This pull request implements `resolve_github_release_asset_url` function in place of the `get_github_package_download_url` with enhanced functionality, matching it's windows equivalent.

#### Related issue: https://github.com/actions/runner-images-internal/issues/5606

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
