### PR TITLE
[Ubuntu] Update Kotlin installer hash check

### DIFF
--- a/images/ubuntu/scripts/build/install-kotlin.sh
+++ b/images/ubuntu/scripts/build/install-kotlin.sh
@@ -13,7 +13,8 @@ download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"k
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - Kotlin
-kotlin_hash=$(get_checksum_from_github_release "JetBrains/kotlin" "kotlin-compiler-.*\.zip" "latest" "SHA256")
+kotlin_hash_file=$(download_with_retry "${download_url}.sha256")
+kotlin_hash=$(cat "$kotlin_hash_file")
 use_checksum_comparison "$archive_path" "$kotlin_hash"
 
 unzip -qq "$archive_path" -d $KOTLIN_ROOT


### PR DESCRIPTION
# Description

Kotlin developers changed method of publishing hashes for installer archive. 

#### Related issue:

- https://github.com/actions/runner-images/issues/9466

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
