### PR TITLE
[macOS] Remove old android SDK versions

### DIFF
--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -160,8 +160,8 @@
     },
     "android": {
         "cmdline-tools": "commandlinetools-mac-9123335_latest.zip",
-        "platform_min_version": "27",
-        "build_tools_min_version": "27.0.0",
+        "platform_min_version": "31",
+        "build_tools_min_version": "31.0.0",
         "extras": [
             "android;m2repository", "google;m2repository", "google;google_play_services"
         ],

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -147,8 +147,8 @@
     },
     "android": {
         "cmdline-tools": "commandlinetools-mac-9123335_latest.zip",
-        "platform_min_version": "27",
-        "build_tools_min_version": "27.0.0",
+        "platform_min_version": "31",
+        "build_tools_min_version": "31.0.0",
         "extras": [
             "android;m2repository", "google;m2repository", "google;google_play_services"
         ],


### PR DESCRIPTION
# Description
Remove old android SDK versions from macOS 11 and macOS 12 images.

#### Related issue:
- #8952

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
