### PR TITLE
[ubuntu] Remove apt-key from build scripts

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -19,11 +19,12 @@ fi
 
 # Packages is available in the official Ubuntu upstream starting from Ubuntu 21
 if is_ubuntu20; then
-    REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable"
-    source /etc/os-release
-    sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-    wget -nv https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
-    apt-key add Release.key
+    REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_$(lsb_release -rs)"
+    GPG_KEY="/usr/share/keyrings/devel_kubic_libcontainers_stable.gpg"
+    REPO_PATH="/etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+
+    curl -fsSL "${REPO_URL}/Release.key" | gpg --dearmor -o $GPG_KEY
+    echo "deb [arch=amd64 signed-by=$GPG_KEY] ${REPO_URL}/ /" > $REPO_PATH
 fi
 
 # Install podman, buildah, scopeo container's tools
@@ -34,7 +35,9 @@ printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc
 
 if is_ubuntu20; then
     # Remove source repo
-    rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    rm $GPG_KEY
+    rm $REPO_PATH
+
     # Document source repo
     echo "containers $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 fi

--- a/images/ubuntu/scripts/build/install-heroku.sh
+++ b/images/ubuntu/scripts/build/install-heroku.sh
@@ -4,16 +4,19 @@
 ##  Desc:  Install Heroku CLI. Based on instructions found here: https://devcenter.heroku.com/articles/heroku-cli
 ################################################################################
 
-# add heroku repository to apt
-echo "deb https://cli-assets.heroku.com/channels/stable/apt ./" > /etc/apt/sources.list.d/heroku.list
+REPO_URL="https://cli-assets.heroku.com/channels/stable/apt"
+GPG_KEY="/usr/share/keyrings/heroku.gpg"
+REPO_PATH="/etc/apt/sources.list.d/heroku.list"
 
-# install heroku's release key for package verification
-curl https://cli-assets.heroku.com/channels/stable/apt/release.key | apt-key add -
+# add heroku repository to apt
+curl -fsSL "${REPO_URL}/release.key" | gpg --dearmor -o $GPG_KEY
+echo "deb [signed-by=$GPG_KEY] $REPO_URL ./" > $REPO_PATH
 
 # install heroku
 apt-get update -y && apt-get install -y heroku
 
 # remove heroku's apt repository
-rm /etc/apt/sources.list.d/heroku.list
+rm $REPO_PATH
+rm $GPG_KEY
 
 invoke_tests "Tools" "Heroku"

--- a/images/ubuntu/scripts/build/install-hhvm.sh
+++ b/images/ubuntu/scripts/build/install-hhvm.sh
@@ -4,10 +4,20 @@
 ##  Desc:  Install HHVM
 ################################################################################
 
-apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
-add-apt-repository https://dl.hhvm.com/ubuntu
+REPO_URL="https://dl.hhvm.com/ubuntu"
+GPG_KEY="/usr/share/keyrings/hhvm.gpg"
+REPO_PATH="/etc/apt/sources.list.d/hhvm.list"
 
+# add HHVM repository to apt
+curl -fsSL https://dl.hhvm.com/conf/hhvm.gpg.key | gpg --dearmor -o $GPG_KEY
+echo "deb [signed-by=$GPG_KEY] $REPO_URL $(lsb_release -cs) main" > $REPO_PATH
+
+# install HHVM
 apt-get update
 apt-get -qq install -y hhvm
+
+# remove HHVM's apt repository
+rm $REPO_PATH
+rm $GPG_KEY
 
 invoke_tests "Tools" "HHVM"

--- a/images/ubuntu/scripts/build/install-mongodb.sh
+++ b/images/ubuntu/scripts/build/install-mongodb.sh
@@ -7,19 +7,24 @@
 # Source the helpers
 source $HELPER_SCRIPTS/install.sh
 
-REPO_URL="https://repo.mongodb.org/apt/ubuntu"
-os_label=$(lsb_release -cs)
 toolset_version=$(get_toolset_value '.mongodb.version')
+REPO_URL="https://repo.mongodb.org/apt/ubuntu"
+GPG_KEY="/usr/share/keyrings/mongodb-org-$toolset_version.gpg"
+REPO_PATH="/etc/apt/sources.list.d/mongodb-org-$toolset_version.list"
 
-#  Install Mongo DB
-wget -qO - https://www.mongodb.org/static/pgp/server-$toolset_version.asc | sudo apt-key add -
+# add Mongo DB repository to apt
+curl -fsSL https://www.mongodb.org/static/pgp/server-$toolset_version.asc | gpg --dearmor -o $GPG_KEY
+echo "deb [ arch=amd64,arm64 signed-by=$GPG_KEY ] $REPO_URL $(lsb_release -cs)/mongodb-org/$toolset_version multiverse" > $REPO_PATH
 
-echo "deb [ arch=amd64,arm64 ] $REPO_URL $os_label/mongodb-org/$toolset_version multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-$toolset_version.list
+# Install Mongo DB
 sudo apt-get update
 sudo apt-get install -y mongodb-org
 
-rm /etc/apt/sources.list.d/mongodb-org-$toolset_version.list
+# remove Mongo DB's apt repository
+rm $REPO_PATH
+rm $GPG_KEY
 
+# Document source repo
 echo "mongodb $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 
 invoke_tests "Databases" "MongoDB"

--- a/images/ubuntu/scripts/build/install-mono.sh
+++ b/images/ubuntu/scripts/build/install-mono.sh
@@ -8,23 +8,29 @@
 source $HELPER_SCRIPTS/os.sh
 
 os_label=$(lsb_release -cs)
+REPO_URL="https://download.mono-project.com/repo/ubuntu"
+GPG_KEY="/usr/share/keyrings/mono-official-stable.gpg"
+REPO_PATH="/etc/apt/sources.list.d/mono-official-stable.list"
 
 # There are no packages for Ubuntu 22 in the repo, but developers confirmed that packages from Ubuntu 20 should work
 if is_ubuntu22; then
     os_label="focal"
 fi
 
-# Test to see if the software in question is already installed, if not install it
-# wget "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF" -O out && sudo apt-key add out && rm out
+# Install Mono repo
+curl -fsSL https://download.mono-project.com/repo/xamarin.gpg | gpg --dearmor -o $GPG_KEY
+echo "deb [signed-by=$GPG_KEY] $REPO_URL stable-$os_label main" > $REPO_PATH
 
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb https://download.mono-project.com/repo/ubuntu stable-$os_label main" | tee /etc/apt/sources.list.d/mono-official-stable.list
+# Install Mono
 apt-get update
 apt-get install -y --no-install-recommends apt-transport-https mono-complete nuget
 
-rm /etc/apt/sources.list.d/mono-official-stable.list
-rm -f /etc/apt/sources.list.d/mono-official-stable.list.save
+# Remove Mono's apt repo
+rm $REPO_PATH
+rm -f "${REPO_PATH}.save"
+rm $GPG_KEY
 
+# Document source repo
 echo "mono https://download.mono-project.com/repo/ubuntu stable-$os_label main" >> $HELPER_SCRIPTS/apt-sources.txt
 
 invoke_tests "Tools" "Mono"


### PR DESCRIPTION
# Description
Since `apt-key` is deprecated, use `gpg`

#### Related issue: https://github.com/actions/runner-images-internal/issues/5606

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
