### PR TITLE
[Ubuntu] Pin Docker 24.0.7 to avoid bugs

### DIFF
--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -17,15 +17,16 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o $GPG_
 echo "deb [arch=amd64 signed-by=$GPG_KEY] $REPO_URL ${os_codename} stable" > $REPO_PATH
 apt-get update
 
-for pkg in docker-ce docker-ce-cli containerd.io docker-buildx-plugin; do
+for pkg in containerd.io docker-ce-cli docker-ce docker-buildx-plugin; do
     version=$(get_toolset_value ".docker.components.\"$pkg\"")
     if [[ $version == "latest" ]]; then
-        apt-get install -y --no-install-recommends "${pkg}"
+        components_to_install+="${pkg} "
     else
         version_string=$(apt-cache madison "${pkg}" | awk '{ print $3 }' | grep "${version}" | grep "${os_codename}" | head -1)
-        apt-get install -y --no-install-recommends "${pkg}=${version_string}"
+        components_to_install+="${pkg}=${version_string} "
     fi
 done
+apt-get install -y --no-install-recommends $components_to_install
 
 # Download docker compose v2 from releases
 # Temporaty pinned to v2.23.3 due https://github.com/actions/runner-images/issues/9172

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -11,18 +11,30 @@ source $HELPER_SCRIPTS/install.sh
 REPO_URL="https://download.docker.com/linux/ubuntu"
 GPG_KEY="/usr/share/keyrings/docker.gpg"
 REPO_PATH="/etc/apt/sources.list.d/docker.list"
+os_codename=$(lsb_release -cs)
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o $GPG_KEY
-echo "deb [arch=amd64 signed-by=$GPG_KEY] $REPO_URL $(lsb_release -cs) stable" > $REPO_PATH
+echo "deb [arch=amd64 signed-by=$GPG_KEY] $REPO_URL ${os_codename} stable" > $REPO_PATH
 apt-get update
-apt-get install --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+
+for pkg in docker-ce docker-ce-cli containerd.io docker-buildx-plugin; do
+    version=$(get_toolset_value ".docker.components.${pkg}")
+    if [[ $version == "latest" ]]; then
+        apt-get install -y --no-install-recommends "${pkg}"
+    else
+        version_string=$(apt-cache madison "${pkg}" | awk '{ print $3 }' | grep "${version}" | grep "${os_codename}" | head -1)
+        apt-get install -y --no-install-recommends "${pkg}=${version_string}"
+    fi
+done
+
 # Download docker compose v2 from releases
 # Temporaty pinned to v2.23.3 due https://github.com/actions/runner-images/issues/9172
-URL=$(resolve_github_release_asset_url "docker/compose" "endswith(\"compose-linux-x86_64\")" "2.23.3")
+compose_version=$(get_toolset_value ".docker.components.compose")
+URL=$(resolve_github_release_asset_url "docker/compose" "endswith(\"compose-linux-x86_64\")" "${compose_version}")
 compose_binary_path=$(download_with_retry "${URL}" "/tmp/docker-compose-v2")
 
 # Supply chain security - Docker Compose v2
-compose_hash_url=$(resolve_github_release_asset_url "docker/compose" "endswith(\"checksums.txt\")" "2.23.3")
+compose_hash_url=$(resolve_github_release_asset_url "docker/compose" "endswith(\"checksums.txt\")" "${compose_version}")
 compose_external_hash=$(get_checksum_from_url "${compose_hash_url}" "compose-linux-x86_64" "SHA256")
 use_checksum_comparison "${compose_binary_path}" "${compose_external_hash}"
 

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -18,7 +18,7 @@ echo "deb [arch=amd64 signed-by=$GPG_KEY] $REPO_URL ${os_codename} stable" > $RE
 apt-get update
 
 for pkg in docker-ce docker-ce-cli containerd.io docker-buildx-plugin; do
-    version=$(get_toolset_value ".docker.components.${pkg}")
+    version=$(get_toolset_value ".docker.components.\"$pkg\"")
     if [[ $version == "latest" ]]; then
         apt-get install -y --no-install-recommends "${pkg}"
     else

--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -236,7 +236,14 @@
             "node:18-alpine",
             "node:20-alpine",
             "ubuntu:20.04"
-        ]
+        ],
+        "components": {
+            "docker-ce": "24.0.7",
+            "docker-ce-cli": "24.0.7",
+            "containerd.io": "latest",
+            "docker-buildx-plugin": "latest",
+            "compose": "2.23.3"
+        }
     },
     "pipx": [
         {

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -227,7 +227,14 @@
             "node:20-alpine",
             "ubuntu:20.04",
             "ubuntu:22.04"
-        ]
+        ],
+        "components": {
+            "docker-ce": "24.0.7",
+            "docker-ce-cli": "24.0.7",
+            "containerd.io": "latest",
+            "docker-buildx-plugin": "latest",
+            "compose": "2.23.3"
+        }
     },
     "pipx": [
         {


### PR DESCRIPTION
# Description

There are number of bugs provided in Moby repo for the Docker v25. Let's avoid install it until patch is ready.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
