### PR TITLE
[Windows] Update OpenSSL to 3.2.1

### DIFF
--- a/images/windows/Windows2019-Readme.md
+++ b/images/windows/Windows2019-Readme.md
@@ -78,7 +78,7 @@
 - GNU Binutils 2.30
 - Newman 6.1.1
 - NSIS 3.09
-- OpenSSL 1.1.1w
+- OpenSSL 3.2.1
 - Packer 1.10.0
 - Parcel 2.11.0
 - Pulumi 3.106.0

--- a/images/windows/Windows2022-Readme.md
+++ b/images/windows/Windows2022-Readme.md
@@ -77,7 +77,7 @@
 - GNU Binutils 2.39
 - Newman 6.1.1
 - NSIS 3.09
-- OpenSSL 1.1.1w
+- OpenSSL 3.2.1
 - Packer 1.10.0
 - Pulumi 3.105.0
 - R 4.3.2

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -492,7 +492,7 @@
         "version": "latest"
     },
     "openssl": {
-        "version": "1.1.1"
+        "version": "3.2.1"
     },
     "pwsh": {
         "version": "7.4"

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -434,7 +434,7 @@
         "version": "latest"
     },
     "openssl": {
-        "version": "1.1.1"
+        "version": "3.2.1"
     },
     "pwsh": {
         "version": "7.4"


### PR DESCRIPTION
# Description

The runners currently provide openssl 1.1.1, which went out of support in September 2023. As openssl is security critical, only supported versions should be used. 3.2.1 is the latest version available. The 3.2 release series is supported until November 2025.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
