### PR TITLE
[macos] Fix links in preimage data

### DIFF
--- a/images/macos/scripts/build/configure-preimagedata.sh
+++ b/images/macos/scripts/build/configure-preimagedata.sh
@@ -21,7 +21,7 @@ else
 fi
 release_label="macOS-${label_version}"
 
-if is_VenturaX64 || is_SonomaX64; then
+if is_Ventura || is_Sonoma; then
   software_url="https://github.com/actions/runner-images/blob/${image_label}/${image_version}/images/macos/${image_label}-Readme.md"
   releaseUrl="https://github.com/actions/runner-images/releases/tag/${image_label}%2F${image_version}"
 else


### PR DESCRIPTION
# Description
This PR fixes installed software and release related links in preimage data for arm64 images.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
