### PR TITLE
[Windows] Update Kotlin installer hash check

### DIFF
--- a/images/windows/scripts/build/Install-Kotlin.ps1
+++ b/images/windows/scripts/build/Install-Kotlin.ps1
@@ -14,11 +14,7 @@ $kotlinDownloadUrl = Resolve-GithubReleaseAssetUrl `
 $kotlinArchivePath = Invoke-DownloadWithRetry $kotlinDownloadUrl
 
 #region Supply chain security
-$externalHash = Get-ChecksumFromGithubRelease `
-    -Repo "JetBrains/kotlin" `
-    -Version "$kotlinVersion" `
-    -FileName (Split-Path $kotlinDownloadUrl -Leaf) `
-    -HashType "SHA256"
+$externalHash = Get-Content $(Invoke-DownloadWithRetry "$kotlinDownloadUrl.sha256")
 Test-FileChecksum $kotlinArchivePath -ExpectedSHA256Sum $externalHash
 #endregion
 


### PR DESCRIPTION
# Description

Kotlin developers changed method of publishing hashes for installer archive. 

#### Related issue:

- https://github.com/actions/runner-images/issues/9466

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
