### PR TITLE
Add WiX `bin` folder to `PATH`.

### DIFF
--- a/images/windows/scripts/build/Install-Wix.ps1
+++ b/images/windows/scripts/build/Install-Wix.ps1
@@ -5,4 +5,9 @@
 
 Install-ChocoPackage wixtoolset -ArgumentList "--force"
 
+# Add WiX bin folder to the PATH
+$currentPath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
+$NewPath = "$currentPath;$($Env:WIX)\bin"
+[Environment]::SetEnvironmentVariable("PATH", $NewPath, "Machine")
+
 Invoke-PesterTests -TestFile "Wix"

--- a/images/windows/scripts/tests/Wix.Tests.ps1
+++ b/images/windows/scripts/tests/Wix.Tests.ps1
@@ -1,11 +1,5 @@
 Describe "Wix" {
-    BeforeAll {
-      $regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
-      $installedApplications = Get-ItemProperty -Path $regKey
-      $version = ($installedApplications | Where-Object { $_.BundleCachePath -imatch ".*\\WiX\d*\.exe$" } | Select-Object -First 1).DisplayName
-    }
-
-    It "Wix Toolset version from registry" {
-      $version | Should -Not -BeNullOrEmpty
+    It "Wix Toolset binaries have been installed and are available in env:Path" {
+        "candle.exe -?" | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
# Description
As mentioned in issue "WiX toolkit is not in the PATH" #9551 the WiX installer does not add its `bin` folder to the `PATH` environment variable. However, it does set the `WIX` environment variable, pointing to the WiX install folder. This code adds WiX `bin` folder using the path that's defined in the `WIX` environment variable, so WiX commands can be called directly from the command-line.

#### Related issue:
#9551
