### PR TITLE
[macOS] Install only latest runtime for Xcode - compatibility  bug

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -4,9 +4,9 @@
         "x64": {
             "versions": [
                 { "link": "15.3", "version": "15.3.0-Beta+15E5178i", "install_runtimes": "true", "sha256": "CE08F7B13B072AE901C3D455C02BF374FA47F678A85B180532C5D80EC4B619C0"},
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "true", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "true", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "false", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "false", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "false", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "true", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
                 { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "true", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
                 { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "true", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
@@ -16,9 +16,9 @@
         "arm64":{
             "versions": [
                 { "link": "15.3", "version": "15.3.0-Beta+15E5178i", "install_runtimes": "true", "sha256": "CE08F7B13B072AE901C3D455C02BF374FA47F678A85B180532C5D80EC4B619C0"},
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "true", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "true", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "false", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "false", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "false", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
                 { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "true", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
                 { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "true", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
                 { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "true", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}


### PR DESCRIPTION
# Description
On the latest builds of `macOS-13` images, strange behaviour is observed in the installed simulators. The behaviour exists only for `Xcode 15`. If you set more than one runtime, the simulators are duplicated, which leads to errors in the future. As a possible workaround, you can only install the latest available runtime for `Xcode 15`. Users will need to download/install previous versions at runtime.

UPD: Also possible to install any other of runtimes, for `Xcode 15.0` for example.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
