### PR TITLE
[Windows] Update downloadsPageUrl for mysql

### DIFF
--- a/images/windows/scripts/build/Install-MysqlCli.ps1
+++ b/images/windows/scripts/build/Install-MysqlCli.ps1
@@ -15,7 +15,11 @@ Install-Binary `
 $mysqlVersionMajorMinor = $mysqlVersion.ToString(2)
 
 if ($mysqlVersion.Build -lt 0) {
-    $downloadsPageUrl = "https://dev.mysql.com/downloads/mysql/${mysqlVersionMajorMinor}.html"
+    if ($mysqlVersionMajorMinor -eq "5.7") {
+        $downloadsPageUrl = "https://downloads.mysql.com/archives/community/"
+    } else {
+        $downloadsPageUrl = "https://dev.mysql.com/downloads/mysql/${mysqlVersionMajorMinor}.html"
+    }
     $mysqlVersion = Invoke-RestMethod -Uri $downloadsPageUrl -Headers @{ 'User-Agent' = 'curl/8.4.0' } `
     | Select-String -Pattern "${mysqlVersionMajorMinor}\.\d+" `
     | ForEach-Object { $_.Matches.Value }


### PR DESCRIPTION
# Description
MySQL 5.7.44 is the final release of the MySQL 5.7 series. 
This packet was removed from the download page - https://dev.mysql.com/downloads/mysql/5.7.html.
Now it is located in the archive page - https://downloads.mysql.com/archives/community/

#### Related issue:
https://github.com/actions/runner-images-internal/issues/5820

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
