### PR TITLE
[ubuntu] Refactor Toolset functions

### DIFF
--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Android.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Android.psm1
@@ -156,7 +156,7 @@ function Get-AndroidGoogleAPIsVersions {
 function Get-AndroidNDKVersions {
     $ndkFolderPath = Join-Path (Get-AndroidSDKRoot) "ndk"
     $versions = Get-ChildItem -Path $ndkFolderPath -Name
-    $ndkDefaultVersion = Get-ToolsetValue "android.ndk.default"
+    $ndkDefaultVersion = (Get-ToolsetContent).android.ndk.default
     $ndkDefaultFullVersion = Get-ChildItem "$env:ANDROID_HOME/ndk/$ndkDefaultVersion.*" -Name | Select-Object -Last 1
 
     return ($versions | ForEach-Object {

--- a/images/ubuntu/scripts/helpers/Common.Helpers.psm1
+++ b/images/ubuntu/scripts/helpers/Common.Helpers.psm1
@@ -63,39 +63,16 @@ function Test-IsUbuntu22 {
 }
 
 function Get-ToolsetContent {
-    $toolset = Join-Path $env:INSTALLER_SCRIPT_FOLDER "toolset.json"
-    Get-Content $toolset -Raw | ConvertFrom-Json
-}
-
-function Get-ToolsetValue {
     <#
     .SYNOPSIS
-        This function retrieves the value of a specific toolset.
+        Retrieves the content of the toolset.json file.
 
     .DESCRIPTION
-        The Get-ToolsetValue is used to retrieve the value of a specific toolset.
-        The toolset is a collection of tools or settings in json format.
-
-    .PARAMETER KeyPath
-        The path to the toolset value in json notation.
-
-    .EXAMPLE
-        Get-ToolsetValue -Toolset "tool.arch.versions"
-
-        This command returns the value of the nodes named "tool", "arch" and "versions" as PSCustomObject.
-
+        This function reads the toolset.json in path provided by INSTALLER_SCRIPT_FOLDER
+        environment variable and returns the content as a PowerShell object.
     #>
-    param (
-        [Parameter(Mandatory = $true)]
-        [string] $KeyPath
-    )
 
-    $jsonNode = Get-ToolsetContent
-
-    $pathParts = $KeyPath.Split(".")
-    # walk through all arguments consequentially to resolve specific json node
-    $pathParts | ForEach-Object {
-        $jsonNode = $jsonNode.$_
-    }
-    return $jsonNode
+    $toolsetPath = Join-Path $env:INSTALLER_SCRIPT_FOLDER "toolset.json"
+    $toolsetJson = Get-Content -Path $toolsetPath -Raw
+    ConvertFrom-Json -InputObject $toolsetJson
 }

--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -59,13 +59,10 @@ verlte() {
     [  "$1" = "$sortedVersion" ]
 }
 
-get_toolset_path() {
-    echo "/imagegeneration/installers/toolset.json"
-}
-
 get_toolset_value() {
-    local toolset_path=$(get_toolset_path)
+    local toolset_path="/imagegeneration/installers/toolset.json"
     local query=$1
+
     echo "$(jq -r "$query" $toolset_path)"
 }
 

--- a/images/ubuntu/scripts/tests/Android.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Android.Tests.ps1
@@ -77,9 +77,9 @@ Describe "Android" {
     }
 
     $androidSdkManagerPackages = Get-AndroidPackages
-    [int]$platformMinVersion = Get-ToolsetValue "android.platform_min_version"
-    [version]$buildToolsMinVersion = Get-ToolsetValue "android.build_tools_min_version"
-    [array]$ndkVersions = Get-ToolsetValue "android.ndk.versions"
+    [int]$platformMinVersion = (Get-ToolsetContent).android.platform_min_version
+    [version]$buildToolsMinVersion = (Get-ToolsetContent).android.build_tools_min_version
+    [array]$ndkVersions = (Get-ToolsetContent).android.ndk.versions
     $ndkFullVersions = $ndkVersions |
         ForEach-Object { (Get-ChildItem "/usr/local/lib/android/sdk/ndk/${_}.*" |
         Select-Object -Last 1).Name } | ForEach-Object { "ndk/${_}" }
@@ -102,9 +102,9 @@ Describe "Android" {
         $platformsInstalled,
         $buildTools,
         $ndkFullVersions,
-        (Get-ToolsetValue "android.extra_list" | ForEach-Object { "extras/${_}" }),
-        (Get-ToolsetValue "android.addon_list" | ForEach-Object { "add-ons/${_}" }),
-        (Get-ToolsetValue "android.additional_tools" | ForEach-Object { "${_}" })
+        ((Get-ToolsetContent).android.extra_list | ForEach-Object { "extras/${_}" }),
+        ((Get-ToolsetContent).android.addon_list | ForEach-Object { "add-ons/${_}" }),
+        ((Get-ToolsetContent).android.additional_tools | ForEach-Object { "${_}" })
     )
 
     $androidPackages = $androidPackages | ForEach-Object { $_ }


### PR DESCRIPTION
# Description
This PR simplifies toolset management:
1. Remove `Get-ToolsetValue` PowerShell function - it is barely used and easily substituted by `Get-ToolsetContent` function
2. Remove `get_toolset_path` bash function and use value directly

#### Related issue: https://github.com/actions/runner-images-internal/issues/5606

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
