### PR TITLE
[macos11] Remove php package

### DIFF
--- a/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -53,7 +53,7 @@ if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
     $languageAndRuntime.AddToolVersionsListInline("NVM - Cached node versions", $(Get-NVMNodeVersionList), '^\d+')
 }
 $languageAndRuntime.AddToolVersion("Perl", $(Get-PerlVersion))
-if ((-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
+if ((-not $os.IsBigSur) -and (-not $os.IsVenturaArm64) -and (-not $os.IsSonomaArm64)) {
     $languageAndRuntime.AddToolVersion("PHP", $(Get-PHPVersion))
 }
 

--- a/images/macos/scripts/tests/PHP.Tests.ps1
+++ b/images/macos/scripts/tests/PHP.Tests.ps1
@@ -3,7 +3,7 @@ Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
 $os = Get-OSVersion
 
 Describe "PHP" {
-    Context "PHP" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
+    Context "PHP" -Skip:($os.IsBigSur -or $os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         It "PHP Path" {
             Get-ToolPath "php" | Should -Not -BeLike "/usr/bin/php*"
         }
@@ -14,7 +14,7 @@ Describe "PHP" {
         }
     }
 
-    Context "Composer" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64) {
+    Context "Composer" -Skip:($os.IsBigSur -or $os.IsVenturaArm64 -or $os.IsSonomaArm64) {
         It "Composer" {
             "composer --version" | Should -ReturnZeroExitCode
         }

--- a/images/macos/templates/macOS-11.pkr.hcl
+++ b/images/macos/templates/macOS-11.pkr.hcl
@@ -244,7 +244,6 @@ build {
       "${path.root}/../scripts/build/install-golang.sh",
       "${path.root}/../scripts/build/install-swiftlint.sh",
       "${path.root}/../scripts/build/install-openjdk.sh",
-      "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-aws-tools.sh",
       "${path.root}/../scripts/build/install-rust.sh",
       "${path.root}/../scripts/build/install-gcc.sh",

--- a/images/macos/toolsets/toolset-11.json
+++ b/images/macos/toolsets/toolset-11.json
@@ -352,9 +352,6 @@
     "llvm": {
         "version": "15"
     },
-    "php": {
-        "version": "8.3"
-    },
     "mongodb": {
         "version": "5.0"
     },


### PR DESCRIPTION
# Description
Remove `php` package from MacOS-11.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
