### PR TITLE
[windows] fix extracting checksum for Miniconda installer

### DIFF
--- a/images/windows/scripts/build/Install-Miniconda.ps1
+++ b/images/windows/scripts/build/Install-Miniconda.ps1
@@ -9,7 +9,7 @@ $installerName = "Miniconda3-latest-Windows-x86_64.exe"
 
 #region Supply chain security
 $distributorFileHash = $null
-$checksums = (Invoke-RestMethod -Uri 'https://repo.anaconda.com/miniconda/' | ConvertFrom-HTML).SelectNodes('//html/body/table/tr')
+$checksums = (ConvertFrom-HTML -Uri 'https://repo.anaconda.com/miniconda/').SelectNodes('//html/body/table/tr')
 
 foreach ($node in $checksums) {
     if ($node.ChildNodes[1].InnerText -eq $installerName) {


### PR DESCRIPTION
# Description

fix Miniconda checksum extraction

#### Related issue:

https://github.com/actions/runner-images/issues/9017

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
