### PR TITLE
[Ubuntu] 22.04: install libssl1.1 via apt

### DIFF
--- a/images/ubuntu/scripts/build/install-sqlpackage.sh
+++ b/images/ubuntu/scripts/build/install-sqlpackage.sh
@@ -10,11 +10,14 @@ source $HELPER_SCRIPTS/os.sh
 
 # Install libssl1.1 dependency
 if is_ubuntu22; then
-    libssl_deb_path=$(download_with_retry "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb")
-    libssl_hash="df9d07d552aab0c7e5b9fbcc568913acd20d50fb8b1e34876fa348b7a0c82d48"
-    use_checksum_comparison "$libssl_deb_path" "$libssl_hash"
+    focal_list=/etc/apt/sources.list.d/focal-security.list
+    echo "deb http://archive.ubuntu.com/ubuntu/ focal-security main" | tee "${focal_list}"
+    apt-get update --quiet
 
-    dpkg -i "$libssl_deb_path"
+    apt-get install --no-install-recommends --yes libssl1.1
+
+    rm "${focal_list}"
+    apt-get update --quiet
 fi
 
 # Install SqlPackage


### PR DESCRIPTION
# Description

Install libssl1.1 for jammy using apt instead, so that no upstream versioning bump would fail the build again.

#### Related issue:
It has been resolved in #9428, which updated the new version string and hash.

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
