### PR TITLE
[Windows] Remove old android SDK versions

### DIFF
--- a/images/windows/scripts/docs-gen/SoftwareReport.Android.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Android.psm1
@@ -39,10 +39,6 @@ function Build-AndroidTable {
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Platform-Tools"
         },
         @{
-            "Package" = "Android SDK Tools"
-            "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android SDK Tools"
-        },
-        @{
             "Package" = "Android Support Repository"
             "Version" = Get-AndroidPackageVersions -PackageInfo $packageInfo -MatchedString "Android Support Repository"
         },

--- a/images/windows/scripts/tests/Android.Tests.ps1
+++ b/images/windows/scripts/tests/Android.Tests.ps1
@@ -31,10 +31,6 @@ Describe "Android SDK" {
     Context "SDKManagers" {
         $testCases = @(
             @{
-                PackageName = "SDK tools"
-                Sdkmanager = "$env:ANDROID_HOME\tools\bin\sdkmanager.bat"
-            },
-            @{
                 PackageName = "Command-line tools"
                 Sdkmanager = "$env:ANDROID_HOME\cmdline-tools\latest\bin\sdkmanager.bat"
             }

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -149,8 +149,8 @@
     "android": {
         "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-9123335_latest.zip",
         "hash": "8A90E6A3DEB2FA13229B2E335EFD07687DCC8A55A3C544DA9F40B41404993E7D",
-        "platform_min_version": "19",
-        "build_tools_min_version": "19.1.0",
+        "platform_min_version": "31",
+        "build_tools_min_version": "31.0.0",
         "extras": [
             "android;m2repository",
             "google;m2repository",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -133,8 +133,8 @@
     "android": {
         "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-9123335_latest.zip",
         "hash": "8A90E6A3DEB2FA13229B2E335EFD07687DCC8A55A3C544DA9F40B41404993E7D",
-        "platform_min_version": "27",
-        "build_tools_min_version": "27.0.0",
+        "platform_min_version": "31",
+        "build_tools_min_version": "31.0.0",
         "extras": [
             "android;m2repository",
             "google;m2repository",


### PR DESCRIPTION
# Description
Remove old android SDK versions from Windows 2019 and Windows 2022 images.

#### Related issue:
- #8952

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
