### PR TITLE
[Windows] Do not create cli-plugins dir if it exists

### DIFF
--- a/images/windows/scripts/build/Install-DockerCompose.ps1
+++ b/images/windows/scripts/build/Install-DockerCompose.ps1
@@ -14,7 +14,10 @@ $toolsetVersion = (Get-ToolsetContent).docker.components.compose
 $composeVersion = (Get-GithubReleasesByVersion -Repo "docker/compose" -Version "${toolsetVersion}").version
 $dockerComposev2Url = "https://github.com/docker/compose/releases/download/v${composeVersion}/docker-compose-windows-x86_64.exe"
 $cliPluginsDir = "C:\ProgramData\docker\cli-plugins"
-New-Item -Path $cliPluginsDir -ItemType Directory
+
+if (-not (Test-Path $cliPluginsDir)) {
+    New-Item -Path $cliPluginsDir -ItemType Directory
+}
 Invoke-DownloadWithRetry -Url $dockerComposev2Url -Path "$cliPluginsDir\docker-compose.exe"
 
 Invoke-PesterTests -TestFile "Docker" -TestName "DockerCompose"


### PR DESCRIPTION
# Description

Looks like choco does it now, but since only recently, lets create dir if only it does not exist

#### Related issue: https://github.com/actions/runner-images/issues/9553

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
