### PR TITLE
[Ubuntu] Remove old android SDK versions

### DIFF
--- a/images/ubuntu/scripts/build/install-android-sdk.sh
+++ b/images/ubuntu/scripts/build/install-android-sdk.sh
@@ -113,9 +113,6 @@ add_filtered_instalaltion_components $minimum_build_tool_version "${available_bu
 # Install components
 echo "y" | $SDKMANAGER ${components[@]}
 
-# Old skdmanager from sdk tools doesn't work with Java > 8, set version 8 explicitly
-sed -i "2i export JAVA_HOME=${JAVA_HOME_8_X64}" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager
-
 # Add required permissions
 chmod -R a+rwx ${ANDROID_SDK_ROOT}
 

--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Android.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Android.psm1
@@ -44,10 +44,6 @@ function Build-AndroidTable {
             "Version" = Get-AndroidPlatformVersions -PackageInfo $packageInfo
         },
         @{
-            "Package" = "Android SDK Tools"
-            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Tools"
-        },
-        @{
             "Package" = "Android Support Repository"
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Support Repository"
         },

--- a/images/ubuntu/scripts/tests/Android.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Android.Tests.ps1
@@ -82,10 +82,6 @@ Describe "Android" {
     Context "SDKManagers" {
         $testCases = @(
             @{
-                PackageName = "SDK tools"
-                Sdkmanager = "$env:ANDROID_HOME/tools/bin/sdkmanager"
-            },
-            @{
                 PackageName = "Command-line tools"
                 Sdkmanager = "$env:ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
             }

--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -79,8 +79,8 @@
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",
-        "platform_min_version": "27",
-        "build_tools_min_version": "27.0.0",
+        "platform_min_version": "31",
+        "build_tools_min_version": "31.0.0",
         "extra_list": [
             "android;m2repository",
             "google;m2repository",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -73,8 +73,8 @@
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",
-        "platform_min_version": "27",
-        "build_tools_min_version": "27.0.0",
+        "platform_min_version": "31",
+        "build_tools_min_version": "31.0.0",
         "extra_list": [
             "android;m2repository",
             "google;m2repository",


### PR DESCRIPTION
# Description
Remove old android SDK versions from ubuntu 20.04 and ubuntu 22.04 images

#### Related issue:
- #8952

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
