### PR TITLE
[ubuntu] Refactor android sdk build script

### DIFF
--- a/images/ubuntu/scripts/build/install-android-sdk.sh
+++ b/images/ubuntu/scripts/build/install-android-sdk.sh
@@ -28,7 +28,7 @@ add_filtered_instalaltion_components() {
 get_full_ndk_version() {
     local major_version=$1
 
-    ndk_version=$($SDKMANAGER --list | grep "ndk;${major_version}/." | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
+    ndk_version=$($SDKMANAGER --list | grep "ndk;${major_version}\." | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
     echo "$ndk_version"
 }
 

--- a/images/ubuntu/scripts/build/install-android-sdk.sh
+++ b/images/ubuntu/scripts/build/install-android-sdk.sh
@@ -9,26 +9,27 @@ source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/etc-environment.sh
 
-function filter_components_by_version {
-    minimumVersion=$1
+add_filtered_instalaltion_components() {
+    local minimum_version=$1
     shift
-    toolsArr=("$@")
+    local tools_array=("$@")
 
-    for item in ${toolsArr[@]}
-    do
-        # take the last argument after spliting string by ';'' and '-''
-        version=$(echo "${item##*[-;]}")
-        if verlte $minimumVersion $version
-        then
+    for item in ${tools_array[@]}; do
+        # Take the last argument after spliting string by ';'' and '-''
+        item_version=$(echo "${item##*[-;]}")
+
+        # Semver 'comparison'. Add item to components array, if item's version is greater than or equal to minimum version
+        if [[ "$(printf "${minimum_version}\n${item_version}\n" | sort -V | head -n1)" == "$minimum_version" ]]; then
             components+=($item)
         fi
     done
 }
 
-function get_full_ndk_version {
-    majorVersion=$1
-    ndkFullVersion=$($SDKMANAGER --list | grep "ndk;${majorVersion}.*" | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
-    echo "$ndkFullVersion"
+get_full_ndk_version() {
+    local major_version=$1
+
+    ndk_version=$($SDKMANAGER --list | grep "ndk;${major_version}/." | awk '{gsub("ndk;", ""); print $1}' | sort -V | tail -n1)
+    echo "$ndk_version"
 }
 
 # Set env variable for SDK Root (https://developer.android.com/studio/command-line/variables)
@@ -45,78 +46,79 @@ mkdir -p ${ANDROID_SDK_ROOT}
 
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
-cmdlineToolsVersion=$(get_toolset_value '.android."cmdline-tools"')
-if [[ $cmdlineToolsVersion == "latest" ]]; then
-    repository_xml_url="https://dl.google.com/android/repository/repository2-1.xml"
-    repository_xml_file=$(download_with_retry "$repository_xml_url")
-    cmdlineToolsVersion=$(
-    yq -p=xml \
-    '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
-    "${repository_xml_file}"
+cmdline_tools_package=$(get_toolset_value '.android."cmdline-tools"')
+if [[ $cmdline_tools_version == "latest" ]]; then
+    REPOSITORY_XML_URL="https://dl.google.com/android/repository/repository2-1.xml"
+    repository_xml_file=$(download_with_retry "$REPOSITORY_XML_URL")
+    cmdline_tools_package=$(
+        yq -p=xml \
+        '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
+        "${repository_xml_file}"
     )
 
-    if [[ -z $cmdlineToolsVersion ]]; then
+    if [[ -z $cmdline_tools_package ]]; then
         echo "Failed to parse latest command-line tools version"
         exit 1
     fi
 fi
 
-archive_path=$(download_with_retry "https://dl.google.com/android/repository/${cmdlineToolsVersion}")
+# Install command line tools
+archive_path=$(download_with_retry "https://dl.google.com/android/repository/${cmdline_tools_package}")
 unzip -qq "$archive_path" -d ${ANDROID_SDK_ROOT}/cmdline-tools
 # Command line tools need to be placed in ${ANDROID_SDK_ROOT}/sdk/cmdline-tools/latest to determine SDK root
 mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/latest
 
 # Check sdk manager installation
-${SDKMANAGER} --list 1>/dev/null
-if [ $? -eq 0 ]
-then
+if ${SDKMANAGER} --list 1>/dev/null; then
     echo "Android SDK manager was installed"
 else
     echo "Android SDK manager was not installed"
     exit 1
 fi
 
-minimumBuildToolVersion=$(get_toolset_value '.android.build_tools_min_version')
-minimumPlatformVersion=$(get_toolset_value '.android.platform_min_version')
-extras=$(get_toolset_value '.android.extra_list[]|"extras;" + .')
-addons=$(get_toolset_value '.android.addon_list[]|"add-ons;" + .')
-additional=$(get_toolset_value '.android.additional_tools[]')
-ANDROID_NDK_MAJOR_VERSIONS=($(get_toolset_value '.android.ndk.versions[]'))
-ANDROID_NDK_MAJOR_DEFAULT=$(get_toolset_value '.android.ndk.default')
+# Get toolset values and prepare environment variables
+minimum_build_tool_version=$(get_toolset_value '.android.build_tools_min_version')
+minimum_platform_version=$(get_toolset_value '.android.platform_min_version')
+android_ndk_major_default=$(get_toolset_value '.android.ndk.default')
+android_ndk_major_versions=($(get_toolset_value '.android.ndk.versions[]'))
+android_ndk_major_latest=(${android_ndk_major_versions[-1]})
 
-components=("${extras[@]}" "${addons[@]}" "${additional[@]}")
-for ndk_version in "${ANDROID_NDK_MAJOR_VERSIONS[@]}"
-do
-    ndk_full_version=$(get_full_ndk_version $ndk_version)
-    components+=("ndk;$ndk_full_version")
-done
-
-ANDROID_NDK_MAJOR_LATEST=(${ANDROID_NDK_MAJOR_VERSIONS[-1]})
-ndkDefaultFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_DEFAULT)
-ndkLatestFullVersion=$(get_full_ndk_version $ANDROID_NDK_MAJOR_LATEST)
-ANDROID_NDK="$ANDROID_SDK_ROOT/ndk/$ndkDefaultFullVersion"
+ndk_default_full_version=$(get_full_ndk_version $android_ndk_major_default)
+ndk_latest_full_version=$(get_full_ndk_version $android_ndk_major_latest)
+ANDROID_NDK=${ANDROID_SDK_ROOT}/ndk/${ndk_default_full_version}
 # ANDROID_NDK, ANDROID_NDK_HOME, and ANDROID_NDK_ROOT variables should be set as many customer builds depend on them https://github.com/actions/runner-images/issues/5879
 setEtcEnvironmentVariable "ANDROID_NDK" "${ANDROID_NDK}"
 setEtcEnvironmentVariable "ANDROID_NDK_HOME" "${ANDROID_NDK}"
 setEtcEnvironmentVariable "ANDROID_NDK_ROOT" "${ANDROID_NDK}"
-setEtcEnvironmentVariable "ANDROID_NDK_LATEST_HOME" "${ANDROID_SDK_ROOT}/ndk/${ndkLatestFullVersion}"
+setEtcEnvironmentVariable "ANDROID_NDK_LATEST_HOME" "${ANDROID_SDK_ROOT}/ndk/${ndk_latest_full_version}"
 
-availablePlatforms=($($SDKMANAGER --list | sed -n '/Available Packages:/,/^$/p' | grep "platforms;android-[0-9]" | cut -d"|" -f 1))
-allBuildTools=($($SDKMANAGER --list | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
-availableBuildTools=$(echo ${allBuildTools[@]//*rc[0-9]/})
+# Prepare components for installation
+extras=$(get_toolset_value '.android.extra_list[] | "extras;" + .')
+addons=$(get_toolset_value '.android.addon_list[] | "add-ons;" + .')
+additional=$(get_toolset_value '.android.additional_tools[]')
+components=("${extras[@]}" "${addons[@]}" "${additional[@]}")
 
-filter_components_by_version $minimumPlatformVersion "${availablePlatforms[@]}"
-filter_components_by_version $minimumBuildToolVersion "${availableBuildTools[@]}"
+for ndk_major_version in "${android_ndk_major_versions[@]}"; do
+    ndk_full_version=$(get_full_ndk_version $ndk_major_version)
+    components+=("ndk;$ndk_full_version")
+done
 
+available_platforms=($($SDKMANAGER --list | sed -n '/Available Packages:/,/^$/p' | grep "platforms;android-[0-9]" | cut -d"|" -f 1))
+all_build_tools=($($SDKMANAGER --list | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
+available_build_tools=$(echo ${all_build_tools[@]//*rc[0-9]/})
+
+add_filtered_instalaltion_components $minimum_platform_version "${available_platforms[@]}"
+add_filtered_instalaltion_components $minimum_build_tool_version "${available_build_tools[@]}"
+
+# Install components
 echo "y" | $SDKMANAGER ${components[@]}
 
 # Old skdmanager from sdk tools doesn't work with Java > 8, set version 8 explicitly
-if isUbuntu20 || isUbuntu22; then
-    sed -i "2i export JAVA_HOME=${JAVA_HOME_8_X64}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
-fi
+sed -i "2i export JAVA_HOME=${JAVA_HOME_8_X64}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
 
 # Add required permissions
 chmod -R a+rwx ${ANDROID_SDK_ROOT}
 
 reloadEtcEnvironment
+
 invoke_tests "Android"

--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -54,11 +54,6 @@ IsPackageInstalled() {
     dpkg -S $1 &> /dev/null
 }
 
-verlte() {
-    sortedVersion=$(printf "$1\n$2\n" | sort -V | head -n1)
-    [  "$1" = "$sortedVersion" ]
-}
-
 get_toolset_value() {
     local toolset_path="/imagegeneration/installers/toolset.json"
     local query=$1


### PR DESCRIPTION
# Description
This PR:
1. Remove `verlte` function - used only once, compare directly instead
2. Rename `filter_components_by_version` to `add_filtered_instalaltion_components`
3. Remove irrelevant workaround and minor style changes

#### Related issue: https://github.com/actions/runner-images-internal/issues/5606

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
