### PR TITLE
Macos patch static path

### DIFF
--- a/images/macos/scripts/helpers/Common.Helpers.psm1
+++ b/images/macos/scripts/helpers/Common.Helpers.psm1
@@ -40,9 +40,17 @@ function Get-OSVersion {
     }
 }
 
-# Get the value of the toolset
 function Get-ToolsetContent {
-    $toolsetPath = Join-Path $env:HOME "image-generation" "toolset.json"
+    <#
+    .SYNOPSIS
+        Retrieves the content of the toolset.json file.
+
+    .DESCRIPTION
+        This function reads the toolset.json in path provided by IMAGE_FOLDER
+        environment variable and returns the content as a PowerShell object.
+    #>
+
+    $toolsetPath = Join-Path $env:IMAGE_FOLDER "toolset.json"
     $toolsetJson = Get-Content -Path $toolsetPath -Raw
     ConvertFrom-Json -InputObject $toolsetJson
 }

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -82,7 +82,7 @@ is_Veertu() {
 }
 
 get_toolset_value() {
-    local toolset_path=$(echo "$HOME/image-generation/toolset.json")
+    local toolset_path=$(echo "$IMAGE_FOLDER/toolset.json")
     local query=$1
     echo "$(jq -r "$query" $toolset_path)"
 }

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -204,7 +204,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
@@ -223,7 +223,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
     script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
@@ -235,7 +235,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
@@ -272,8 +272,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
-    scripts         = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts          = [
       "${path.root}/../scripts/build/Install-Toolset.ps1",
       "${path.root}/../scripts/build/Configure-Toolset.ps1"
     ]
@@ -285,7 +286,8 @@ build {
   }
 
   provisioner "shell" {
-    inline = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    inline           = [
       "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
       "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -7,6 +7,10 @@ packer {
   }
 }
 
+locals {
+  image_folder = "/Users/${var.vm_username}/image-generation"
+}
+
 variable "baseimage_name" {
   type = string
 }
@@ -100,37 +104,37 @@ build {
   sources = ["source.vsphere-clone.template"]
 
   provisioner "shell" {
-    inline = ["mkdir ~/image-generation"]
+    inline = ["mkdir ${local.image_folder}"]
   }
 
   provisioner "file" {
-    destination = "~/image-generation/"
+    destination = "${local.image_folder}/"
     sources     = [
-      "./assets/xamarin-selector",
-      "./scripts/tests",
-      "./scripts/docs-gen",
-      "./scripts/helpers"
+      "${path.root}/../assets/xamarin-selector",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen",
+      "${path.root}/../scripts/helpers"
     ]
   }
 
   provisioner "file" {
-    destination = "~/image-generation/docs-gen/"
-    source      = "../../helpers/software-report-base"
+    destination = "${local.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
   }
 
   provisioner "file" {
-    destination = "~/image-generation/add-certificate.swift"
-    source      = "./assets/add-certificate.swift"
+    destination = "${local.image_folder}/add-certificate.swift"
+    source      = "${path.root}/../assets/add-certificate.swift"
   }
 
   provisioner "file" {
     destination = "~/.bashrc"
-    source      = "./assets/bashrc"
+    source      = "${path.root}/../assets/bashrc"
   }
 
   provisioner "file" {
     destination = "~/.bash_profile"
-    source      = "./assets/bashprofile"
+    source      = "${path.root}/../assets/bashprofile"
   }
 
   provisioner "shell" {
@@ -139,32 +143,32 @@ build {
 
   provisioner "file" {
     destination = "~/bootstrap"
-    source      = "./assets/bootstrap-provisioner/"
+    source      = "${path.root}/../assets/bootstrap-provisioner/"
   }
 
   provisioner "file" {
-    destination = "~/image-generation/toolset.json"
-    source      = "./toolsets/toolset-11.json"
+    destination = "${local.image_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-11.json"
   }
 
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = [
-      "mv ~/image-generation/docs-gen ~/image-generation/software-report",
-      "mv ~/image-generation/xamarin-selector ~/image-generation/assets",
+      "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
+      "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ~/image-generation/helpers/confirm-identified-developers.scpt ~/utils",
-      "mv ~/image-generation/helpers/invoke-tests.sh ~/utils",
-      "mv ~/image-generation/helpers/utils.sh ~/utils",
-      "mv ~/image-generation/helpers/xamarin-utils.sh ~/utils"
+      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
+      "mv ${local.image_folder}/helpers/utils.sh ~/utils",
+      "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"
     ]
   }
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts         = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/install-homebrew.sh"
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/install-homebrew.sh"
     ]
   }
 
@@ -172,14 +176,14 @@ build {
     environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
     execute_command  = "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/configure-network-interface-detection.sh",
-      "./scripts/build/configure-autologin.sh",
-      "./scripts/build/configure-auto-updates.sh",
-      "./scripts/build/configure-screensaver.sh",
-      "./scripts/build/configure-ntpconf.sh",
-      "./scripts/build/configure-max-files-limitation.sh",
-      "./scripts/build/configure-shell.sh"
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/configure-network-interface-detection.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
+      "${path.root}/../scripts/build/configure-auto-updates.sh",
+      "${path.root}/../scripts/build/configure-screensaver.sh",
+      "${path.root}/../scripts/build/configure-ntpconf.sh",
+      "${path.root}/../scripts/build/configure-max-files-limitation.sh",
+      "${path.root}/../scripts/build/configure-shell.sh"
     ]
   }
 
@@ -187,9 +191,9 @@ build {
     environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts          = [
-      "./scripts/build/configure-preimagedata.sh",
-      "./scripts/build/configure-ssh.sh",
-      "./scripts/build/configure-machine.sh"
+      "${path.root}/../scripts/build/configure-preimagedata.sh",
+      "${path.root}/../scripts/build/configure-ssh.sh",
+      "${path.root}/../scripts/build/configure-machine.sh"
     ]
   }
 
@@ -204,24 +208,24 @@ build {
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
-      "./scripts/build/configure-windows.sh",
-      "./scripts/build/install-powershell.sh",
-      "./scripts/build/install-dotnet.sh",
-      "./scripts/build/install-python.sh",
-      "./scripts/build/install-azcopy.sh",
-      "./scripts/build/install-openssl.sh",
-      "./scripts/build/install-ruby.sh",
-      "./scripts/build/install-rubygems.sh",
-      "./scripts/build/install-git.sh",
-      "./scripts/build/install-mongodb.sh",
-      "./scripts/build/install-node.sh"
+      "${path.root}/../scripts/build/configure-windows.sh",
+      "${path.root}/../scripts/build/install-powershell.sh",
+      "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-python.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-openssl.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rubygems.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-mongodb.sh",
+      "${path.root}/../scripts/build/install-node.sh"
     ]
   }
 
   provisioner "shell" {
     environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
-    script           = "./scripts/build/Install-Xcode.ps1"
+    script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
 
   provisioner "shell" {
@@ -234,70 +238,70 @@ build {
     environment_vars = ["API_PAT=${var.github_api_pat}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts          = [
-      "./scripts/build/install-actions-cache.sh",
-      "./scripts/build/install-common-utils.sh",
-      "./scripts/build/install-llvm.sh",
-      "./scripts/build/install-golang.sh",
-      "./scripts/build/install-swiftlint.sh",
-      "./scripts/build/install-openjdk.sh",
-      "./scripts/build/install-php.sh",
-      "./scripts/build/install-aws-tools.sh",
-      "./scripts/build/install-rust.sh",
-      "./scripts/build/install-gcc.sh",
-      "./scripts/build/install-haskell.sh",
-      "./scripts/build/install-cocoapods.sh",
-      "./scripts/build/install-android-sdk.sh",
-      "./scripts/build/install-xamarin.sh",
-      "./scripts/build/install-visualstudio.sh",
-      "./scripts/build/install-nvm.sh",
-      "./scripts/build/install-apache.sh",
-      "./scripts/build/install-nginx.sh",
-      "./scripts/build/install-postgresql.sh",
-      "./scripts/build/install-audiodevice.sh",
-      "./scripts/build/install-vcpkg.sh",
-      "./scripts/build/install-miniconda.sh",
-      "./scripts/build/install-safari.sh",
-      "./scripts/build/install-chrome.sh",
-      "./scripts/build/install-edge.sh",
-      "./scripts/build/install-firefox.sh",
-      "./scripts/build/install-pypy.sh",
-      "./scripts/build/install-pipx-packages.sh",
-      "./scripts/build/install-bicep.sh",
-      "./scripts/build/install-codeql-bundle.sh"
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-common-utils.sh",
+      "${path.root}/../scripts/build/install-llvm.sh",
+      "${path.root}/../scripts/build/install-golang.sh",
+      "${path.root}/../scripts/build/install-swiftlint.sh",
+      "${path.root}/../scripts/build/install-openjdk.sh",
+      "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-gcc.sh",
+      "${path.root}/../scripts/build/install-haskell.sh",
+      "${path.root}/../scripts/build/install-cocoapods.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-xamarin.sh",
+      "${path.root}/../scripts/build/install-visualstudio.sh",
+      "${path.root}/../scripts/build/install-nvm.sh",
+      "${path.root}/../scripts/build/install-apache.sh",
+      "${path.root}/../scripts/build/install-nginx.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
+      "${path.root}/../scripts/build/install-audiodevice.sh",
+      "${path.root}/../scripts/build/install-vcpkg.sh",
+      "${path.root}/../scripts/build/install-miniconda.sh",
+      "${path.root}/../scripts/build/install-safari.sh",
+      "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-edge.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
+      "${path.root}/../scripts/build/install-pypy.sh",
+      "${path.root}/../scripts/build/install-pipx-packages.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
   }
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
     scripts         = [
-      "./scripts/build/Install-Toolset.ps1",
-      "./scripts/build/Configure-Toolset.ps1"
+      "${path.root}/../scripts/build/Install-Toolset.ps1",
+      "${path.root}/../scripts/build/Configure-Toolset.ps1"
     ]
   }
 
   provisioner "shell" {
     execute_command = "ruby {{ .Path }}"
-    script          = "./scripts/build/configure-xcode-simulators.rb"
+    script          = "${path.root}/../scripts/build/configure-xcode-simulators.rb"
   }
 
   provisioner "shell" {
     inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}",
-      "pwsh -File \"$HOME/image-generation/tests/RunAll-Tests.ps1\""
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
+      "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]
   }
 
   provisioner "file" {
-    destination = "../image-output/"
+    destination = "${path.root}/../../image-output/"
     direction   = "download"
-    source      = "~/image-generation/output/*"
+    source      = "${local.image_folder}/output/*"
   }
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts         = [
-      "./scripts/build/configure-hostname.sh",
-      "./scripts/build/configure-system.sh"
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
     ]
   }
 }

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -2,9 +2,13 @@ packer {
   required_plugins {
     veertu-anka = {
       version = ">= v3.2.0"
-      source = "github.com/veertuinc/veertu-anka"
+      source  = "github.com/veertuinc/veertu-anka"
     }
   }
+}
+
+locals {
+  image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
 variable "source_vm_name" {
@@ -20,259 +24,260 @@ variable "build_id" {
 }
 
 variable "vm_username" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vm_password" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "github_api_pat" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "xcode_install_storage_url" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "xcode_install_sas" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vcpu_count" {
-  type = string
+  type    = string
   default = "6"
 }
 
 variable "ram_size" {
-  type = string
+  type    = string
   default = "24G"
 }
 
 variable "image_os" {
-  type = string
+  type    = string
   default = "macos12"
 }
 
 source "veertu-anka-vm-clone" "template" {
-  vm_name = "${var.build_id}"
+  vm_name        = "${var.build_id}"
   source_vm_name = "${var.source_vm_name}"
-  source_vm_tag = "${var.source_vm_tag}"
-  vcpu_count = "${var.vcpu_count}"
-  ram_size = "${var.ram_size}"
-  stop_vm = "true"
+  source_vm_tag  = "${var.source_vm_tag}"
+  vcpu_count     = "${var.vcpu_count}"
+  ram_size       = "${var.ram_size}"
+  stop_vm        = "true"
 }
 
 build {
-  sources = [
-    "source.veertu-anka-vm-clone.template"
-  ]
+  sources = ["source.veertu-anka-vm-clone.template"]
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/image-generation"
-    ]
+    inline = ["mkdir ${local.image_folder}"]
   }
+
   provisioner "file" {
-    destination = "image-generation/"
+    destination = "${local.image_folder}/"
     sources = [
-      "./assets/xamarin-selector",
-      "./scripts/tests",
-      "./scripts/docs-gen",
-      "./scripts/helpers"
+      "${path.root}/../assets/xamarin-selector",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen",
+      "${path.root}/../scripts/helpers"
     ]
   }
+
   provisioner "file" {
-    destination = "image-generation/docs-gen/"
-    source = "../../helpers/software-report-base"
+    destination = "${local.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
   }
+
   provisioner "file" {
-    destination = "image-generation/add-certificate.swift"
-    source = "./assets/add-certificate.swift"
+    destination = "${local.image_folder}/add-certificate.swift"
+    source      = "${path.root}/../assets/add-certificate.swift"
   }
+
   provisioner "file" {
-    destination = ".bashrc"
-    source = "./assets/bashrc"
+    destination = "~/.bashrc"
+    source      = "${path.root}/../assets/bashrc"
   }
+
   provisioner "file" {
-    destination = ".bash_profile"
-    source = "./assets/bashprofile"
+    destination = "~/.bash_profile"
+    source      = "${path.root}/../assets/bashprofile"
   }
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/bootstrap"
-    ]
+    inline = [ "mkdir ~/bootstrap" ]
   }
+
   provisioner "file" {
-    destination = "bootstrap"
-    source = "./assets/bootstrap-provisioner/"
+    destination = "~/bootstrap"
+    source      = "${path.root}/../assets/bootstrap-provisioner/"
   }
+
   provisioner "file" {
-    destination = "image-generation/toolset.json"
-    source = "./toolsets/toolset-12.json"
+    destination = "${local.image_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-12.json"
   }
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = [
-      "mv ~/image-generation/docs-gen ~/image-generation/software-report",
-      "mv ~/image-generation/xamarin-selector ~/image-generation/assets",
+      "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
+      "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ~/image-generation/helpers/confirm-identified-developers.scpt ~/utils",
-      "mv ~/image-generation/helpers/invoke-tests.sh ~/utils",
-      "mv ~/image-generation/helpers/utils.sh ~/utils",
-      "mv ~/image-generation/helpers/xamarin-utils.sh ~/utils"
+      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
+      "mv ${local.image_folder}/helpers/utils.sh ~/utils",
+      "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"
     ]
   }
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/install-homebrew.sh"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/install-homebrew.sh"
+    ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-tccdb-macos.sh",
-      "./scripts/build/configure-network-interface-detection.sh",
-      "./scripts/build/configure-autologin.sh",
-      "./scripts/build/configure-auto-updates.sh",
-      "./scripts/build/configure-screensaver.sh",
-      "./scripts/build/configure-ntpconf.sh",
-      "./scripts/build/configure-max-files-limitation.sh",
-      "./scripts/build/configure-shell.sh"
+    environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-network-interface-detection.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
+      "${path.root}/../scripts/build/configure-auto-updates.sh",
+      "${path.root}/../scripts/build/configure-screensaver.sh",
+      "${path.root}/../scripts/build/configure-ntpconf.sh",
+      "${path.root}/../scripts/build/configure-max-files-limitation.sh",
+      "${path.root}/../scripts/build/configure-shell.sh"
     ]
-    environment_vars = [
-      "PASSWORD=${var.vm_password}",
-      "USERNAME=${var.vm_username}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-preimagedata.sh",
-      "./scripts/build/configure-ssh.sh",
-      "./scripts/build/configure-machine.sh"
+    environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-preimagedata.sh",
+      "${path.root}/../scripts/build/configure-ssh.sh",
+      "${path.root}/../scripts/build/configure-machine.sh"
     ]
-    environment_vars = [
-      "IMAGE_VERSION=${var.build_id}",
-      "IMAGE_OS=${var.image_os}",
-      "PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    pause_before = "30s"
-    scripts = [
-      "./scripts/build/configure-windows.sh",
-      "./scripts/build/install-powershell.sh",
-      "./scripts/build/install-dotnet.sh",
-      "./scripts/build/install-python.sh",
-      "./scripts/build/install-azcopy.sh",
-      "./scripts/build/install-openssl.sh",
-      "./scripts/build/install-ruby.sh",
-      "./scripts/build/install-rubygems.sh",
-      "./scripts/build/install-git.sh",
-      "./scripts/build/install-mongodb.sh",
-      "./scripts/build/install-node.sh",
-      "./scripts/build/install-common-utils.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-windows.sh",
+      "${path.root}/../scripts/build/install-powershell.sh",
+      "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-python.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-openssl.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rubygems.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-mongodb.sh",
+      "${path.root}/../scripts/build/install-node.sh",
+      "${path.root}/../scripts/build/install-common-utils.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}",
-      "USER_PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    script = "./scripts/build/Install-Xcode.ps1"
-    environment_vars = [
-      "XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}",
-      "XCODE_INSTALL_SAS=${var.xcode_install_sas}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-actions-cache.sh",
-      "./scripts/build/install-llvm.sh",
-      "./scripts/build/install-golang.sh",
-      "./scripts/build/install-swiftlint.sh",
-      "./scripts/build/install-openjdk.sh",
-      "./scripts/build/install-php.sh",
-      "./scripts/build/install-aws-tools.sh",
-      "./scripts/build/install-rust.sh",
-      "./scripts/build/install-gcc.sh",
-      "./scripts/build/install-haskell.sh",
-      "./scripts/build/install-cocoapods.sh",
-      "./scripts/build/install-android-sdk.sh",
-      "./scripts/build/install-xamarin.sh",
-      "./scripts/build/install-visualstudio.sh",
-      "./scripts/build/install-nvm.sh",
-      "./scripts/build/install-apache.sh",
-      "./scripts/build/install-nginx.sh",
-      "./scripts/build/install-postgresql.sh",
-      "./scripts/build/install-audiodevice.sh",
-      "./scripts/build/install-vcpkg.sh",
-      "./scripts/build/install-miniconda.sh",
-      "./scripts/build/install-safari.sh",
-      "./scripts/build/install-chrome.sh",
-      "./scripts/build/install-edge.sh",
-      "./scripts/build/install-firefox.sh",
-      "./scripts/build/install-pypy.sh",
-      "./scripts/build/install-pipx-packages.sh",
-      "./scripts/build/install-bicep.sh",
-      "./scripts/build/install-codeql-bundle.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-llvm.sh",
+      "${path.root}/../scripts/build/install-golang.sh",
+      "${path.root}/../scripts/build/install-swiftlint.sh",
+      "${path.root}/../scripts/build/install-openjdk.sh",
+      "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-gcc.sh",
+      "${path.root}/../scripts/build/install-haskell.sh",
+      "${path.root}/../scripts/build/install-cocoapods.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-xamarin.sh",
+      "${path.root}/../scripts/build/install-visualstudio.sh",
+      "${path.root}/../scripts/build/install-nvm.sh",
+      "${path.root}/../scripts/build/install-apache.sh",
+      "${path.root}/../scripts/build/install-nginx.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
+      "${path.root}/../scripts/build/install-audiodevice.sh",
+      "${path.root}/../scripts/build/install-vcpkg.sh",
+      "${path.root}/../scripts/build/install-miniconda.sh",
+      "${path.root}/../scripts/build/install-safari.sh",
+      "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-edge.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
+      "${path.root}/../scripts/build/install-pypy.sh",
+      "${path.root}/../scripts/build/install-pipx-packages.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/Install-Toolset.ps1",
-      "./scripts/build/Configure-Toolset.ps1"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/Install-Toolset.ps1",
+      "${path.root}/../scripts/build/Configure-Toolset.ps1"
+    ]
   }
+
   provisioner "shell" {
-    script = "./scripts/build/configure-xcode-simulators.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
+    script          = "${path.root}/../scripts/build/configure-xcode-simulators.rb"
   }
+
   provisioner "shell" {
-      script = "./scripts/build/Update-XcodeSimulators.ps1"
-      execute_command = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
+    script          = "${path.root}/../scripts/build/Update-XcodeSimulators.ps1"
   }
+
   provisioner "shell" {
-    inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}",
-      "pwsh -File \"$HOME/image-generation/tests/RunAll-Tests.ps1\""
-    ]
     execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-  }
-  provisioner "file" {
-    destination = "../image-output/"
-    direction = "download"
-    source = "./image-generation/output/"
-  }
-  provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-hostname.sh",
-      "./scripts/build/configure-system.sh"
+    inline          = [
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
+      "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../../image-output/"
+    direction   = "download"
+    source      = "${local.image_folder}/output/"
+  }
+
+  provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
+    ]
   }
 }

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -174,7 +174,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
@@ -194,7 +194,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
     script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
@@ -206,7 +206,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
@@ -242,8 +242,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
-    scripts         = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts          = [
       "${path.root}/../scripts/build/Install-Toolset.ps1",
       "${path.root}/../scripts/build/Configure-Toolset.ps1"
     ]
@@ -260,8 +261,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    inline          = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    inline           = [
       "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
       "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]

--- a/images/macos/templates/macOS-12.pkr.hcl
+++ b/images/macos/templates/macOS-12.pkr.hcl
@@ -7,6 +7,10 @@ packer {
   }
 }
 
+locals {
+  image_folder = "/Users/${var.vm_username}/image-generation"
+}
+
 variable "baseimage_name" {
   type = string
 }
@@ -100,37 +104,37 @@ build {
   sources = ["source.vsphere-clone.template"]
 
   provisioner "shell" {
-    inline = ["mkdir ~/image-generation"]
+    inline = ["mkdir ${local.image_folder}"]
   }
 
   provisioner "file" {
-    destination = "~/image-generation/"
+    destination = "${local.image_folder}/"
     sources     = [
-      "./assets/xamarin-selector",
-      "./scripts/tests",
-      "./scripts/docs-gen",
-      "./scripts/helpers"
+      "${path.root}/../assets/xamarin-selector",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen",
+      "${path.root}/../scripts/helpers"
     ]
   }
 
   provisioner "file" {
-    destination = "~/image-generation/docs-gen/"
-    source      = "../../helpers/software-report-base"
+    destination = "${local.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
   }
 
   provisioner "file" {
-    destination = "~/image-generation/add-certificate.swift"
-    source      = "./assets/add-certificate.swift"
+    destination = "${local.image_folder}/add-certificate.swift"
+    source      = "${path.root}/../assets/add-certificate.swift"
   }
 
   provisioner "file" {
     destination = "~/.bashrc"
-    source      = "./assets/bashrc"
+    source      = "${path.root}/../assets/bashrc"
   }
 
   provisioner "file" {
     destination = "~/.bash_profile"
-    source      = "./assets/bashprofile"
+    source      = "${path.root}/../assets/bashprofile"
   }
 
   provisioner "shell" {
@@ -139,32 +143,32 @@ build {
 
   provisioner "file" {
     destination = "~/bootstrap"
-    source      = "./assets/bootstrap-provisioner/"
+    source      = "${path.root}/../assets/bootstrap-provisioner/"
   }
 
   provisioner "file" {
-    destination = "~/image-generation/toolset.json"
-    source      = "./toolsets/toolset-12.json"
+    destination = "${local.image_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-12.json"
   }
 
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = [
-      "mv ~/image-generation/docs-gen ~/image-generation/software-report",
-      "mv ~/image-generation/xamarin-selector ~/image-generation/assets",
+      "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
+      "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ~/image-generation/helpers/confirm-identified-developers.scpt ~/utils",
-      "mv ~/image-generation/helpers/invoke-tests.sh ~/utils",
-      "mv ~/image-generation/helpers/utils.sh ~/utils",
-      "mv ~/image-generation/helpers/xamarin-utils.sh ~/utils"
+      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
+      "mv ${local.image_folder}/helpers/utils.sh ~/utils",
+      "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"
     ]
   }
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts         = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/install-homebrew.sh"
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/install-homebrew.sh"
     ]
   }
 
@@ -172,13 +176,13 @@ build {
     environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
     execute_command  = "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
-      "./scripts/build/configure-network-interface-detection.sh",
-      "./scripts/build/configure-autologin.sh",
-      "./scripts/build/configure-auto-updates.sh",
-      "./scripts/build/configure-screensaver.sh",
-      "./scripts/build/configure-ntpconf.sh",
-      "./scripts/build/configure-max-files-limitation.sh",
-      "./scripts/build/configure-shell.sh"
+      "${path.root}/../scripts/build/configure-network-interface-detection.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
+      "${path.root}/../scripts/build/configure-auto-updates.sh",
+      "${path.root}/../scripts/build/configure-screensaver.sh",
+      "${path.root}/../scripts/build/configure-ntpconf.sh",
+      "${path.root}/../scripts/build/configure-max-files-limitation.sh",
+      "${path.root}/../scripts/build/configure-shell.sh"
     ]
   }
 
@@ -186,9 +190,9 @@ build {
     environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "PASSWORD=${var.vm_password}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts          = [
-      "./scripts/build/configure-preimagedata.sh",
-      "./scripts/build/configure-ssh.sh",
-      "./scripts/build/configure-machine.sh"
+      "${path.root}/../scripts/build/configure-preimagedata.sh",
+      "${path.root}/../scripts/build/configure-ssh.sh",
+      "${path.root}/../scripts/build/configure-machine.sh"
     ]
   }
 
@@ -203,25 +207,25 @@ build {
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
-      "./scripts/build/configure-windows.sh",
-      "./scripts/build/install-powershell.sh",
-      "./scripts/build/install-dotnet.sh",
-      "./scripts/build/install-python.sh",
-      "./scripts/build/install-azcopy.sh",
-      "./scripts/build/install-openssl.sh",
-      "./scripts/build/install-ruby.sh",
-      "./scripts/build/install-rubygems.sh",
-      "./scripts/build/install-git.sh",
-      "./scripts/build/install-mongodb.sh",
-      "./scripts/build/install-node.sh",
-      "./scripts/build/install-common-utils.sh"
+      "${path.root}/../scripts/build/configure-windows.sh",
+      "${path.root}/../scripts/build/install-powershell.sh",
+      "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-python.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-openssl.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rubygems.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-mongodb.sh",
+      "${path.root}/../scripts/build/install-node.sh",
+      "${path.root}/../scripts/build/install-common-utils.sh"
     ]
   }
 
   provisioner "shell" {
     environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
-    script           = "./scripts/build/Install-Xcode.ps1"
+    script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
 
   provisioner "shell" {
@@ -234,74 +238,74 @@ build {
     environment_vars = ["API_PAT=${var.github_api_pat}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts          = [
-      "./scripts/build/install-actions-cache.sh",
-      "./scripts/build/install-llvm.sh",
-      "./scripts/build/install-golang.sh",
-      "./scripts/build/install-swiftlint.sh",
-      "./scripts/build/install-openjdk.sh",
-      "./scripts/build/install-php.sh",
-      "./scripts/build/install-aws-tools.sh",
-      "./scripts/build/install-rust.sh",
-      "./scripts/build/install-gcc.sh",
-      "./scripts/build/install-haskell.sh",
-      "./scripts/build/install-cocoapods.sh",
-      "./scripts/build/install-android-sdk.sh",
-      "./scripts/build/install-xamarin.sh",
-      "./scripts/build/install-visualstudio.sh",
-      "./scripts/build/install-nvm.sh",
-      "./scripts/build/install-apache.sh",
-      "./scripts/build/install-nginx.sh",
-      "./scripts/build/install-postgresql.sh",
-      "./scripts/build/install-audiodevice.sh",
-      "./scripts/build/install-vcpkg.sh",
-      "./scripts/build/install-miniconda.sh",
-      "./scripts/build/install-safari.sh",
-      "./scripts/build/install-chrome.sh",
-      "./scripts/build/install-edge.sh",
-      "./scripts/build/install-firefox.sh",
-      "./scripts/build/install-pypy.sh",
-      "./scripts/build/install-pipx-packages.sh",
-      "./scripts/build/install-bicep.sh",
-      "./scripts/build/install-codeql-bundle.sh"
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-llvm.sh",
+      "${path.root}/../scripts/build/install-golang.sh",
+      "${path.root}/../scripts/build/install-swiftlint.sh",
+      "${path.root}/../scripts/build/install-openjdk.sh",
+      "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-gcc.sh",
+      "${path.root}/../scripts/build/install-haskell.sh",
+      "${path.root}/../scripts/build/install-cocoapods.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-xamarin.sh",
+      "${path.root}/../scripts/build/install-visualstudio.sh",
+      "${path.root}/../scripts/build/install-nvm.sh",
+      "${path.root}/../scripts/build/install-apache.sh",
+      "${path.root}/../scripts/build/install-nginx.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
+      "${path.root}/../scripts/build/install-audiodevice.sh",
+      "${path.root}/../scripts/build/install-vcpkg.sh",
+      "${path.root}/../scripts/build/install-miniconda.sh",
+      "${path.root}/../scripts/build/install-safari.sh",
+      "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-edge.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
+      "${path.root}/../scripts/build/install-pypy.sh",
+      "${path.root}/../scripts/build/install-pipx-packages.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
   }
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
     scripts         = [
-      "./scripts/build/Install-Toolset.ps1",
-      "./scripts/build/Configure-Toolset.ps1"
+      "${path.root}/../scripts/build/Install-Toolset.ps1",
+      "${path.root}/../scripts/build/Configure-Toolset.ps1"
     ]
   }
 
   provisioner "shell" {
     execute_command = "ruby {{ .Path }}"
-    script          = "./scripts/build/configure-xcode-simulators.rb"
+    script          = "${path.root}/../scripts/build/configure-xcode-simulators.rb"
   }
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
-    script          = "./scripts/build/Update-XcodeSimulators.ps1"
+    script          = "${path.root}/../scripts/build/Update-XcodeSimulators.ps1"
   }
 
   provisioner "shell" {
     inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}",
-      "pwsh -File \"$HOME/image-generation/tests/RunAll-Tests.ps1\""
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
+      "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]
   }
 
   provisioner "file" {
-    destination = "../image-output/"
+    destination = "${path.root}/../../image-output/"
     direction   = "download"
-    source      = "~/image-generation/output/*"
+    source      = "${local.image_folder}/output/*"
   }
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts         = [
-      "./scripts/build/configure-hostname.sh",
-      "./scripts/build/configure-system.sh"
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
     ]
   }
 }

--- a/images/macos/templates/macOS-12.pkr.hcl
+++ b/images/macos/templates/macOS-12.pkr.hcl
@@ -203,7 +203,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
@@ -223,7 +223,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
     script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
@@ -235,7 +235,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
@@ -271,8 +271,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
-    scripts         = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts          = [
       "${path.root}/../scripts/build/Install-Toolset.ps1",
       "${path.root}/../scripts/build/Configure-Toolset.ps1"
     ]
@@ -289,7 +290,8 @@ build {
   }
 
   provisioner "shell" {
-    inline = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    inline           = [
       "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
       "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -172,7 +172,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
@@ -192,7 +192,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
     script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
@@ -204,7 +204,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
@@ -230,8 +230,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
-    scripts         = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts          = [
       "${path.root}/../scripts/build/Install-Toolset.ps1",
       "${path.root}/../scripts/build/Configure-Toolset.ps1"
     ]
@@ -243,8 +244,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    inline          = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    inline           = [
       "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
       "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -2,9 +2,13 @@ packer {
   required_plugins {
     veertu-anka = {
       version = ">= v3.2.0"
-      source = "github.com/veertuinc/veertu-anka"
+      source  = "github.com/veertuinc/veertu-anka"
     }
   }
+}
+
+locals {
+  image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
 variable "source_vm_name" {
@@ -20,246 +24,247 @@ variable "build_id" {
 }
 
 variable "vm_username" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vm_password" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "github_api_pat" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "xcode_install_storage_url" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "xcode_install_sas" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vcpu_count" {
-  type = string
+  type    = string
   default = "6"
 }
 
 variable "ram_size" {
-  type = string
+  type    = string
   default = "24G"
 }
 
 variable "image_os" {
-  type = string
+  type    = string
   default = "macos13"
 }
 
 source "veertu-anka-vm-clone" "template" {
-  vm_name = "${var.build_id}"
+  vm_name        = "${var.build_id}"
   source_vm_name = "${var.source_vm_name}"
-  source_vm_tag = "${var.source_vm_tag}"
-  vcpu_count = "${var.vcpu_count}"
-  ram_size = "${var.ram_size}"
-  stop_vm = "true"
+  source_vm_tag  = "${var.source_vm_tag}"
+  vcpu_count     = "${var.vcpu_count}"
+  ram_size       = "${var.ram_size}"
+  stop_vm        = "true"
 }
 
 build {
-  sources = [
-    "source.veertu-anka-vm-clone.template"
-  ]
+  sources = ["source.veertu-anka-vm-clone.template"]
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/image-generation"
+    inline = ["mkdir ${local.image_folder}"]
+  }
+
+  provisioner "file" {
+    destination = "${local.image_folder}/"
+    sources     = [
+      "${path.root}/../assets/xamarin-selector",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen",
+      "${path.root}/../scripts/helpers"
     ]
   }
+
   provisioner "file" {
-    destination = "image-generation/"
-    sources = [
-      "./assets/xamarin-selector",
-      "./scripts/tests",
-      "./scripts/docs-gen",
-      "./scripts/helpers"
-    ]
+    destination = "${local.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
   }
+
   provisioner "file" {
-    destination = "image-generation/docs-gen/"
-    source = "../../helpers/software-report-base"
+    destination = "${local.image_folder}/add-certificate.swift"
+    source      = "${path.root}/../assets/add-certificate.swift"
   }
+
   provisioner "file" {
-    destination = "image-generation/add-certificate.swift"
-    source = "./assets/add-certificate.swift"
+    destination = "~/.bashrc"
+    source      = "${path.root}/../assets/bashrc"
   }
+
   provisioner "file" {
-    destination = ".bashrc"
-    source = "./assets/bashrc"
+    destination = "~/.bash_profile"
+    source      = "${path.root}/../assets/bashprofile"
   }
-  provisioner "file" {
-    destination = ".bash_profile"
-    source = "./assets/bashprofile"
-  }
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/bootstrap"
-    ]
+    inline = ["mkdir ~/bootstrap"]
   }
+
   provisioner "file" {
-    destination = "bootstrap"
-    source = "./assets/bootstrap-provisioner/"
+    destination = "~/bootstrap"
+    source      = "${path.root}/../assets/bootstrap-provisioner/"
   }
+
   provisioner "file" {
-    destination = "image-generation/toolset.json"
-    source = "./toolsets/toolset-13.json"
+    destination = "${local.image_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-13.json"
   }
+
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = [
-      "mv ~/image-generation/docs-gen ~/image-generation/software-report",
-      "mv ~/image-generation/xamarin-selector ~/image-generation/assets",
+      "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
+      "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ~/image-generation/helpers/confirm-identified-developers.scpt ~/utils",
-      "mv ~/image-generation/helpers/invoke-tests.sh ~/utils",
-      "mv ~/image-generation/helpers/utils.sh ~/utils",
-      "mv ~/image-generation/helpers/xamarin-utils.sh ~/utils"
+      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
+      "mv ${local.image_folder}/helpers/utils.sh ~/utils",
+      "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"
     ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/install-homebrew.sh"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/install-homebrew.sh"
+    ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-tccdb-macos.sh",
-      "./scripts/build/configure-auto-updates.sh",
-      "./scripts/build/configure-ntpconf.sh",
-      "./scripts/build/configure-shell.sh"
+    environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-auto-updates.sh",
+      "${path.root}/../scripts/build/configure-ntpconf.sh",
+      "${path.root}/../scripts/build/configure-shell.sh"
     ]
-    environment_vars = [
-      "PASSWORD=${var.vm_password}",
-      "USERNAME=${var.vm_username}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-preimagedata.sh",
-      "./scripts/build/configure-ssh.sh",
-      "./scripts/build/configure-machine.sh"
+    environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-preimagedata.sh",
+      "${path.root}/../scripts/build/configure-ssh.sh",
+      "${path.root}/../scripts/build/configure-machine.sh"
     ]
-    environment_vars = [
-      "IMAGE_VERSION=${var.build_id}",
-      "IMAGE_OS=${var.image_os}",
-      "PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    pause_before = "30s"
-    scripts = [
-      "./scripts/build/configure-windows.sh",
-      "./scripts/build/install-powershell.sh",
-      "./scripts/build/install-mono.sh",
-      "./scripts/build/install-dotnet.sh",
-      "./scripts/build/install-python.sh",
-      "./scripts/build/install-azcopy.sh",
-      "./scripts/build/install-openssl.sh",
-      "./scripts/build/install-ruby.sh",
-      "./scripts/build/install-rubygems.sh",
-      "./scripts/build/install-git.sh",
-      "./scripts/build/install-node.sh",
-      "./scripts/build/install-common-utils.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-windows.sh",
+      "${path.root}/../scripts/build/install-powershell.sh",
+      "${path.root}/../scripts/build/install-mono.sh",
+      "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-python.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-openssl.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rubygems.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-node.sh",
+      "${path.root}/../scripts/build/install-common-utils.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}",
-      "USER_PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    script = "./scripts/build/Install-Xcode.ps1"
-    environment_vars = [
-      "XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}",
-      "XCODE_INSTALL_SAS=${var.xcode_install_sas}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-actions-cache.sh",
-      "./scripts/build/install-llvm.sh",
-      "./scripts/build/install-swiftlint.sh",
-      "./scripts/build/install-openjdk.sh",
-      "./scripts/build/install-php.sh",
-      "./scripts/build/install-aws-tools.sh",
-      "./scripts/build/install-rust.sh",
-      "./scripts/build/install-gcc.sh",
-      "./scripts/build/install-cocoapods.sh",
-      "./scripts/build/install-android-sdk.sh",
-      "./scripts/build/install-apache.sh",
-      "./scripts/build/install-vcpkg.sh",
-      "./scripts/build/install-safari.sh",
-      "./scripts/build/install-chrome.sh",
-      "./scripts/build/install-edge.sh",
-      "./scripts/build/install-firefox.sh",
-      "./scripts/build/install-pypy.sh",
-      "./scripts/build/install-bicep.sh",
-      "./scripts/build/install-codeql-bundle.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-llvm.sh",
+      "${path.root}/../scripts/build/install-swiftlint.sh",
+      "${path.root}/../scripts/build/install-openjdk.sh",
+      "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-gcc.sh",
+      "${path.root}/../scripts/build/install-cocoapods.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-apache.sh",
+      "${path.root}/../scripts/build/install-vcpkg.sh",
+      "${path.root}/../scripts/build/install-safari.sh",
+      "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-edge.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
+      "${path.root}/../scripts/build/install-pypy.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/Install-Toolset.ps1",
-      "./scripts/build/Configure-Toolset.ps1"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/Install-Toolset.ps1",
+      "${path.root}/../scripts/build/Configure-Toolset.ps1"
+    ]
   }
+
   provisioner "shell" {
-    script = "./scripts/build/configure-xcode-simulators.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
+    script          = "${path.root}/../scripts/build/configure-xcode-simulators.rb"
   }
+
   provisioner "shell" {
-    inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}",
-      "pwsh -File \"$HOME/image-generation/tests/RunAll-Tests.ps1\""
-    ]
     execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    inline          = [
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
+      "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
+    ]
   }
+
   provisioner "file" {
-    destination = "../image-output/"
-    direction = "download"
-    source = "./image-generation/output/"
+    destination = "${path.root}/../../image-output/"
+    direction   = "download"
+    source      = "${local.image_folder}/output/"
   }
+
   provisioner "shell" {
-    inline = [
-      "rm -rf \"$(brew --cache)\""
-    ]
+    inline = ["rm -rf \"$(brew --cache)\""]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-hostname.sh",
-      "./scripts/build/configure-system.sh"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
+    ]
   }
 }

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -2,9 +2,13 @@ packer {
   required_plugins {
     veertu-anka = {
       version = ">= v3.2.0"
-      source = "github.com/veertuinc/veertu-anka"
+      source  = "github.com/veertuinc/veertu-anka"
     }
   }
+}
+
+locals {
+  image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
 variable "source_vm_name" {
@@ -20,234 +24,234 @@ variable "build_id" {
 }
 
 variable "vm_username" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vm_password" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "github_api_pat" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "xcode_install_storage_url" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "xcode_install_sas" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vcpu_count" {
-  type = string
+  type    = string
   default = "6"
 }
 
 variable "ram_size" {
-  type = string
+  type    = string
   default = "8G"
 }
 
 variable "image_os" {
-  type = string
+  type    = string
   default = "macos13"
 }
 
 source "veertu-anka-vm-clone" "template" {
-  vm_name = "${var.build_id}"
+  vm_name        = "${var.build_id}"
   source_vm_name = "${var.source_vm_name}"
-  source_vm_tag = "${var.source_vm_tag}"
-  vcpu_count = "${var.vcpu_count}"
-  ram_size = "${var.ram_size}"
-  stop_vm = "true"
-  log_level = "debug"
+  source_vm_tag  = "${var.source_vm_tag}"
+  vcpu_count     = "${var.vcpu_count}"
+  ram_size       = "${var.ram_size}"
+  stop_vm        = "true"
+  log_level      = "debug"
 }
 
 build {
-  sources = [
-    "source.veertu-anka-vm-clone.template"
-  ]
+  sources = ["source.veertu-anka-vm-clone.template"]
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/image-generation"
+    inline = ["mkdir ${local.image_folder}"]
+  }
+
+  provisioner "file" {
+    destination = "${local.image_folder}/"
+    sources     = [
+      "${path.root}/../assets/xamarin-selector",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen",
+      "${path.root}/../scripts/helpers"
     ]
   }
+
   provisioner "file" {
-    destination = "image-generation/"
-    sources = [
-      "./assets/xamarin-selector",
-      "./scripts/tests",
-      "./scripts/docs-gen",
-      "./scripts/helpers"
-    ]
+    destination = "${local.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
   }
+
   provisioner "file" {
-    destination = "image-generation/docs-gen/"
-    source = "../../helpers/software-report-base"
+    destination = "${local.image_folder}/add-certificate.swift"
+    source      = "${path.root}/../assets/add-certificate.swift"
   }
+
   provisioner "file" {
-    destination = "image-generation/add-certificate.swift"
-    source = "./assets/add-certificate.swift"
+    destination = "~/.bashrc"
+    source      = "${path.root}/../assets/bashrc"
   }
+
   provisioner "file" {
-    destination = ".bashrc"
-    source = "./assets/bashrc"
+    destination = "~/.bash_profile"
+    source      = "${path.root}/../assets/bashprofile"
   }
-  provisioner "file" {
-    destination = ".bash_profile"
-    source = "./assets/bashprofile"
-  }
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/bootstrap"
-    ]
+    inline = ["mkdir ~/bootstrap"]
   }
+
   provisioner "file" {
-    destination = "bootstrap"
-    source = "./assets/bootstrap-provisioner/"
+    destination = "~/bootstrap"
+    source      = "${path.root}/../assets/bootstrap-provisioner/"
   }
+
   provisioner "file" {
-    destination = "image-generation/toolset.json"
-    source = "./toolsets/toolset-13.json"
+    destination = "${local.image_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-13.json"
   }
+
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = [
-      "mv ~/image-generation/docs-gen ~/image-generation/software-report",
-      "mv ~/image-generation/xamarin-selector ~/image-generation/assets",
+      "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
+      "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ~/image-generation/helpers/confirm-identified-developers.scpt ~/utils",
-      "mv ~/image-generation/helpers/invoke-tests.sh ~/utils",
-      "mv ~/image-generation/helpers/utils.sh ~/utils",
-      "mv ~/image-generation/helpers/xamarin-utils.sh ~/utils"
+      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
+      "mv ${local.image_folder}/helpers/utils.sh ~/utils",
+      "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"
     ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/install-homebrew.sh"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/install-homebrew.sh"
+    ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-tccdb-macos.sh",
-      "./scripts/build/configure-auto-updates.sh",
-      "./scripts/build/configure-ntpconf.sh",
-      "./scripts/build/configure-shell.sh"
+    environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-auto-updates.sh",
+      "${path.root}/../scripts/build/configure-ntpconf.sh",
+      "${path.root}/../scripts/build/configure-shell.sh"
     ]
-    environment_vars = [
-      "PASSWORD=${var.vm_password}",
-      "USERNAME=${var.vm_username}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-preimagedata.sh",
-      "./scripts/build/configure-ssh.sh",
-      "./scripts/build/configure-machine.sh"
+    environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-preimagedata.sh",
+      "${path.root}/../scripts/build/configure-ssh.sh",
+      "${path.root}/../scripts/build/configure-machine.sh"
     ]
-    environment_vars = [
-      "IMAGE_VERSION=${var.build_id}",
-      "IMAGE_OS=${var.image_os}",
-      "PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    pause_before = "30s"
-    scripts = [
-      "./scripts/build/install-rosetta.sh",
-      "./scripts/build/configure-windows.sh",
-      "./scripts/build/install-powershell.sh",
-      "./scripts/build/install-mono.sh",
-      "./scripts/build/install-dotnet.sh",
-      "./scripts/build/install-azcopy.sh",
-      "./scripts/build/install-openssl.sh",
-      "./scripts/build/install-ruby.sh",
-      "./scripts/build/install-rubygems.sh",
-      "./scripts/build/install-git.sh",
-      "./scripts/build/install-node.sh",
-      "./scripts/build/install-common-utils.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
+    scripts          = [
+      "${path.root}/../scripts/build/install-rosetta.sh",
+      "${path.root}/../scripts/build/configure-windows.sh",
+      "${path.root}/../scripts/build/install-powershell.sh",
+      "${path.root}/../scripts/build/install-mono.sh",
+      "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-openssl.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rubygems.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-node.sh",
+      "${path.root}/../scripts/build/install-common-utils.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}",
-      "USER_PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    script = "./scripts/build/Install-Xcode.ps1"
-    environment_vars = [
-      "XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}",
-      "XCODE_INSTALL_SAS=${var.xcode_install_sas}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}" ]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-actions-cache.sh",
-      "./scripts/build/install-llvm.sh",
-      "./scripts/build/install-openjdk.sh",
-      "./scripts/build/install-aws-tools.sh",
-      "./scripts/build/install-rust.sh",
-      "./scripts/build/install-gcc.sh",
-      "./scripts/build/install-cocoapods.sh",
-      "./scripts/build/install-android-sdk.sh",
-      "./scripts/build/install-safari.sh",
-      "./scripts/build/install-chrome.sh",
-      "./scripts/build/install-bicep.sh",
-      "./scripts/build/install-codeql-bundle.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-llvm.sh",
+      "${path.root}/../scripts/build/install-openjdk.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-gcc.sh",
+      "${path.root}/../scripts/build/install-cocoapods.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-safari.sh",
+      "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/Install-Toolset.ps1",
-      "./scripts/build/Configure-Toolset.ps1"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/Install-Toolset.ps1",
+      "${path.root}/../scripts/build/Configure-Toolset.ps1"
+    ]
   }
+
   provisioner "shell" {
-    script = "./scripts/build/configure-xcode-simulators.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
+    script          = "${path.root}/../scripts/build/configure-xcode-simulators.rb"
   }
+
   provisioner "shell" {
-    inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}",
-      "pwsh -File \"$HOME/image-generation/tests/RunAll-Tests.ps1\""
-    ]
     execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-  }
-  provisioner "file" {
-    destination = "../image-output/"
-    direction = "download"
-    source = "./image-generation/output/"
-  }
-  provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-hostname.sh"
+    inline          = [
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
+      "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../../image-output/"
+    direction   = "download"
+    source      = "${local.image_folder}/output/"
+  }
+
+  provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = ["${path.root}/../scripts/build/configure-hostname.sh"]
   }
 }

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -173,7 +173,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
@@ -193,7 +193,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}" ]
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
     script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
@@ -205,7 +205,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
@@ -224,8 +224,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
-    scripts         = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    scripts          = [
       "${path.root}/../scripts/build/Install-Toolset.ps1",
       "${path.root}/../scripts/build/Configure-Toolset.ps1"
     ]
@@ -237,8 +238,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    inline          = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    inline           = [
       "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
       "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -2,9 +2,13 @@ packer {
   required_plugins {
     veertu-anka = {
       version = ">= v3.2.0"
-      source = "github.com/veertuinc/veertu-anka"
+      source  = "github.com/veertuinc/veertu-anka"
     }
   }
+}
+
+locals {
+  image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
 variable "source_vm_name" {
@@ -20,238 +24,238 @@ variable "build_id" {
 }
 
 variable "vm_username" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vm_password" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "github_api_pat" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "xcode_install_storage_url" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "xcode_install_sas" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vcpu_count" {
-  type = string
+  type    = string
   default = "6"
 }
 
 variable "ram_size" {
-  type = string
+  type    = string
   default = "24G"
 }
 
 variable "image_os" {
-  type = string
+  type    = string
   default = "macos14"
 }
 
 source "veertu-anka-vm-clone" "template" {
-  vm_name = "${var.build_id}"
+  vm_name        = "${var.build_id}"
   source_vm_name = "${var.source_vm_name}"
-  source_vm_tag = "${var.source_vm_tag}"
-  vcpu_count = "${var.vcpu_count}"
-  ram_size = "${var.ram_size}"
-  stop_vm = "true"
+  source_vm_tag  = "${var.source_vm_tag}"
+  vcpu_count     = "${var.vcpu_count}"
+  ram_size       = "${var.ram_size}"
+  stop_vm        = "true"
 }
 
 build {
-  sources = [
-    "source.veertu-anka-vm-clone.template"
-  ]
+  sources = ["source.veertu-anka-vm-clone.template"]
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/image-generation"
+    inline = ["mkdir ${local.image_folder}"]
+  }
+
+  provisioner "file" {
+    destination = "${local.image_folder}/"
+    sources     = [
+      "${path.root}/../assets/xamarin-selector",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen",
+      "${path.root}/../scripts/helpers"
     ]
   }
+
   provisioner "file" {
-    destination = "image-generation/"
-    sources = [
-      "./assets/xamarin-selector",
-      "./scripts/tests",
-      "./scripts/docs-gen",
-      "./scripts/helpers"
-    ]
+    destination = "${local.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
   }
+
   provisioner "file" {
-    destination = "image-generation/docs-gen/"
-    source = "../../helpers/software-report-base"
+    destination = "${local.image_folder}/add-certificate.swift"
+    source      = "${path.root}/../assets/add-certificate.swift"
   }
+
   provisioner "file" {
-    destination = "image-generation/add-certificate.swift"
-    source = "./assets/add-certificate.swift"
+    destination = "~/.bashrc"
+    source      = "${path.root}/../assets/bashrc"
   }
+
   provisioner "file" {
-    destination = ".bashrc"
-    source = "./assets/bashrc"
+    destination = "~/.bash_profile"
+    source      = "${path.root}/../assets/bashprofile"
   }
-  provisioner "file" {
-    destination = ".bash_profile"
-    source = "./assets/bashprofile"
-  }
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/bootstrap"
-    ]
+    inline = ["mkdir ~/bootstrap"]
   }
+
   provisioner "file" {
-    destination = "bootstrap"
-    source = "./assets/bootstrap-provisioner/"
+    destination = "~/bootstrap"
+    source      = "${path.root}/../assets/bootstrap-provisioner/"
   }
+
   provisioner "file" {
-    destination = "image-generation/toolset.json"
-    source = "./toolsets/toolset-14.json"
+    destination = "${local.image_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-14.json"
   }
+
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = [
-      "mv ~/image-generation/docs-gen ~/image-generation/software-report",
-      "mv ~/image-generation/xamarin-selector ~/image-generation/assets",
+      "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
+      "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ~/image-generation/helpers/confirm-identified-developers.scpt ~/utils",
-      "mv ~/image-generation/helpers/invoke-tests.sh ~/utils",
-      "mv ~/image-generation/helpers/utils.sh ~/utils",
-      "mv ~/image-generation/helpers/xamarin-utils.sh ~/utils"
+      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
+      "mv ${local.image_folder}/helpers/utils.sh ~/utils",
+      "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"
     ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/install-homebrew.sh"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/install-homebrew.sh"
+    ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-tccdb-macos.sh",
-      "./scripts/build/configure-auto-updates.sh",
-      "./scripts/build/configure-ntpconf.sh",
-      "./scripts/build/configure-shell.sh"
+    environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-auto-updates.sh",
+      "${path.root}/../scripts/build/configure-ntpconf.sh",
+      "${path.root}/../scripts/build/configure-shell.sh"
     ]
-    environment_vars = [
-      "PASSWORD=${var.vm_password}",
-      "USERNAME=${var.vm_username}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-preimagedata.sh",
-      "./scripts/build/configure-ssh.sh",
-      "./scripts/build/configure-machine.sh"
+    environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-preimagedata.sh",
+      "${path.root}/../scripts/build/configure-ssh.sh",
+      "${path.root}/../scripts/build/configure-machine.sh"
     ]
-    environment_vars = [
-      "IMAGE_VERSION=${var.build_id}",
-      "IMAGE_OS=${var.image_os}",
-      "PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    pause_before = "30s"
-    scripts = [
-      "./scripts/build/configure-windows.sh",
-      "./scripts/build/install-powershell.sh",
-      "./scripts/build/install-mono.sh",
-      "./scripts/build/install-dotnet.sh",
-      "./scripts/build/install-python.sh",
-      "./scripts/build/install-azcopy.sh",
-      "./scripts/build/install-openssl.sh",
-      "./scripts/build/install-ruby.sh",
-      "./scripts/build/install-rubygems.sh",
-      "./scripts/build/install-git.sh",
-      "./scripts/build/install-node.sh",
-      "./scripts/build/install-common-utils.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-windows.sh",
+      "${path.root}/../scripts/build/install-powershell.sh",
+      "${path.root}/../scripts/build/install-mono.sh",
+      "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-python.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-openssl.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rubygems.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-node.sh",
+      "${path.root}/../scripts/build/install-common-utils.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}",
-      "USER_PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    script = "./scripts/build/Install-Xcode.ps1"
-    environment_vars = [
-      "XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}",
-      "XCODE_INSTALL_SAS=${var.xcode_install_sas}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-actions-cache.sh",
-      "./scripts/build/install-llvm.sh",
-      "./scripts/build/install-swiftlint.sh",
-      "./scripts/build/install-openjdk.sh",
-      "./scripts/build/install-php.sh",
-      "./scripts/build/install-aws-tools.sh",
-      "./scripts/build/install-rust.sh",
-      "./scripts/build/install-gcc.sh",
-      "./scripts/build/install-cocoapods.sh",
-      "./scripts/build/install-android-sdk.sh",
-      "./scripts/build/install-apache.sh",
-      "./scripts/build/install-vcpkg.sh",
-      "./scripts/build/install-safari.sh",
-      "./scripts/build/install-chrome.sh",
-      "./scripts/build/install-edge.sh",
-      "./scripts/build/install-firefox.sh",
-      "./scripts/build/install-pypy.sh",
-      "./scripts/build/install-bicep.sh",
-      "./scripts/build/install-codeql-bundle.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-llvm.sh",
+      "${path.root}/../scripts/build/install-swiftlint.sh",
+      "${path.root}/../scripts/build/install-openjdk.sh",
+      "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-gcc.sh",
+      "${path.root}/../scripts/build/install-cocoapods.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-apache.sh",
+      "${path.root}/../scripts/build/install-vcpkg.sh",
+      "${path.root}/../scripts/build/install-safari.sh",
+      "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-edge.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
+      "${path.root}/../scripts/build/install-pypy.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    script = "./scripts/build/configure-xcode-simulators.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
+    script          = "${path.root}/../scripts/build/configure-xcode-simulators.rb"
   }
+
   provisioner "shell" {
-    inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}"
-    ]
     execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    inline          = [
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}"
+    ]
   }
+
   provisioner "file" {
-    destination = "../image-output/"
-    direction = "download"
-    source = "./image-generation/output/"
+    destination = "${path.root}/../../image-output/"
+    direction   = "download"
+    source      = "${local.image_folder}/output/"
   }
+
   provisioner "shell" {
-    inline = [
-      "rm -rf \"$(brew --cache)\""
-    ]
+    inline = ["rm -rf \"$(brew --cache)\""]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-hostname.sh",
-      "./scripts/build/configure-system.sh"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
+    ]
   }
 }

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -172,7 +172,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
@@ -192,7 +192,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
     script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
@@ -204,7 +204,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
@@ -235,8 +235,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    inline          = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    inline           = [
       "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}"
     ]
   }

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -2,9 +2,13 @@ packer {
   required_plugins {
     veertu-anka = {
       version = ">= v3.2.0"
-      source = "github.com/veertuinc/veertu-anka"
+      source  = "github.com/veertuinc/veertu-anka"
     }
   }
+}
+
+locals {
+  image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
 variable "source_vm_name" {
@@ -20,226 +24,225 @@ variable "build_id" {
 }
 
 variable "vm_username" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vm_password" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "github_api_pat" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "xcode_install_storage_url" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "xcode_install_sas" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "vcpu_count" {
-  type = string
+  type    = string
   default = "6"
 }
 
 variable "ram_size" {
-  type = string
+  type    = string
   default = "8G"
 }
 
 variable "image_os" {
-  type = string
+  type    = string
   default = "macos14"
 }
 
 source "veertu-anka-vm-clone" "template" {
-  vm_name = "${var.build_id}"
+  vm_name        = "${var.build_id}"
   source_vm_name = "${var.source_vm_name}"
-  source_vm_tag = "${var.source_vm_tag}"
-  vcpu_count = "${var.vcpu_count}"
-  ram_size = "${var.ram_size}"
-  stop_vm = "true"
-  log_level = "debug"
+  source_vm_tag  = "${var.source_vm_tag}"
+  vcpu_count     = "${var.vcpu_count}"
+  ram_size       = "${var.ram_size}"
+  stop_vm        = "true"
+  log_level      = "debug"
 }
 
 build {
-  sources = [
-    "source.veertu-anka-vm-clone.template"
-  ]
+  sources = ["source.veertu-anka-vm-clone.template"]
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/image-generation"
+    inline = ["mkdir ${local.image_folder}"]
+  }
+
+  provisioner "file" {
+    destination = "${local.image_folder}/"
+    sources     = [
+      "${path.root}/../assets/xamarin-selector",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen",
+      "${path.root}/../scripts/helpers"
     ]
   }
+
   provisioner "file" {
-    destination = "image-generation/"
-    sources = [
-      "./assets/xamarin-selector",
-      "./scripts/tests",
-      "./scripts/docs-gen",
-      "./scripts/helpers"
-    ]
+    destination = "${local.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
   }
+
   provisioner "file" {
-    destination = "image-generation/docs-gen/"
-    source = "../../helpers/software-report-base"
+    destination = "${local.image_folder}/add-certificate.swift"
+    source      = "${path.root}/../add-certificate.swift"
   }
+
   provisioner "file" {
-    destination = "image-generation/add-certificate.swift"
-    source = "./assets/add-certificate.swift"
+    destination = "~/.bashrc"
+    source      = "${path.root}/../assets/bashrc"
   }
+
   provisioner "file" {
-    destination = ".bashrc"
-    source = "./assets/bashrc"
+    destination = "~/.bash_profile"
+    source      = "${path.root}/../assets/bashprofile"
   }
-  provisioner "file" {
-    destination = ".bash_profile"
-    source = "./assets/bashprofile"
-  }
+
   provisioner "shell" {
-    inline = [
-      "mkdir ~/bootstrap"
-    ]
+    inline = ["mkdir ~/bootstrap"]
   }
+
   provisioner "file" {
-    destination = "bootstrap"
-    source = "./assets/bootstrap-provisioner/"
+    destination = "~/bootstrap"
+    source      = "${path.root}/../assets/bootstrap-provisioner/"
   }
+
   provisioner "file" {
-    destination = "image-generation/toolset.json"
-    source = "./toolsets/toolset-14.json"
+    destination = "${local.image_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-14.json"
   }
+
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = [
-      "mv ~/image-generation/docs-gen ~/image-generation/software-report",
-      "mv ~/image-generation/xamarin-selector ~/image-generation/assets",
+      "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
+      "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ~/image-generation/helpers/confirm-identified-developers.scpt ~/utils",
-      "mv ~/image-generation/helpers/invoke-tests.sh ~/utils",
-      "mv ~/image-generation/helpers/utils.sh ~/utils",
-      "mv ~/image-generation/helpers/xamarin-utils.sh ~/utils"
+      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
+      "mv ${local.image_folder}/helpers/utils.sh ~/utils",
+      "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"
     ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-xcode-clt.sh",
-      "./scripts/build/install-homebrew.sh",
-      "./scripts/build/install-rosetta.sh"
-    ]
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = [
+      "${path.root}/../scripts/build/install-xcode-clt.sh",
+      "${path.root}/../scripts/build/install-homebrew.sh",
+      "${path.root}/../scripts/build/install-rosetta.sh"
+    ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-tccdb-macos.sh",
-      "./scripts/build/configure-auto-updates.sh",
-      "./scripts/build/configure-ntpconf.sh",
-      "./scripts/build/configure-shell.sh"
+    environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-auto-updates.sh",
+      "${path.root}/../scripts/build/configure-ntpconf.sh",
+      "${path.root}/../scripts/build/configure-shell.sh"
     ]
-    environment_vars = [
-      "PASSWORD=${var.vm_password}",
-      "USERNAME=${var.vm_username}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-preimagedata.sh",
-      "./scripts/build/configure-ssh.sh",
-      "./scripts/build/configure-machine.sh"
+    environment_vars = ["IMAGE_VERSION=${var.build_id}", "IMAGE_OS=${var.image_os}", "PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-preimagedata.sh",
+      "${path.root}/../scripts/build/configure-ssh.sh",
+      "${path.root}/../scripts/build/configure-machine.sh"
     ]
-    environment_vars = [
-      "IMAGE_VERSION=${var.build_id}",
-      "IMAGE_OS=${var.image_os}",
-      "PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    pause_before = "30s"
-    scripts = [
-      "./scripts/build/configure-windows.sh",
-      "./scripts/build/install-powershell.sh",
-      "./scripts/build/install-mono.sh",
-      "./scripts/build/install-dotnet.sh",
-      "./scripts/build/install-azcopy.sh",
-      "./scripts/build/install-openssl.sh",
-      "./scripts/build/install-ruby.sh",
-      "./scripts/build/install-rubygems.sh",
-      "./scripts/build/install-git.sh",
-      "./scripts/build/install-node.sh",
-      "./scripts/build/install-common-utils.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
+    scripts          = [
+      "${path.root}/../scripts/build/configure-windows.sh",
+      "${path.root}/../scripts/build/install-powershell.sh",
+      "${path.root}/../scripts/build/install-mono.sh",
+      "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-openssl.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rubygems.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-node.sh",
+      "${path.root}/../scripts/build/install-common-utils.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}",
-      "USER_PASSWORD=${var.vm_password}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    script = "./scripts/build/Install-Xcode.ps1"
-    environment_vars = [
-      "XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}",
-      "XCODE_INSTALL_SAS=${var.xcode_install_sas}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
+    script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
+
   provisioner "shell" {
     execute_command   = "source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "shutdown -r now"]
   }
+
   provisioner "shell" {
-    scripts = [
-      "./scripts/build/install-actions-cache.sh",
-      "./scripts/build/install-llvm.sh",
-      "./scripts/build/install-openjdk.sh",
-      "./scripts/build/install-aws-tools.sh",
-      "./scripts/build/install-rust.sh",
-      "./scripts/build/install-gcc.sh",
-      "./scripts/build/install-cocoapods.sh",
-      "./scripts/build/install-android-sdk.sh",
-      "./scripts/build/install-safari.sh",
-      "./scripts/build/install-chrome.sh",
-      "./scripts/build/install-bicep.sh",
-      "./scripts/build/install-codeql-bundle.sh"
+    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts          = [
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-llvm.sh",
+      "${path.root}/../scripts/build/install-openjdk.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-gcc.sh",
+      "${path.root}/../scripts/build/install-cocoapods.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-safari.sh",
+      "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
-    environment_vars = [
-      "API_PAT=${var.github_api_pat}"
-    ]
-    execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
   }
+
   provisioner "shell" {
-    script = "./scripts/build/configure-xcode-simulators.rb"
     execute_command = "source $HOME/.bash_profile; ruby {{ .Path }}"
+    script          = "${path.root}/../scripts/build/configure-xcode-simulators.rb"
   }
+
   provisioner "shell" {
-    inline = [
-      "pwsh -File \"$HOME/image-generation/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"$HOME/image-generation/output/software-report\" -ImageName ${var.build_id}"
-    ]
     execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-  }
-  provisioner "file" {
-    destination = "../image-output/"
-    direction = "download"
-    source = "./image-generation/output/"
-  }
-  provisioner "shell" {
-    scripts = [
-      "./scripts/build/configure-hostname.sh"
+    inline          = [
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}"
     ]
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../../image-output/"
+    direction   = "download"
+    source      = "${local.image_folder}/output/"
+  }
+
+  provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    scripts         = ["${path.root}/../scripts/build/configure-hostname.sh"]
   }
 }

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -174,7 +174,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "USER_PASSWORD=${var.vm_password}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
@@ -193,7 +193,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}"]
+    environment_vars = ["XCODE_INSTALL_STORAGE_URL=${var.xcode_install_storage_url}", "XCODE_INSTALL_SAS=${var.xcode_install_sas}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} pwsh -f {{ .Path }}"
     script           = "${path.root}/../scripts/build/Install-Xcode.ps1"
   }
@@ -205,7 +205,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars = ["API_PAT=${var.github_api_pat}"]
+    environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
@@ -229,8 +229,9 @@ build {
   }
 
   provisioner "shell" {
-    execute_command = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    inline          = [
+    environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
+    execute_command  = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    inline           = [
       "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}"
     ]
   }


### PR DESCRIPTION
# Description
This PR applies various path related changes to packer templates for MacOS builds:
1) Adds `image_folder` local
2) Adds `path.root` packer variable usage
3) Removes static path definition in `Get-ToolsetContent` and `get_toolset_value` by adding `IMAGE_FOLDER` environment variable
4) Minor HCL code style changes for better readability

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
