### PR TITLE
[ubuntu] Fix static path in install.sh

### DIFF
--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -46,7 +46,7 @@ download_with_retry() {
 }
 
 get_toolset_value() {
-    local toolset_path="/imagegeneration/installers/toolset.json"
+    local toolset_path="${INSTALLER_SCRIPT_FOLDER}/toolset.json"
     local query=$1
 
     echo "$(jq -r "$query" $toolset_path)"

--- a/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
@@ -259,7 +259,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = ["${path.root}/../scripts/build/install-powershell.sh"]
   }

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -259,7 +259,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = ["${path.root}/../scripts/build/install-powershell.sh"]
   }


### PR DESCRIPTION
# Description
As pointed out by @luka5 in https://github.com/actions/runner-images/pull/9114, ubuntu build script contains statically defined path. This PR adds `INSTALLER_SCRIPT_FOLDER` variable usage instead.

#### Related issue: 

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
