### PR TITLE
Pin Azure plugin version in packer templates

### DIFF
--- a/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     azure = {
       source  = "github.com/hashicorp/azure"
-      version = "~> 2"
+      version = "1.4.5"
     }
   }
 }

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     azure = {
       source  = "github.com/hashicorp/azure"
-      version = "~> 2"
+      version = "1.4.5"
     }
   }
 }

--- a/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     azure = {
       source  = "github.com/hashicorp/azure"
-      version = "~> 2"
+      version = "1.4.5"
     }
   }
 }

--- a/images/windows/templates/windows-2019.pkr.hcl
+++ b/images/windows/templates/windows-2019.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     azure = {
       source  = "github.com/hashicorp/azure"
-      version = "~> 2"
+      version = "1.4.5"
     }
   }
 }

--- a/images/windows/templates/windows-2022.pkr.hcl
+++ b/images/windows/templates/windows-2022.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     azure = {
       source  = "github.com/hashicorp/azure"
-      version = "~> 2"
+      version = "1.4.5"
     }
   }
 }


### PR DESCRIPTION
# Description
Azure plugin v2.0+ for packer contains breaking changes, which affects pipelines. Pin version to `1.4.5`

#### Related issue: https://github.com/actions/runner-images-internal/issues/5654

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
