### PR TITLE
Fix macOS CI - clean images updates

### DIFF
--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -89,13 +89,6 @@ function Invoke-SoftwareUpdate {
         return
     }
 
-    Write-Host "`t[*] Fetching Software Updates ready to install on '$TemplateName' VM:"
-    Show-StringWithFormat $newUpdates
-    $listOfNewUpdates = $($($newUpdates.Split("*")).Split("Title") | Where-Object {$_ -match "Label:"}).Replace("Label: ", '')
-    Write-Host "`t[*] Installing Software Updates on '$TemplateName' VM:"
-    Install-SoftwareUpdate -HostName $ipAddress -listOfUpdates $listOfNewUpdates -Password $Password | Show-StringWithFormat
-
-    # Check if Action: restart
     # Define the next macOS version
     $command = "sw_vers"
     $guestMacosVersion = Invoke-SSHPassCommand -HostName $ipAddress -Command $command
@@ -103,27 +96,26 @@ function Invoke-SoftwareUpdate {
         '12.\d' { $nextOSVersion = 'macOS Ventura|macOS Sonoma' }
         '13.\d' { $nextOSVersion = 'macOS Sonoma'  }
     }
-    # Make an array of updates
-    $listOfNewUpdates = $newUpdates.split('*').Trim('')
+
+    Write-Host "`t[*] Fetching Software Updates ready to install on '$TemplateName' VM:"
+    Show-StringWithFormat $newUpdates
+    $listOfNewUpdates = $($($newUpdates.Split("*")).Split("Title").where({$_ -match "Label:"}).Replace("Label: ", '').where({$_ -notmatch $nextOSVersion}))
+    Write-Host "`t[*] Installing Software Updates on '$TemplateName' VM:"
+    Install-SoftwareUpdate -HostName $ipAddress -listOfUpdates $listOfNewUpdates -Password $Password | Show-StringWithFormat
+    Write-Host "`t[*] Sleep 300 seconds before the software updates have been installed"
+    Start-Sleep -Seconds 300
+    Write-Host "`t[*] Waiting for loginwindow process"
+    Wait-LoginWindow -HostName $ipAddress | Show-StringWithFormat
+    # Re-enable AutoLogon after installing a new security software update
+    Invoke-EnableAutoLogon
+
     foreach ($newupdate in $listOfNewUpdates) {
-        # Will be True if the value is not Venture, not empty, and contains "Action: restart" words
-        if ($newupdate.Contains("Action: restart") -and !($newupdate -match $nextOSVersion) -and (-not [String]::IsNullOrEmpty($newupdate))) {
-            Write-Host "`t[*] Sleep 120 seconds before the software updates have been installed"
-            Start-Sleep -Seconds 120
-
-            Write-Host "`t[*] Waiting for loginwindow process"
-            Wait-LoginWindow -HostName $ipAddress | Show-StringWithFormat
-
-            # Re-enable AutoLogon after installing a new security software update
-            Invoke-EnableAutoLogon
-
-            # Check software updates have been installed
-            $updates = Get-SoftwareUpdate -HostName $ipAddress
-            if ($updates.Contains("Action: restart") -and !($newupdate -match $nextOSVersion)) {
-                Write-Host "`t[x] Software updates failed to install: "
-                Show-StringWithFormat $updates
-                exit 1
-            }
+        # Check software updates have been installed
+        $updates = Get-SoftwareUpdate -HostName $ipAddress
+        if ($updates.Contains("Action: restart") -and !($updates -match $nextOSVersion)) {
+            Write-Host "`t[x] Software updates failed to install: "
+            Show-StringWithFormat $updates
+            exit 1
         }
     }
 
@@ -135,6 +127,7 @@ function Invoke-SoftwareUpdate {
     $command = "sw_vers"
     Invoke-SSHPassCommand -HostName $ipAddress -Command $command | Show-StringWithFormat
 }
+
 
 function Invoke-UpdateSettings {
     param (

--- a/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
+++ b/images.CI/macos/anka/CreateCleanAnkaTemplate.ps1
@@ -102,8 +102,8 @@ function Invoke-SoftwareUpdate {
     $listOfNewUpdates = $($($newUpdates.Split("*")).Split("Title").where({$_ -match "Label:"}).Replace("Label: ", '').where({$_ -notmatch $nextOSVersion}))
     Write-Host "`t[*] Installing Software Updates on '$TemplateName' VM:"
     Install-SoftwareUpdate -HostName $ipAddress -listOfUpdates $listOfNewUpdates -Password $Password | Show-StringWithFormat
-    Write-Host "`t[*] Sleep 300 seconds before the software updates have been installed"
-    Start-Sleep -Seconds 300
+    Write-Host "`t[*] Sleep 60 seconds before the software updates have been installed"
+    Start-Sleep -Seconds 60
     Write-Host "`t[*] Waiting for loginwindow process"
     Wait-LoginWindow -HostName $ipAddress | Show-StringWithFormat
     # Re-enable AutoLogon after installing a new security software update

--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -325,19 +325,21 @@ function Invoke-WithRetry {
         [int] $RetryCount = 20,
         [int] $Seconds = 60
     )
-    $ErrorActionPreference = "SilentlyContinue"
     while ($RetryCount -gt 0) {
-        if ($Command) {
-            $result = & $Command
-        }
+        try {
+            if ($Command) {
+                $result = & $Command
+            }
 
-        if (& $BreakCondition) {
-            return $result
+            if (& $BreakCondition) {
+                return $result
+            }
+        } catch {
+            Write-Host "`t    [!] Error during command execution: $_"
         }
 
         $RetryCount--
         if ($RetryCount -eq 0) {
-            $ErrorActionPreference = "Stop"
             Write-Error "No more attempts left: $BreakCondition"
         }
         Write-Host "`t    [/] Waiting $Seconds seconds before retrying. Retries left: $RetryCount"

--- a/images.CI/macos/anka/Service.Helpers.psm1
+++ b/images.CI/macos/anka/Service.Helpers.psm1
@@ -266,36 +266,13 @@ function Install-SoftwareUpdate {
         [array] $listOfUpdates,
         [string] $Password
     )
-    # If an update is happening on macOS 12 or 13 we will use the prepared list of updates, otherwise, we will install all updates.
-    $command = "sw_vers"
-    $guestMacosVersion = Invoke-SSHPassCommand -HostName $HostName -Command $command
-    if ($guestMacosVersion[1] -match "12") {
-        foreach ($update in $listOfUpdates) {
-            # Filtering updates that contain "Ventura" word
-            if ($update -notmatch "Ventura") {
-                $command = "sudo /usr/sbin/softwareupdate --restart --verbose --install '$($update.trim())'"
-                Invoke-SSHPassCommand -HostName $HostName -Command $command
-            }
-        }
-    } elseif ($guestMacosVersion[1] -match "13") {
-        $osArch = $(arch)
-        if ($osArch -eq "arm64") {
-            Invoke-SoftwareUpdateArm64 -HostName $HostName -Password $Password -ListOfUpdates $listOfUpdates
-        } else {
-            foreach ($update in $listOfUpdates) {
-                # Filtering updates that contain "Sonoma" word
-                if ($update -notmatch "Sonoma") {
-                    $command = "sudo /usr/sbin/softwareupdate --restart --verbose --install '$($update.trim())'"
-                    Invoke-SSHPassCommand -HostName $HostName -Command $command
-                }
-            }
-        }
+    # If an update is happening on macOS arm64 we will use the additional tool to install updates.
+    $osArch = $(arch)
+    if ($osArch -eq "arm64") {
+        Invoke-SoftwareUpdateArm64 -HostName $HostName -Password $Password -ListOfUpdates $listOfUpdates
     } else {
-        $osArch = $(arch)
-        if ($osArch -eq "arm64") {
-            Invoke-SoftwareUpdateArm64 -HostName $HostName -Password $Password -ListOfUpdates $listOfUpdates
-        } else {
-            $command = "sudo /usr/sbin/softwareupdate --all --install --restart --verbose"
+        foreach ($update in $listOfUpdates) {
+            $command = "sudo /usr/sbin/softwareupdate --restart --verbose --install '$($update.trim())'"
             Invoke-SSHPassCommand -HostName $HostName -Command $command
         }
     }
@@ -348,7 +325,7 @@ function Invoke-WithRetry {
         [int] $RetryCount = 20,
         [int] $Seconds = 60
     )
-
+    $ErrorActionPreference = "SilentlyContinue"
     while ($RetryCount -gt 0) {
         if ($Command) {
             $result = & $Command
@@ -360,6 +337,7 @@ function Invoke-WithRetry {
 
         $RetryCount--
         if ($RetryCount -eq 0) {
+            $ErrorActionPreference = "Stop"
             Write-Error "No more attempts left: $BreakCondition"
         }
         Write-Host "`t    [/] Waiting $Seconds seconds before retrying. Retries left: $RetryCount"


### PR DESCRIPTION
# Description

- Updating the scheme for working with macOS updates - now there are no attempts to install or check an update to a new version of the OS.
- Added an error handler for launching with attempts - before that it crashed in some cases.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
