### PR TITLE
[Windows] Pin Docker 24.0.7 to avoid bugs

### DIFF
--- a/images/windows/scripts/build/Install-Docker.ps1
+++ b/images/windows/scripts/build/Install-Docker.ps1
@@ -6,7 +6,7 @@
 ################################################################################
 
 Write-Host "Get latest Moby release"
-$toolsetVersion = Get-ToolsetContent.docker.components.docker-ce
+$toolsetVersion = (Get-ToolsetContent).docker.components.docker
 $mobyVersion = (Get-GithubReleasesByVersion -Repo "moby/moby" -Version "${toolsetVersion}").version
 $dockerceUrl = "https://download.docker.com/win/static/stable/x86_64/"
 $dockerceBinaries = Invoke-WebRequest -Uri $dockerceUrl -UseBasicParsing

--- a/images/windows/scripts/build/Install-Docker.ps1
+++ b/images/windows/scripts/build/Install-Docker.ps1
@@ -6,13 +6,13 @@
 ################################################################################
 
 Write-Host "Get latest Moby release"
-$mobyLatestVersion = (Get-GithubReleasesByVersion -Repo "moby/moby" -Version "latest").version
-
+$toolsetVersion = Get-ToolsetContent.docker.components.docker-ce
+$mobyVersion = (Get-GithubReleasesByVersion -Repo "moby/moby" -Version "${toolsetVersion}").version
 $dockerceUrl = "https://download.docker.com/win/static/stable/x86_64/"
 $dockerceBinaries = Invoke-WebRequest -Uri $dockerceUrl -UseBasicParsing
 
-Write-Host "Check Moby version $mobyLatestVersion"
-$mobyRelease = $dockerceBinaries.Links.href -match "${mobyLatestVersion}\.zip" | Select-Object -Last 1
+Write-Host "Check Moby version $mobyVersion"
+$mobyRelease = $dockerceBinaries.Links.href -match "${mobyVersion}\.zip" | Select-Object -Last 1
 if (-not $mobyRelease) {
     Write-Host "Release not found for $mobyLatestRelease version"
     $versions = [regex]::Matches($dockerceBinaries.Links.href, "docker-(\d+\.\d+\.\d+)\.zip") | Sort-Object { [version] $_.Groups[1].Value }

--- a/images/windows/scripts/build/Install-DockerCompose.ps1
+++ b/images/windows/scripts/build/Install-DockerCompose.ps1
@@ -10,9 +10,9 @@ Install-ChocoPackage docker-compose -ArgumentList "--version=$versionToInstall"
 
 Write-Host "Install-Package Docker-Compose v2"
 # Temporaty pinned to v2.23.3 due https://github.com/actions/runner-images/issues/9172
-$toolsetVersion = Get-ToolsetContent.docker.components.compose
+$toolsetVersion = (Get-ToolsetContent).docker.components.compose
 $composeVersion = (Get-GithubReleasesByVersion -Repo "docker/compose" -Version "${toolsetVersion}").version
-$dockerComposev2Url = "https://github.com/docker/compose/releases/download/v${version}/docker-compose-windows-x86_64.exe"
+$dockerComposev2Url = "https://github.com/docker/compose/releases/download/v${composeVersion}/docker-compose-windows-x86_64.exe"
 $cliPluginsDir = "C:\ProgramData\docker\cli-plugins"
 New-Item -Path $cliPluginsDir -ItemType Directory
 Invoke-DownloadWithRetry -Url $dockerComposev2Url -Path "$cliPluginsDir\docker-compose.exe"

--- a/images/windows/scripts/build/Install-DockerCompose.ps1
+++ b/images/windows/scripts/build/Install-DockerCompose.ps1
@@ -10,7 +10,9 @@ Install-ChocoPackage docker-compose -ArgumentList "--version=$versionToInstall"
 
 Write-Host "Install-Package Docker-Compose v2"
 # Temporaty pinned to v2.23.3 due https://github.com/actions/runner-images/issues/9172
-$dockerComposev2Url = "https://github.com/docker/compose/releases/download/v2.23.3/docker-compose-windows-x86_64.exe"
+$toolsetVersion = Get-ToolsetContent.docker.components.compose
+$composeVersion = (Get-GithubReleasesByVersion -Repo "docker/compose" -Version "${toolsetVersion}").version
+$dockerComposev2Url = "https://github.com/docker/compose/releases/download/v${version}/docker-compose-windows-x86_64.exe"
 $cliPluginsDir = "C:\ProgramData\docker\cli-plugins"
 New-Item -Path $cliPluginsDir -ItemType Directory
 Invoke-DownloadWithRetry -Url $dockerComposev2Url -Path "$cliPluginsDir\docker-compose.exe"

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -383,7 +383,11 @@
             "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019",
             "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019",
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
-        ]
+        ],
+        "components": {
+            "docker-ce": "24.0.7",
+            "compose": "2.23.3"
+        }   
     },
     "pipx": [
         {

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -385,7 +385,7 @@
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
         ],
         "components": {
-            "docker-ce": "24.0.7",
+            "docker": "24.0.7",
             "compose": "2.23.3"
         }   
     },

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -330,7 +330,11 @@
             "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022",
             "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022",
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
-        ]
+        ],
+        "components": {
+            "docker-ce": "24.0.7",
+            "compose": "2.23.3"
+        }
     },
     "pipx": [
         {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -332,7 +332,7 @@
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
         ],
         "components": {
-            "docker-ce": "24.0.7",
+            "docker": "24.0.7",
             "compose": "2.23.3"
         }
     },


### PR DESCRIPTION
# Description
There are number of bugs provided in Moby repo for the Docker v25. Let's avoid install it until patch is ready.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
