### PR TITLE
[macos11] Remove imagemagick package

### DIFF
--- a/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -128,7 +128,7 @@ $utilities.AddToolVersion("gpg (GnuPG)", $(Get-GPGVersion))
 if ($os.IsBigSur) {
     $utilities.AddToolVersion("helm", $(Get-HelmVersion))
 }
-if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
+if ((-not $os.IsBigSur) -and (-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $utilities.AddToolVersion("ImageMagick", $(Get-ImageMagickVersion))
 }
 $utilities.AddToolVersion("jq", $(Get-JqVersion))

--- a/images/macos/scripts/tests/BasicTools.Tests.ps1
+++ b/images/macos/scripts/tests/BasicTools.Tests.ps1
@@ -191,7 +191,7 @@ Describe "yq" {
     }
 }
 
-Describe "imagemagick" -Skip:($os.IsVentura -or $os.IsSonoma) {
+Describe "imagemagick" -Skip:($os.IsBigSur -or $os.IsVentura -or $os.IsSonoma) {
     It "imagemagick" {
         "magick -version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -219,8 +219,7 @@
             "libxext",
             "libxft",
             "tcl-tk",
-            "r",
-            "imagemagick"
+            "r"
         ],
         "cask_packages": [
             "julia"


### PR DESCRIPTION
# Description
Remove `imagemagick` package from MacOS-11.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
