### PR TITLE
[Ubuntu] Decrease vm.mmap_rnd_bit to prevent ASLR ASAN issues

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -41,6 +41,9 @@ echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf
 echo 'fs.inotify.max_user_watches=655360' | tee -a /etc/sysctl.conf
 echo 'fs.inotify.max_user_instances=1280' | tee -a /etc/sysctl.conf
 
+# https://github.com/actions/runner-images/issues/9491
+echo 'vm.mmap_rnd_bits=28' | tee -a /etc/sysctl.conf
+
 # https://github.com/actions/runner-images/pull/7860
 netfilter_rule='/etc/udev/rules.d/50-netfilter.rules'
 rules_directory="$(dirname "${netfilter_rule}")"


### PR DESCRIPTION
# Description

Getting the number decreased to bypass ASL problem when compiling with LLVM and ASAN turned on.

#### Related issue: https://github.com/actions/runner-images/issues/9491

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
