### PR TITLE
Updating signature for Visual Studio Enterprise 2022.17.

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -176,7 +176,7 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE",
+        "signature": "C2048FB509F1C37A8C3E9EC6648118458AA01780",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",


### PR DESCRIPTION
# Description
Fixing signature for Visual Studio Enterprise 2022.17 in toolset 2022.

#### Related issue:
#9188 