### PR TITLE
[macOS]  remove blackhole 2ch

### DIFF
--- a/images/macos/scripts/build/install-audiodevice.sh
+++ b/images/macos/scripts/build/install-audiodevice.sh
@@ -12,14 +12,4 @@ brew_smart_install "switchaudio-osx"
 echo "install sox"
 brew_smart_install "sox"
 
-# Big Sur doesn't support soundflower installation without user interaction https://github.com/mattingalls/Soundflower/releases/tag/2.0b2
-# Install blackhole-2ch for Big Sur instead
-
-echo "install blackhole-2ch"
-brew_smart_install "blackhole-2ch"
-
-echo "set BlackHole 2ch as input/output device"
-SwitchAudioSource -s "BlackHole 2ch" -t input
-SwitchAudioSource -s "BlackHole 2ch" -t output
-
 invoke_tests "System" "Audio Device"

--- a/images/macos/scripts/tests/System.Tests.ps1
+++ b/images/macos/scripts/tests/System.Tests.ps1
@@ -33,10 +33,6 @@ Describe "Audio device" -Skip:($os.IsVentura -or $os.IsSonoma) {
     It "SwitchAudioSource is installed" {
         "SwitchAudioSource -c" | Should -ReturnZeroExitCode
     }
-
-    It "Audio channel BlackHole 2ch" {
-        SwitchAudioSource -c | Should -BeLikeExactly "BlackHole 2ch"
-    }
 }
 
 Describe "Screen Resolution" -Skip:(isVeertu) {


### PR DESCRIPTION
blackhole-2ch upstream site is now blocked as malicious and ssl got expired which makes it uninstallable.