### PR TITLE
[Ubuntu] Add predefined variable to skip test in the pipeline

### DIFF
--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -1,4 +1,6 @@
-Describe "Disk free space" {
+# The $env:AGENT_NAME and $env:RUNNER_NAME are predefined variables for the ADO pipelines and for the GitHub actions respectively.
+# If the test is running on the ADO pipeline or on the GitHub actions, the test will be skipped
+Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) -or -not [String]::IsNullOrEmpty($env:RUNNER_NAME)) {
     It "Image has more than 31GB free space" {
         $freeSpace = (Get-PSDrive "/").Free
         $freeSpace | Should -BeGreaterOrEqual 31GB


### PR DESCRIPTION
# Description
The `$env:AGENT_NAME` and `$env:RUNNER_NAME` are predefined variables for the ADO pipelines and for the GitHub actions respectively.
If the variables is not empty, it means the test is running on the ADO pipeline or on the GitHub actions, and should be skipped.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
