### PR TITLE
[Windows] Add WLAN AutoConfig service

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -260,7 +260,8 @@
         { "name": "FS-iSCSITarget-Server", "includeAllSubFeatures": true, "includeManagementTools": true },
         { "name": "Containers" },
         { "name": "Microsoft-Windows-Subsystem-Linux", "optionalFeature": true },
-        { "name": "VirtualMachinePlatform", "optionalFeature": true }
+        { "name": "VirtualMachinePlatform", "optionalFeature": true },
+        { "name": "Wireless-Networking" }
     ],
     "visualStudio": {
         "version" : "2019",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -170,7 +170,8 @@
         { "name": "NET-Framework-Features", "includeAllSubFeatures": true },
         { "name": "Hyper-V", "includeAllSubFeatures": true },
         { "name": "HypervisorPlatform", "optionalFeature": true },
-        { "name": "Hyper-V-PowerShell" }
+        { "name": "Hyper-V-PowerShell" },
+        { "name": "Wireless-Networking" }
     ],
     "visualStudio": {
         "version" : "2022",


### PR DESCRIPTION
# Description
This PR added the WLAN AutoConfig service for Windows Server OS to toolset.json. If an application needs the service, we just start the service

#### Related issue:
Add WLAN AutoConfig service for Windows image #9305

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
