### PR TITLE
[ubuntu] Refactor functions for GitHub assets and hashes

### DIFF
--- a/images/ubuntu/scripts/build/install-actions-cache.sh
+++ b/images/ubuntu/scripts/build/install-actions-cache.sh
@@ -17,7 +17,7 @@ echo "Setting up ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE variable to ${ACTION_ARCHIV
 setEtcEnvironmentVariable "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE" "${ACTION_ARCHIVE_CACHE_DIR}"
 
 # Download latest release from github.com/actions/action-versions and untar to /opt/actionarchivecache
-downloadUrl=$(resolve_github_release_asset_url "actions/action-versions" "contains(\"action-versions.tar.gz\")" "latest")
+downloadUrl=$(resolve_github_release_asset_url "actions/action-versions" "endswith(\"action-versions.tar.gz\")" "latest")
 archive_path=$(download_with_retry "$downloadUrl")
 tar -xzf "$archive_path" -C $ACTION_ARCHIVE_CACHE_DIR
 

--- a/images/ubuntu/scripts/build/install-aliyun-cli.sh
+++ b/images/ubuntu/scripts/build/install-aliyun-cli.sh
@@ -25,7 +25,7 @@ archive_path=$(download_with_retry "$download_url")
 if isUbuntu20; then
     external_hash=$(get_toolset_value '.aliyunCli.sha256')
 else
-    external_hash=$(get_hash_from_remote_file "$hash_url" "aliyun-cli-linux" "amd64.tgz")
+    external_hash=$(get_checksum_from_url "$hash_url" "aliyun-cli-linux.*amd64.tgz" "SHA256")
 fi
 
 use_checksum_comparison "$archive_path" "$external_hash"

--- a/images/ubuntu/scripts/build/install-aws-tools.sh
+++ b/images/ubuntu/scripts/build/install-aws-tools.sh
@@ -18,7 +18,7 @@ apt install "$smplugin_deb_path"
 
 # Download the latest aws sam cli release
 aws_sam_cli_archive_name="aws-sam-cli-linux-x86_64.zip"
-sam_cli_download_url=$(resolve_github_release_asset_url "aws/aws-sam-cli" "endswith(\"aws-sam-cli-linux-x86_64.zip\")" "latest")
+sam_cli_download_url=$(resolve_github_release_asset_url "aws/aws-sam-cli" "endswith(\"$aws_sam_cli_archive_name\")" "latest")
 aws_sam_cli_archive_path=$(download_with_retry "$sam_cli_download_url")
 
 # Supply chain security - AWS SAM CLI

--- a/images/ubuntu/scripts/build/install-aws-tools.sh
+++ b/images/ubuntu/scripts/build/install-aws-tools.sh
@@ -18,10 +18,11 @@ apt install "$smplugin_deb_path"
 
 # Download the latest aws sam cli release
 aws_sam_cli_archive_name="aws-sam-cli-linux-x86_64.zip"
-aws_sam_cli_archive_path=$(download_with_retry "https://github.com/aws/aws-sam-cli/releases/latest/download/${aws_sam_cli_archive_name}")
+sam_cli_download_url=$(resolve_github_release_asset_url "aws/aws-sam-cli" "endswith(\"aws-sam-cli-linux-x86_64.zip\")" "latest")
+aws_sam_cli_archive_path=$(download_with_retry "$sam_cli_download_url")
 
 # Supply chain security - AWS SAM CLI
-aws_sam_cli_hash=$(get_github_package_hash "aws" "aws-sam-cli" "${aws_sam_cli_archive_name}.. ")
+aws_sam_cli_hash=$(get_checksum_from_github_release "aws/aws-sam-cli" "${aws_sam_cli_archive_name}.. " "latest" "SHA256")
 use_checksum_comparison "$aws_sam_cli_archive_path" "$aws_sam_cli_hash"
 
 # Install the latest aws sam cli release

--- a/images/ubuntu/scripts/build/install-cmake.sh
+++ b/images/ubuntu/scripts/build/install-cmake.sh
@@ -18,7 +18,7 @@ else
 	curl -fsSL "${download_url}" -o cmakeinstall.sh
 	# Supply chain security - CMake
 	hash_url=$(resolve_github_release_asset_url "Kitware/CMake" "endswith(\"SHA-256.txt\")" "latest")
-	external_hash=$(get_hash_from_remote_file "$hash_url" "linux-x86_64.sh")
+	external_hash=$(get_checksum_from_url "$hash_url" "linux-x86_64.sh" "SHA256")
 	use_checksum_comparison "cmakeinstall.sh" "$external_hash"
 	# Install CMake and remove the install script
 	chmod +x cmakeinstall.sh \

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -19,7 +19,7 @@ apt-get update
 apt-get install --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 
 # Download docker compose v2 from releases
-URL=$(resolve_github_release_asset_url "docker/compose" "contains(\"compose-linux-x86_64\")" "latest")
+URL=$(resolve_github_release_asset_url "docker/compose" "endswith(\"compose-linux-x86_64\")" "latest")
 curl -fsSL "${URL}" -o /tmp/docker-compose
 # Supply chain security - Docker Compose v2
 compose_hash_url=$(resolve_github_release_asset_url "docker/compose" "contains(\"checksums.txt\")" "latest")

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -22,7 +22,7 @@ apt-get install --no-install-recommends docker-ce docker-ce-cli containerd.io do
 URL=$(resolve_github_release_asset_url "docker/compose" "endswith(\"compose-linux-x86_64\")" "latest")
 curl -fsSL "${URL}" -o /tmp/docker-compose
 # Supply chain security - Docker Compose v2
-compose_hash_url=$(resolve_github_release_asset_url "docker/compose" "contains(\"checksums.txt\")" "latest")
+compose_hash_url=$(resolve_github_release_asset_url "docker/compose" "endswith(\"checksums.txt\")" "latest")
 compose_external_hash=$(get_hash_from_remote_file "${compose_hash_url}" "compose-linux-x86_64")
 use_checksum_comparison "/tmp/docker-compose" "${compose_external_hash}"
 # Install docker compose v2

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -23,7 +23,7 @@ URL=$(resolve_github_release_asset_url "docker/compose" "endswith(\"compose-linu
 curl -fsSL "${URL}" -o /tmp/docker-compose
 # Supply chain security - Docker Compose v2
 compose_hash_url=$(resolve_github_release_asset_url "docker/compose" "endswith(\"checksums.txt\")" "latest")
-compose_external_hash=$(get_hash_from_remote_file "${compose_hash_url}" "compose-linux-x86_64")
+compose_external_hash=$(get_checksum_from_url "${compose_hash_url}" "compose-linux-x86_64" "SHA256")
 use_checksum_comparison "/tmp/docker-compose" "${compose_external_hash}"
 # Install docker compose v2
 install /tmp/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
@@ -68,7 +68,7 @@ aws_latest_release_url="https://api.github.com/repos/awslabs/amazon-ecr-credenti
 aws_helper_url=$(curl "${authString[@]}" -fsSL "${aws_latest_release_url}" | jq -r '.body' | awk -F'[()]' '/linux-amd64/ {print $2}')
 aws_helper_binary_path=$(download_with_retry "$aws_helper_url")
 # Supply chain security - amazon-ecr-credential-helper
-aws_helper_external_hash=$(get_hash_from_remote_file "${aws_helper_url}.sha256" "docker-credential-ecr-login")
+aws_helper_external_hash=$(get_checksum_from_url "${aws_helper_url}.sha256" "docker-credential-ecr-login" "SHA256")
 use_checksum_comparison "$aws_helper_binary_path" "$aws_helper_external_hash"
 # Install amazon-ecr-credential-helper
 install "$aws_helper_binary_path" "/usr/bin/docker-credential-ecr-login"

--- a/images/ubuntu/scripts/build/install-github-cli.sh
+++ b/images/ubuntu/scripts/build/install-github-cli.sh
@@ -13,7 +13,7 @@ source $HELPER_SCRIPTS/install.sh
 gh_cli_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"linux\") and contains(\"amd64\") and endswith(\".deb\")" "latest")
 gh_cli_deb_path=$(download_with_retry "$gh_cli_url")
 # Supply chain security - GitHub CLI
-hash_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"checksums.txt\")" "latest")
+hash_url=$(resolve_github_release_asset_url "cli/cli" "endswith(\"checksums.txt\")" "latest")
 external_hash=$(get_hash_from_remote_file "$hash_url" "linux_amd64.deb")
 use_checksum_comparison "$gh_cli_deb_path" "$external_hash"
 # Install GitHub CLI

--- a/images/ubuntu/scripts/build/install-github-cli.sh
+++ b/images/ubuntu/scripts/build/install-github-cli.sh
@@ -14,7 +14,7 @@ gh_cli_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"linux\") and
 gh_cli_deb_path=$(download_with_retry "$gh_cli_url")
 # Supply chain security - GitHub CLI
 hash_url=$(resolve_github_release_asset_url "cli/cli" "endswith(\"checksums.txt\")" "latest")
-external_hash=$(get_hash_from_remote_file "$hash_url" "linux_amd64.deb")
+external_hash=$(get_checksum_from_url "$hash_url" "linux_amd64.deb" "SHA256")
 use_checksum_comparison "$gh_cli_deb_path" "$external_hash"
 # Install GitHub CLI
 apt install "$gh_cli_deb_path"

--- a/images/ubuntu/scripts/build/install-github-cli.sh
+++ b/images/ubuntu/scripts/build/install-github-cli.sh
@@ -10,7 +10,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Download GitHub CLI
-gh_cli_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"linux\") and contains(\"amd64\") and contains(\".deb\")" "latest")
+gh_cli_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"linux\") and contains(\"amd64\") and endswith(\".deb\")" "latest")
 gh_cli_deb_path=$(download_with_retry "$gh_cli_url")
 # Supply chain security - GitHub CLI
 hash_url=$(resolve_github_release_asset_url "cli/cli" "contains(\"checksums.txt\")" "latest")

--- a/images/ubuntu/scripts/build/install-kotlin.sh
+++ b/images/ubuntu/scripts/build/install-kotlin.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 KOTLIN_ROOT="/usr/share"
-download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"kotlin-compiler\")" "latest")
+download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"kotlin-compiler\") and endswith(\".zip\")" "latest")
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - Kotlin

--- a/images/ubuntu/scripts/build/install-kotlin.sh
+++ b/images/ubuntu/scripts/build/install-kotlin.sh
@@ -12,7 +12,7 @@ download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"k
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - Kotlin
-kotlin_hash=$(get_github_package_hash "JetBrains" "kotlin" "kotlin-compiler-.*\.zip" "" "latest" "false" "|" 3)
+kotlin_hash=$(get_checksum_from_github_release "JetBrains/kotlin" "kotlin-compiler-.*\.zip" "latest" "SHA256")
 use_checksum_comparison "$archive_path" "$kotlin_hash"
 
 unzip -qq "$archive_path" -d $KOTLIN_ROOT

--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -30,7 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 # Download minikube
 curl -fsSL -O https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 # Supply chain security - minikube
-minikube_hash=$(get_github_package_hash "kubernetes" "minikube" "linux-amd64" "" "latest" "false" ":" 2)
+minikube_hash=$(get_checksum_from_github_release "kubernetes/minikube" "linux-amd64" "latest" "SHA256")
 use_checksum_comparison "minikube-linux-amd64" "${minikube_hash}"
 # Install minikube
 sudo install minikube-linux-amd64 /usr/local/bin/minikube

--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -9,7 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Download KIND
-kind_url=$(resolve_github_release_asset_url "kubernetes-sigs/kind" "contains(\"kind-linux-amd64\")" "latest")
+kind_url=$(resolve_github_release_asset_url "kubernetes-sigs/kind" "endswith(\"kind-linux-amd64\")" "latest")
 curl -fsSL -o /tmp/kind "${kind_url}"
 # Supply chain security - KIND
 kind_external_hash=$(get_hash_from_remote_file "${kind_url}.sha256sum" "kind-linux-amd64")

--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -12,7 +12,7 @@ source $HELPER_SCRIPTS/install.sh
 kind_url=$(resolve_github_release_asset_url "kubernetes-sigs/kind" "endswith(\"kind-linux-amd64\")" "latest")
 curl -fsSL -o /tmp/kind "${kind_url}"
 # Supply chain security - KIND
-kind_external_hash=$(get_hash_from_remote_file "${kind_url}.sha256sum" "kind-linux-amd64")
+kind_external_hash=$(get_checksum_from_url "${kind_url}.sha256sum" "kind-linux-amd64" "SHA256")
 use_checksum_comparison "/tmp/kind" "${kind_external_hash}"
 # Install KIND
 sudo install /tmp/kind /usr/local/bin/kind

--- a/images/ubuntu/scripts/build/install-oras-cli.sh
+++ b/images/ubuntu/scripts/build/install-oras-cli.sh
@@ -14,7 +14,7 @@ download_url=$(resolve_github_release_asset_url "oras-project/oras" "endswith(\"
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - ORAS CLI
-hash_url=$(resolve_github_release_asset_url "oras-project/oras" "contains(\"checksums.txt\")" "latest")
+hash_url=$(resolve_github_release_asset_url "oras-project/oras" "endswith(\"checksums.txt\")" "latest")
 external_hash=$(get_hash_from_remote_file "${hash_url}" "linux_amd64.tar.gz")
 use_checksum_comparison "$archive_path" "${external_hash}"
 

--- a/images/ubuntu/scripts/build/install-oras-cli.sh
+++ b/images/ubuntu/scripts/build/install-oras-cli.sh
@@ -15,7 +15,7 @@ archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - ORAS CLI
 hash_url=$(resolve_github_release_asset_url "oras-project/oras" "endswith(\"checksums.txt\")" "latest")
-external_hash=$(get_hash_from_remote_file "${hash_url}" "linux_amd64.tar.gz")
+external_hash=$(get_checksum_from_url "${hash_url}" "linux_amd64.tar.gz" "SHA256")
 use_checksum_comparison "$archive_path" "${external_hash}"
 
 # Unzip ORAS CLI

--- a/images/ubuntu/scripts/build/install-pulumi.sh
+++ b/images/ubuntu/scripts/build/install-pulumi.sh
@@ -14,7 +14,7 @@ download_url="https://get.pulumi.com/releases/sdk/pulumi-v${version}-linux-x64.t
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - Pulumi
-external_hash=$(get_hash_from_remote_file "https://github.com/pulumi/pulumi/releases/download/v${version}/SHA512SUMS" "linux-x64.tar.gz")
+external_hash=$(get_checksum_from_url "https://github.com/pulumi/pulumi/releases/download/v${version}/SHA512SUMS" "linux-x64.tar.gz" "SHA512")
 use_checksum_comparison "$archive_path" "$external_hash" "512"
 
 # Unzipping Pulumi

--- a/images/ubuntu/scripts/build/install-runner-package.sh
+++ b/images/ubuntu/scripts/build/install-runner-package.sh
@@ -7,7 +7,7 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-linux-x64-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz")' "latest")
+download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-linux-x64-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest")
 archive_name="${download_url##*/}"
 archive_path=$(download_with_retry "$download_url")
 

--- a/images/ubuntu/scripts/build/install-selenium.sh
+++ b/images/ubuntu/scripts/build/install-selenium.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/etc-environment.sh
 SELENIUM_MAJOR_VERSION=$(get_toolset_value '.selenium.version')
 
 # Download Selenium server
-SELENIUM_DOWNLOAD_URL=$(resolve_github_release_asset_url "SeleniumHQ/selenium" "contains(\"selenium-server-\") and endswith(\".jar\")" "$SELENIUM_MAJOR_VERSION\.+")
+SELENIUM_DOWNLOAD_URL=$(resolve_github_release_asset_url "SeleniumHQ/selenium" "contains(\"selenium-server-\") and endswith(\".jar\")" "$SELENIUM_MAJOR_VERSION\.+" "" "true")
 SELENIUM_JAR_PATH=$(download_with_retry "$SELENIUM_DOWNLOAD_URL" "/usr/share/java/selenium-server.jar")
 
 # Create an epmty file to retrive selenium version

--- a/images/ubuntu/scripts/build/install-selenium.sh
+++ b/images/ubuntu/scripts/build/install-selenium.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/etc-environment.sh
 SELENIUM_MAJOR_VERSION=$(get_toolset_value '.selenium.version')
 
 # Download Selenium server
-SELENIUM_DOWNLOAD_URL=$(resolve_github_release_asset_url "SeleniumHQ/selenium" "contains(\"selenium-server-\") and endswith(\".jar\")" "$SELENIUM_MAJOR_VERSION\.*")
+SELENIUM_DOWNLOAD_URL=$(resolve_github_release_asset_url "SeleniumHQ/selenium" "contains(\"selenium-server-\") and endswith(\".jar\")" "$SELENIUM_MAJOR_VERSION\.+")
 SELENIUM_JAR_PATH=$(download_with_retry "$SELENIUM_DOWNLOAD_URL" "/usr/share/java/selenium-server.jar")
 
 # Create an epmty file to retrive selenium version

--- a/images/ubuntu/scripts/build/install-yq.sh
+++ b/images/ubuntu/scripts/build/install-yq.sh
@@ -13,7 +13,7 @@ base_url="https://github.com/mikefarah/yq/releases/latest/download"
 binary_path=$(download_with_retry "${base_url}/yq_linux_amd64")
 
 # Supply chain security - yq
-external_hash=$(get_hash_from_remote_file "${base_url}/checksums" "yq_linux_amd64 " "" " " "19")
+external_hash=$(get_checksum_from_url "${base_url}/checksums" "yq_linux_amd64 " "SHA256" "true" " " "19")
 use_checksum_comparison "$binary_path" "$external_hash"
 
 # Install yq

--- a/images/ubuntu/scripts/build/install-zstd.sh
+++ b/images/ubuntu/scripts/build/install-zstd.sh
@@ -15,7 +15,7 @@ download_url="https://github.com/facebook/zstd/releases/download/${release_tag}/
 archive_path=$(download_with_retry "${download_url}")
 
 # Supply chain security - zstd
-external_hash=$(get_hash_from_remote_file "${download_url}.sha256" "${release_name}.tar.gz")
+external_hash=$(get_checksum_from_url "${download_url}.sha256" "${release_name}.tar.gz" "SHA256")
 use_checksum_comparison "$archive_path" "$external_hash"
 
 # Install zstd

--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -127,7 +127,7 @@ resolve_github_release_asset_url() {
 
     if [[ "$(echo "$matched_url" | wc -l)" -gt 1 ]]; then
         if [[ $allow_multiple_matches == "true" ]]; then
-            matchedUrl=$(echo "$matched_url" | tail -n 1)
+            matched_url=$(echo "$matched_url" | tail -n 1)
         else
             echo "Multiple matches found for ${version} version and ${url_filter} URL filter. Please make filters more specific"
             exit 1


### PR DESCRIPTION
# Description
This PR:
1) Adds `get_github_releases_by_version()` function
2) Reworks `resolve_github_release_asset_url()` function
3) Renames `get_github_package_hash()` function to `get_checksum_from_github_release()` and reworks it
4) Renames `get_hash_from_remote_file()` function to `get_checksum_from_url()` and reworks it

#### Related issue: https://github.com/actions/runner-images-internal/issues/5606

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
