### PR TITLE
[macOS] Add libsodium to the macOS-14

### DIFF
--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -65,6 +65,7 @@
             "gnu-tar",
             "kotlin",
             "libpq",
+            "libsodium",
             "p7zip",
             "packer",
             "perl",


### PR DESCRIPTION
# Description
Add libsodium to the macOS-14

#### Related issue:
https://github.com/actions/runner-images/issues/9341

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
