### PR TITLE
Add emulator and platform-tools of Android SDK to Ubuntu

### DIFF
--- a/images/ubuntu/scripts/build/install-android-sdk.sh
+++ b/images/ubuntu/scripts/build/install-android-sdk.sh
@@ -103,6 +103,9 @@ for ndk_major_version in "${android_ndk_major_versions[@]}"; do
     components+=("ndk;$ndk_full_version")
 done
 
+components+=("platform-tools;")
+components+=("emulator;")
+
 available_platforms=($($SDKMANAGER --list | sed -n '/Available Packages:/,/^$/p' | grep "platforms;android-[0-9]" | cut -d"|" -f 1))
 all_build_tools=($($SDKMANAGER --list | grep "build-tools;" | cut -d"|" -f 1 | sort -u))
 available_build_tools=$(echo ${all_build_tools[@]//*rc[0-9]/})


### PR DESCRIPTION
# Description

We has discussed this topic before, but we were not satisfied with the outcome.

The main reasons for this are:
- When we build an Android app or library using Gradle, the packages I added are reinstalled every time.
- This isn't just happening in a few repositories, but in a very large number of repositories.

Also, as a counterargument to the previous answer:

> relatively short runtime installation time.

It seems odd to reject this based on the time it takes to install, and if this reason was acceptable they should remove a ton of other non-Android packages.

> not to bake emulator android component into the image at this time due to maintenance concerns

`emulator` and `platform-tools` do not need to look back at previous versions, and unless otherwise specified, the latest version of the packages will always be required regardless of the AGP version.

> Component can be installed on runtime:

I'm sure most people know how to install it, and I wasn't asking how to do it.  
We just wished the package would be included with the image.

---

#### Related issue:
- #9227
- #9219

## Check list
- [x] Related issue / work item is attached
- [ ] Changes are tested and related VM images are successfully generated
