### PR TITLE
[macOS] distinguish Arm64/M1 in the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/announcement.yml
+++ b/.github/ISSUE_TEMPLATE/announcement.yml
@@ -41,6 +41,7 @@ body:
         - label: macOS 11
         - label: macOS 12
         - label: macOS 13
+        - label: macOS 13 Arm64
         - label: Windows Server 2019
         - label: Windows Server 2022
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,6 +24,7 @@ body:
         - label: macOS 11
         - label: macOS 12
         - label: macOS 13
+        - label: macOS 13 Arm64
         - label: Windows Server 2019
         - label: Windows Server 2022
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/tool-request.yml
+++ b/.github/ISSUE_TEMPLATE/tool-request.yml
@@ -62,6 +62,7 @@ body:
         - label: macOS 11
         - label: macOS 12
         - label: macOS 13
+        - label: macOS 13 Arm64
         - label: Windows Server 2019
         - label: Windows Server 2022
   - type: textarea


### PR DESCRIPTION
# Description

Let's now distinguish Apple Silicon runners in template for better reports granularity