### PR TITLE
[ubuntu] Remove quoted PATH from /etc/environment

### DIFF
--- a/images/ubuntu/scripts/build/configure-system.sh
+++ b/images/ubuntu/scripts/build/configure-system.sh
@@ -20,7 +20,7 @@ chmod 755 $IMAGE_FOLDER
 ENVPATH=$(grep 'PATH=' /etc/environment | head -n 1 | sed -z 's/^PATH=*//')
 ENVPATH=${ENVPATH#"\""}
 ENVPATH=${ENVPATH%"\""}
-add_etc_environment_variable "PATH" "${ENVPATH}"
+replace_etc_environment_variable "PATH" "${ENVPATH}"
 echo "Updated /etc/environment: $(cat /etc/environment)"
 
 # Сlean yarn and npm cache

--- a/images/ubuntu/scripts/helpers/etc-environment.sh
+++ b/images/ubuntu/scripts/helpers/etc-environment.sh
@@ -27,7 +27,7 @@ replace_etc_environment_variable() {
     local variable_value=$2
 
     # modify /etc/environemnt in place by replacing a string that begins with variable_name
-    sudo sed -i -e "s%^${variable_name}=.*$%${variable_name}=\"${variable_value}\"%" /etc/environment
+    sudo sed -i -e "s%^${variable_name}=.*$%${variable_name}=${variable_value}%" /etc/environment
 }
 
 set_etc_environment_variable() {


### PR DESCRIPTION
# Description
This PR:
1) Replaces quoted `PATH` variable value in `/etc/environment` with its unquoted value, thus removing the duplicate
2) Removes quotes addition from `replace_etc_environment_variable` helper function

#### Related issue: https://github.com/actions/runner-images/issues/9307

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
