### PR TITLE
Pin syft for SBOM report to v0.100.0

### DIFF
--- a/.github/workflows/create_sbom_report.yml
+++ b/.github/workflows/create_sbom_report.yml
@@ -55,10 +55,10 @@ jobs:
           }
       - name: Install SYFT tool on Windows
         if: ${{ runner.os == 'Windows' }}
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b D:/syft
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b D:/syft v0.100.0
       - name: Install SYFT tool on Ubuntu or macOS
         if: ${{ runner.os != 'Windows' }}
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v0.100.0
       #Running section.
       - name: Run SYFT on Windows
         if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
# Description
This PR pins `syft` used for SBOM generation to `v0.100.0` since latest version of `syft` is pushing workflow run times above 6h.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
