### PR TITLE
[Windows] Remove Ruby, Go old versions

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -5,13 +5,10 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "2.5",
-                "2.6",
-                "2.7",
                 "3.0",
                 "3.1"
             ],
-            "default": "2.5"
+            "default": "3.0"
         },
         {
             "name": "Python",
@@ -72,12 +69,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.19.*",
                 "1.20.*",
                 "1.21.*",
                 "1.22.*"
             ],
-            "default": "1.20.*"
+            "default": "1.21.*"
         }
     ],
     "powershellModules": [

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -5,7 +5,6 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "2.7",
                 "3.0",
                 "3.1"
             ],
@@ -69,12 +68,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.19.*",
                 "1.20.*",
                 "1.21.*",
                 "1.22.*"
             ],
-            "default": "1.20.*"
+            "default": "1.21.*"
         }
     ],
     "powershellModules": [


### PR DESCRIPTION
# Description
Remove Ruby and Go old versions

#### Related issue:
- https://github.com/actions/runner-images/issues/9326
- https://github.com/actions/runner-images/issues/9327

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
