### PR TITLE
[Ubuntu] Update the Packer version output

### DIFF
--- a/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -348,7 +348,7 @@ function Get-Aria2Version {
 }
 
 function Get-AzcopyVersion {
-    $azcopyVersion = Run-Command "azcopy --version" | Take-Part -Part 2
+    $azcopyVersion = [string]$(Run-Command "azcopy --version") | Take-Part -Part 2
     return $azcopyVersion
 }
 

--- a/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -348,7 +348,7 @@ function Get-Aria2Version {
 }
 
 function Get-AzcopyVersion {
-    $azcopyVersion = [string]$(Run-Command "azcopy --version") | Take-Part -Part 2
+    $azcopyVersion = Run-Command "azcopy --version" | Take-Part -Part 2
     return $azcopyVersion
 }
 

--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Tools.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Tools.psm1
@@ -177,7 +177,7 @@ function Get-NvmVersion {
 }
 
 function Get-PackerVersion {
-    $packerVersion = packer --version
+    $packerVersion = (packer --version | Select-String "^Packer").Line.Replace('v','') | Get-StringPart -Part 1
     return $packerVersion
 }
 


### PR DESCRIPTION
# Description
Update the Packer version output.
Get rid of `Packer v` in `Packer v1.10.0` output.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
