### PR TITLE
Ubuntu 22.04 update libssl version in install-sqlpackage.sh

### DIFF
--- a/images/ubuntu/scripts/build/install-sqlpackage.sh
+++ b/images/ubuntu/scripts/build/install-sqlpackage.sh
@@ -10,8 +10,8 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install libssl1.1 dependency
 if is_ubuntu22; then
-    libssl_deb_path=$(download_with_retry "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb")
-    libssl_hash="0b3251aee55db6e20d02f4b9a2b703c9874a85ab6a20b12f4870f52f91633d37"
+    libssl_deb_path=$(download_with_retry "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb")
+    libssl_hash="97d7f8cb9ddc7f06b23dce73a25b75e5c02ec18112c4a8e5da53624d1fd718a2"
     use_checksum_comparison "$libssl_deb_path" "$libssl_hash"
 
     dpkg -i "$libssl_deb_path"


### PR DESCRIPTION
# Description
Bug fixing
The version of libssl used by ubuntu 22.04 in the script is no longer available. This change updates the version number and hash to the latest available

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
