### PR TITLE
Cleanup json formatted packer template references

### DIFF
--- a/helpers/CreateAzureVMFromPackerTemplate.ps1
+++ b/helpers/CreateAzureVMFromPackerTemplate.ps1
@@ -28,7 +28,7 @@ Function CreateAzureVMFromPackerTemplate {
             The location where the Azure virtual machine will be provisioned. Example: "eastus"
 
         .EXAMPLE
-            CreateAzureVMFromPackerTemplate -SubscriptionId {YourSubscriptionId} -ResourceGroupName {ResourceGroupName} -TemplateFile "C:\BuildVmImages\temporaryTemplate.json" -VirtualMachineName "testvm1" -AdminUsername "shady1" -AdminPassword "SomeSecurePassword1" -AzureLocation "eastus"
+            CreateAzureVMFromPackerTemplate -SubscriptionId {SubscriptionId} -ResourceGroupName {ResourceGroupName} -VirtualMachineName "testvm1" -ManagedImageName {ManagedImageName} -AdminUsername "shady1" -AdminPassword "SomeSecurePassword1" -AzureLocation "eastus"
     #>
     param (
         [Parameter(Mandatory = $True)]

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -176,30 +176,20 @@ Function GenerateResourcesAndImage {
         }
 
         Write-Host "Access to packer generated VM will be restricted to agent IP Address: $AgentIp."
-        if ($TemplatePath.Contains("pkr.hcl")) {
-            if ($PSVersionTable.PSVersion.Major -eq 5) {
-                Write-Verbose "PowerShell 5 detected. Replacing double quotes with escaped double quotes in allowed inbound IP addresses."
-                $AllowedInboundIpAddresses = '[\"{0}\"]' -f $AgentIp
-            }
-            elseif ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -le 2) {
-                Write-Verbose "PowerShell 7.0-7.2 detected. Replacing double quotes with escaped double quotes in allowed inbound IP addresses."
-                $AllowedInboundIpAddresses = '[\"{0}\"]' -f $AgentIp
-            }
-            else {
-                $AllowedInboundIpAddresses = '["{0}"]' -f $AgentIp
-            }
+        if ($PSVersionTable.PSVersion.Major -eq 5) {
+            Write-Verbose "PowerShell 5 detected. Replacing double quotes with escaped double quotes in allowed inbound IP addresses."
+            $AllowedInboundIpAddresses = '[\"{0}\"]' -f $AgentIp
+        }
+        elseif ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -le 2) {
+            Write-Verbose "PowerShell 7.0-7.2 detected. Replacing double quotes with escaped double quotes in allowed inbound IP addresses."
+            $AllowedInboundIpAddresses = '[\"{0}\"]' -f $AgentIp
         }
         else {
-            $AllowedInboundIpAddresses = $AgentIp
+            $AllowedInboundIpAddresses = '["{0}"]' -f $AgentIp
         }
     }
     else {
-        if ($TemplatePath.Contains("pkr.hcl")) {
-            $AllowedInboundIpAddresses = "[]"
-        }
-        else {
-            $AllowedInboundIpAddresses = ""
-        }
+        $AllowedInboundIpAddresses = "[]"
     }
     Write-Debug "Allowed inbound IP addresses: $AllowedInboundIpAddresses."
 
@@ -216,16 +206,6 @@ Function GenerateResourcesAndImage {
         $TagsJson = $TagsJson -replace '"', '\"'
     }
     Write-Debug "Tags JSON: $TagsJson."
-    if ($TemplatePath.Contains(".json")) {
-        Write-Verbose "Injecting tags into packer template."
-        if ($Tags) {
-            $BuilderScriptPathInjected = $TemplatePath.Replace(".json", "-temp.json")
-            $PackerTemplateContent = Get-Content -Path $TemplatePath | ConvertFrom-Json
-            $PackerTemplateContent.builders | Add-Member -Name "azure_tags" -Value $Tags -MemberType NoteProperty
-            $PackerTemplateContent | ConvertTo-Json -Depth 3 | Out-File -Encoding Ascii $BuilderScriptPathInjected
-            $TemplatePath = $BuilderScriptPathInjected
-        }
-    }
 
     $InstallPassword = $env:UserName + [System.GUID]::NewGuid().ToString().ToUpper()
 

--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -69,14 +69,7 @@ jobs:
         $TemplateDirectoryPath = Join-Path "images" $TemplateDirectoryName | Resolve-Path
 
         $TemplateFileName = "${{ parameters.image_template_name }}"
-        if ($TemplateFileName) {
-          $TemplatePath = Join-Path $TemplateDirectoryPath $TemplateFileName
-        } else {
-          $TemplatePath = Join-Path $TemplateDirectoryPath "$ImageType.pkr.hcl"
-          if ( -not (Test-Path $TemplatePath) ) {
-              $TemplatePath = Join-Path $TemplateDirectoryPath "$ImageType.json"
-          }
-        }
+        $TemplatePath = Join-Path $TemplateDirectoryPath $TemplateFileName
         Write-Host "##vso[task.setvariable variable=TemplateDirectoryPath;]$TemplateDirectoryPath"
         Write-Host "##vso[task.setvariable variable=TemplatePath;]$TemplatePath"
 


### PR DESCRIPTION
# Description
This PR cleans up `json` formatted packer template references and code blocks, since all template files were converted `.hcl`

#### Related issue: https://github.com/actions/runner-images-internal/issues/5654

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
