### PR TITLE
Avoid static path definition

### DIFF
--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -46,7 +46,7 @@ download_with_retry() {
 }
 
 get_toolset_value() {
-    local toolset_path="/imagegeneration/installers/toolset.json"
+    local toolset_path="${INSTALLER_SCRIPT_FOLDER}/toolset.json"
     local query=$1
 
     echo "$(jq -r "$query" $toolset_path)"


### PR DESCRIPTION
# Description

Since the latest refactoring the ubuntu installer scripts are no longer in `installers` but in `build`. In the VM / during the build we still use `/imagegeneration/installers` as defined in the Packerfiles.

This PR changes the only place left where the path is defined and not used via ENV.

Afterwards I would recommend to change the envs in the Packerfiles to `/imagegeneration/build`