### PR TITLE
[macOS] Update SoftwareReport scripts

### DIFF
--- a/images/macos/scripts/build/Install-Xcode.ps1
+++ b/images/macos/scripts/build/Install-Xcode.ps1
@@ -44,7 +44,6 @@ $xcodeVersions | ForEach-Object {
         $xcodebuildPath = Get-XcodeToolPath -Version $_.link -ToolName 'xcodebuild'
         Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $runtime" | Out-Null
     }
-
 }
 
 Invoke-XcodeRunFirstLaunch -Version $defaultXcode

--- a/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -154,7 +154,7 @@ function Build-OSInfoSection {
     )
 
     $fieldsToInclude = @("System Version:", "Kernel Version:")
-    $rawSystemInfo = Invoke-Expression "system_profiler SPSoftwareDataType"
+    $rawSystemInfo = Run-Command "system_profiler SPSoftwareDataType"
     $parsedSystemInfo = $rawSystemInfo | Where-Object { -not ($_ | Select-String -NotMatch $fieldsToInclude) } | ForEach-Object { $_.Trim() }
     $parsedSystemInfo[0] -match "System Version: macOS (?<version>\d+)" | Out-Null
     $version = $Matches.Version
@@ -169,12 +169,12 @@ function Build-OSInfoSection {
 }
 
 function Get-MonoVersion {
-    $monoVersion = mono --version | Out-String | Take-Part -Part 4
+    $monoVersion = Run-Command "mono --version" | Out-String | Take-Part -Part 4
     return $monoVersion
 }
 
 function Get-MSBuildVersion {
-    $msbuildVersion = msbuild -version | Select-Object -Last 1
+    $msbuildVersion = Run-Command "msbuild -version" | Select-Object -Last 1
     $monoVersion = Get-MonoVersion
     return "$msbuildVersion (Mono $monoVersion)"
 }
@@ -250,7 +250,7 @@ function Get-NuGetVersion {
 }
 
 function Get-CondaVersion {
-    $condaVersion = Invoke-Expression "conda --version"
+    $condaVersion = Run-Command "conda --version"
     return ($condaVersion -replace "^conda").Trim()
 }
 
@@ -312,7 +312,7 @@ function Get-SVNVersion {
 
 function Get-PackerVersion {
     # Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
-    $result = Run-Command -Command "packer --version"
+    $result = Run-Command "packer --version"
     $packerVersion = [regex]::matches($result, "(\d+.){2}\d+").Value
     return $packerVersion
 }
@@ -538,22 +538,22 @@ function Get-JazzyVersion {
 }
 
 function Get-ZlibVersion {
-	$zlibVersion = brew info --json zlib | jq -r '.[].installed[].version'
+	$zlibVersion = (Run-Command "brew info --json zlib" | ConvertFrom-Json).installed.version
 	return $zlibVersion
 }
 
 function Get-LibXftVersion {
-    $libXftVersion = brew info --json libxft | jq -r '.[].installed[].version'
+    $libXftVersion = (Run-Command "brew info --json libxft" | ConvertFrom-Json).installed.version
     return $libXftVersion
 }
 
 function Get-LibXextVersion {
-    $libXextVersion = brew info --json libxext | jq -r '.[].installed[].version'
+    $libXextVersion = (Run-Command "brew info --json libxext" | ConvertFrom-Json).installed.version
     return $libXextVersion
 }
 
 function Get-TclTkVersion {
-    $tcltkVersion = brew info --json tcl-tk | jq -r '.[].installed[].version'
+    $tcltkVersion = (Run-Command "brew info --json tcl-tk" | ConvertFrom-Json).installed.version
     return $tcltkVersion
 }
 

--- a/images/macos/scripts/helpers/Xcode.Installer.psm1
+++ b/images/macos/scripts/helpers/Xcode.Installer.psm1
@@ -38,7 +38,7 @@ function Invoke-DownloadXcodeArchive {
     if ($xcodeSha256 -ne $Sha256Sum) {
         throw "Xcode $Version checksum mismatch. Expected: $Sha256Sum, Actual: $xcodeSha256"
     }
-  
+
     return $tempXipDirectory
 }
 
@@ -65,6 +65,7 @@ function Get-AvailableXcodeVersions {
     $availableVersions = $rawVersionsList | ForEach-Object {
         $partStable,$partMajor = $_.Split(" ", 2)
         $semver = $stableSemver = [SemVer]::Parse($partStable)
+
         if ($partMajor) {
             # Convert 'beta 3' -> 'beta.3', 'Release Candidate' -> 'releasecandidate', 'GM Seed 2' -> 'gmseed.2'
             $normalizedLabel = $partMajor.toLower() -replace " (\d)", '.$1' -replace " ([a-z])", '$1'


### PR DESCRIPTION
# Description
This PR refactors PowerShell scripts used for macOS Software Report:

 - Almost all functions used to get application version were changed to the "Run-Command" function.
 - Scripts were aligned with code style guide.

#### Related issue:
 - https://github.com/actions/runner-images-internal/issues/5621

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
