### PR TITLE
[Windows] Update Resolve-GithubReleaseAssetUrl function

### DIFF
--- a/images/windows/scripts/build/Install-Selenium.ps1
+++ b/images/windows/scripts/build/Install-Selenium.ps1
@@ -13,7 +13,8 @@ $seleniumMajorVersion = (Get-ToolsetContent).selenium.version
 $seleniumDownloadUrl = Resolve-GithubReleaseAssetUrl `
     -Repo "SeleniumHQ/selenium" `
     -Version "$seleniumMajorVersion.*" `
-    -Asset "selenium-server-*.jar"
+    -Asset "selenium-server-*.jar" `
+    -AllowMultipleMatches
 
 $seleniumBinPath = Join-Path $seleniumDirectory "selenium-server.jar"
 Invoke-DownloadWithRetry -Url $seleniumDownloadUrl -Path $seleniumBinPath

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -677,9 +677,14 @@ function Resolve-GithubReleaseAssetUrl {
         Write-Debug "Found no download urls matching pattern ${UrlMatchPattern}"
         Write-Debug "Available download urls:`n$($matchingReleases.assets.browser_download_url -join "`n")"
         throw "No assets found in ${Repository} matching version `"${Version}`" and pattern `"${UrlMatchPattern}`""
-    } elseif ($matchedUrl.Count -gt 1) {
-        Write-Debug "Found multiple download urls matching pattern ${UrlMatchPattern}:`n$($matchedUrl -join "`n")"
-        throw "Multiple download urls found in ${Repository} version `"${matchedVersion}`" matching pattern `"${UrlMatchPattern}`":`n$($matchedUrl -join "`n")"
+    }
+    # If multiple urls match the pattern, sort them and take the last one
+    # Will only work with simple number series of no more than nine in a row.
+    if ($matchedUrl.Count -gt 1) {
+        Write-Error "Found multiple download urls matching pattern ${UrlMatchPattern}:`n$($matchedUrl -join "`n")"
+        Write-Host "Performing sorting of urls to find the most recent version matching the pattern"
+        $matchedUrl = $matchedUrl | Sort-Object -Descending
+        $matchedUrl = $matchedUrl[0]
     }
 
     Write-Host "Found download url for ${Repository} version ${matchedVersion}: ${matchedUrl}"


### PR DESCRIPTION
# Description

This way function will work for GitHub releases with multiple asset versions. Will only work with simple number series of no more than ten in a row.
Currently it's only SeleniumHQ/selenium. Example: 
- https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.16.0/selenium-dotnet-strongnamed-4.16.0.zip
- https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.16.0/selenium-dotnet-strongnamed-4.16.1.zip

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
