### PR TITLE
[Ubuntu] update docker components to be >=24.0.9

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -245,11 +245,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.8"
+                "version": "24.0.9"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.8"
+                "version": "24.0.9"
             }
         ],
         "plugins": [

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -236,11 +236,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.8"
+                "version": "24.0.9"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.8"
+                "version": "24.0.9"
             }
         ],
         "plugins": [


### PR DESCRIPTION
# Description

The actual fix is in that patch version

#### Related issue: https://github.com/actions/runner-images/issues/9349

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
