### PR TITLE
[Ubuntu] update docker version

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -245,11 +245,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.7"
+                "version": "24.0.8"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.7"
+                "version": "24.0.8"
             }
         ],
         "plugins": [
@@ -257,7 +257,7 @@
                 "plugin": "buildx",
                 "version": "latest",
                 "asset": "linux-amd64"
-            },            
+            },
             {
                 "plugin": "compose",
                 "version": "2.23.3",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -236,11 +236,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.7"
+                "version": "24.0.8"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.7"
+                "version": "24.0.8"
             }
         ],
         "plugins": [


### PR DESCRIPTION
# Description
 Update docker patch version from 24.0.7 to 24.0.8

#### Related issue:
https://github.com/actions/runner-images/issues/9349

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
