### PR TITLE
Prevent Configure-DeveloperMode.ps1 from failing

### DIFF
--- a/images/windows/scripts/build/Configure-DeveloperMode.ps1
+++ b/images/windows/scripts/build/Configure-DeveloperMode.ps1
@@ -10,4 +10,4 @@ if (-not(Test-Path -Path $RegistryKeyPath)) {
 }
 
 # Add registry value to enable Developer Mode
-New-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -PropertyType DWORD -Value 1
+New-ItemProperty -Path $RegistryKeyPath -Name AllowDevelopmentWithoutDevLicense -PropertyType DWORD -Value 1 -Force


### PR DESCRIPTION
# Description
Prevent the script `Configure-DeveloperMode.ps1` from failing if the `AllowDevelopmentWithoutDevLicense` reg key already has been set.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
