### PR TITLE
Support null builder for MacOS templates

### DIFF
--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -11,12 +11,27 @@ locals {
   image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
+variable "builder_type" {
+  type = string
+  default = "veertu-anka-vm-clone"
+  validation {
+    condition = contains(["veertu-anka-vm-clone", "null"], var.builder_type)
+    error_message = "The builder_type value must be one of [veertu-anka-vm-clone, null]."
+  }
+}
+
 variable "source_vm_name" {
   type = string
 }
 
 variable "source_vm_tag" {
   type = string
+  default = ""
+}
+
+variable "socks_proxy" {
+  type = string
+  default = ""
 }
 
 variable "build_id" {
@@ -72,8 +87,15 @@ source "veertu-anka-vm-clone" "template" {
   stop_vm        = "true"
 }
 
+source "null" "template" {
+  ssh_host = "${var.source_vm_name}"
+  ssh_username = "${var.vm_username}"
+  ssh_password = "${var.vm_password}"
+  ssh_proxy_host = "${var.socks_proxy}"
+}
+
 build {
-  sources = ["source.veertu-anka-vm-clone.template"]
+  sources = ["source.${var.builder_type}.template"]
 
   provisioner "shell" {
     inline = ["mkdir ${local.image_folder}"]

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -11,12 +11,27 @@ locals {
   image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
+variable "builder_type" {
+  type = string
+  default = "veertu-anka-vm-clone"
+  validation {
+    condition = contains(["veertu-anka-vm-clone", "null"], var.builder_type)
+    error_message = "The builder_type value must be one of [veertu-anka-vm-clone, null]."
+  }
+}
+
 variable "source_vm_name" {
   type = string
 }
 
 variable "source_vm_tag" {
   type = string
+  default = ""
+}
+
+variable "socks_proxy" {
+  type = string
+  default = ""
 }
 
 variable "build_id" {
@@ -72,8 +87,15 @@ source "veertu-anka-vm-clone" "template" {
   stop_vm        = "true"
 }
 
+source "null" "template" {
+  ssh_host = "${var.source_vm_name}"
+  ssh_username = "${var.vm_username}"
+  ssh_password = "${var.vm_password}"
+  ssh_proxy_host = "${var.socks_proxy}"
+}
+
 build {
-  sources = ["source.veertu-anka-vm-clone.template"]
+  sources = ["source.${var.builder_type}.template"]
 
   provisioner "shell" {
     inline = ["mkdir ${local.image_folder}"]

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -11,12 +11,27 @@ locals {
   image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
+variable "builder_type" {
+  type = string
+  default = "veertu-anka-vm-clone"
+  validation {
+    condition = contains(["veertu-anka-vm-clone", "null"], var.builder_type)
+    error_message = "The builder_type value must be one of [veertu-anka-vm-clone, null]."
+  }
+}
+
 variable "source_vm_name" {
   type = string
 }
 
 variable "source_vm_tag" {
   type = string
+  default = ""
+}
+
+variable "socks_proxy" {
+  type = string
+  default = ""
 }
 
 variable "build_id" {
@@ -73,8 +88,15 @@ source "veertu-anka-vm-clone" "template" {
   log_level      = "debug"
 }
 
+source "null" "template" {
+  ssh_host = "${var.source_vm_name}"
+  ssh_username = "${var.vm_username}"
+  ssh_password = "${var.vm_password}"
+  ssh_proxy_host = "${var.socks_proxy}"
+}
+
 build {
-  sources = ["source.veertu-anka-vm-clone.template"]
+  sources = ["source.${var.builder_type}.template"]
 
   provisioner "shell" {
     inline = ["mkdir ${local.image_folder}"]

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -11,12 +11,27 @@ locals {
   image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
+variable "builder_type" {
+  type = string
+  default = "veertu-anka-vm-clone"
+  validation {
+    condition = contains(["veertu-anka-vm-clone", "null"], var.builder_type)
+    error_message = "The builder_type value must be one of [veertu-anka-vm-clone, null]."
+  }
+}
+
 variable "source_vm_name" {
   type = string
 }
 
 variable "source_vm_tag" {
   type = string
+  default = ""
+}
+
+variable "socks_proxy" {
+  type = string
+  default = ""
 }
 
 variable "build_id" {
@@ -72,8 +87,15 @@ source "veertu-anka-vm-clone" "template" {
   stop_vm        = "true"
 }
 
+source "null" "template" {
+  ssh_host = "${var.source_vm_name}"
+  ssh_username = "${var.vm_username}"
+  ssh_password = "${var.vm_password}"
+  ssh_proxy_host = "${var.socks_proxy}"
+}
+
 build {
-  sources = ["source.veertu-anka-vm-clone.template"]
+  sources = ["source.${var.builder_type}.template"]
 
   provisioner "shell" {
     inline = ["mkdir ${local.image_folder}"]

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -11,12 +11,27 @@ locals {
   image_folder = "/Users/${var.vm_username}/image-generation"
 }
 
+variable "builder_type" {
+  type = string
+  default = "veertu-anka-vm-clone"
+  validation {
+    condition = contains(["veertu-anka-vm-clone", "null"], var.builder_type)
+    error_message = "The builder_type value must be one of [veertu-anka-vm-clone, null]."
+  }
+}
+
 variable "source_vm_name" {
   type = string
 }
 
 variable "source_vm_tag" {
   type = string
+  default = ""
+}
+
+variable "socks_proxy" {
+  type = string
+  default = ""
 }
 
 variable "build_id" {
@@ -73,8 +88,15 @@ source "veertu-anka-vm-clone" "template" {
   log_level      = "debug"
 }
 
+source "null" "template" {
+  ssh_host = "${var.source_vm_name}"
+  ssh_username = "${var.vm_username}"
+  ssh_password = "${var.vm_password}"
+  ssh_proxy_host = "${var.socks_proxy}"
+}
+
 build {
-  sources = ["source.veertu-anka-vm-clone.template"]
+  sources = ["source.${var.builder_type}.template"]
 
   provisioner "shell" {
     inline = ["mkdir ${local.image_folder}"]


### PR DESCRIPTION
# Description

This PR adds ability to run Anka-based MacOS templates using `null` Packer builder. With null builder VM is expected to be pre-created and Packer would only deploy packages to it leaving VM management to the caller.

By default template uses Anka source (as it is today). Passing `-var builder_type=null` to the Packer switches to using null `builder`. VM host/ip and credentials have to be provided as well.

```
packer build \
    -var builder_type=null \
    -var source_vm_name=192.168.1.15 \
    -var vm_username=USERNAME \
    -var vm_password=PASSWORD \
    <rest of arguments>
```

This change also allows running Packer against the localhost, but with one caveat - template will fail once it reaches the reboot step. For the non-localhost scenario reboot is handled properly.


<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
