### PR TITLE
[Ubuntu] pick one dotnet sdk version for each major release

### DIFF
--- a/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
+++ b/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
@@ -72,7 +72,7 @@ for version in ${dotnet_versions[@]}; do
     fi
 done
 
-sorted_sdks=$(echo ${sdks[@]} | tr ' ' '\n' | sort -r | uniq -w 5)
+sorted_sdks=$(echo ${sdks[@]} | tr ' ' '\n' | sort -V -r | sort -t. -k 1,1 -u)
 
 # Download/install additional SDKs in parallel
 export -f download_with_retry

--- a/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
+++ b/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
@@ -60,7 +60,7 @@ apt-get update
 
 # Install .NET SDK from home repository
 # Get list of all released SDKs from channels which are not end-of-life or preview
-sdks=()
+sdks=($(dotnet --list-sdks | awk '{ print $1 "9999"; }'))
 for version in ${dotnet_versions[@]}; do
     release_url="https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/${version}/releases.json"
     releases=$(cat "$(download_with_retry "$release_url")")
@@ -72,7 +72,7 @@ for version in ${dotnet_versions[@]}; do
     fi
 done
 
-sorted_sdks=$(echo ${sdks[@]} | tr ' ' '\n' | sort -V -r | sort -t. -k 1,1 -u)
+sorted_sdks=$(echo ${sdks[@]} | tr ' ' '\n' | sort -V -r | sort -t. -k 1,1 -u | sed 's,9999$,,')
 
 # Download/install additional SDKs in parallel
 export -f download_with_retry


### PR DESCRIPTION
# Description
The ubuntu builds currently fail with:
```
==> docker.build_image: Multiple versions from list '6.0.419, 7.0.116, 7.0.203, 7.0.313, 7.0.406, 8.0.102, 8.0.200, 8.0.201' return the same result from regex '^\d+\.\d+\.\d': 8.0.2
==> docker.build_image: At /imagegeneration/SoftwareReport/software-report-base/SoftwareReport.Nodes.psm1:265 char:17
==> docker.build_image: + …             throw "Multiple versions from list '$($this.GetValue())'  …
==> docker.build_image: +               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> docker.build_image: + CategoryInfo          : OperationStopped: (Multiple versions f…d+\.\d+\.\d': 8.0.2:String) [], RuntimeException
==> docker.build_image: + FullyQualifiedErrorId : Multiple versions from list '6.0.419, 7.0.116, 7.0.203, 7.0.313, 7.0.406, 8.0.102, 8.0.200, 8.0.201' return the same result from regex '^\d+\.\d+\.\d': 8.0.2
```
The reason is the `sorted_sdks` picks multiple 7.0.x and 8.0.x releases to install, and yet one per each major version is expected in ToolVersionsListNode. This change correct the way `sorted_sdks` is generated.
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
