### PR TITLE
Configurable SSH port

### DIFF
--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -24,6 +24,11 @@ variable "source_vm_name" {
   type = string
 }
 
+variable "source_vm_port" {
+  type = number
+  default = 22
+}
+
 variable "source_vm_tag" {
   type = string
   default = ""
@@ -89,8 +94,9 @@ source "veertu-anka-vm-clone" "template" {
 
 source "null" "template" {
   ssh_host = "${var.source_vm_name}"
+  ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_password = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -24,6 +24,11 @@ variable "source_vm_name" {
   type = string
 }
 
+variable "source_vm_port" {
+  type = number
+  default = 22
+}
+
 variable "source_vm_tag" {
   type = string
   default = ""
@@ -89,8 +94,9 @@ source "veertu-anka-vm-clone" "template" {
 
 source "null" "template" {
   ssh_host = "${var.source_vm_name}"
+  ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_password = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -24,6 +24,11 @@ variable "source_vm_name" {
   type = string
 }
 
+variable "source_vm_port" {
+  type = number
+  default = 22
+}
+
 variable "source_vm_tag" {
   type = string
   default = ""
@@ -90,8 +95,9 @@ source "veertu-anka-vm-clone" "template" {
 
 source "null" "template" {
   ssh_host = "${var.source_vm_name}"
+  ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_password = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -24,6 +24,11 @@ variable "source_vm_name" {
   type = string
 }
 
+variable "source_vm_port" {
+  type = number
+  default = 22
+}
+
 variable "source_vm_tag" {
   type = string
   default = ""
@@ -89,8 +94,9 @@ source "veertu-anka-vm-clone" "template" {
 
 source "null" "template" {
   ssh_host = "${var.source_vm_name}"
+  ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_password = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -24,6 +24,11 @@ variable "source_vm_name" {
   type = string
 }
 
+variable "source_vm_port" {
+  type = number
+  default = 22
+}
+
 variable "source_vm_tag" {
   type = string
   default = ""
@@ -90,8 +95,9 @@ source "veertu-anka-vm-clone" "template" {
 
 source "null" "template" {
   ssh_host = "${var.source_vm_name}"
+  ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_password = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 


### PR DESCRIPTION
# Description

This PR adds an option to specify SSH port for the `null` builder (defaults to `22`).

It also switches `null` builder to using public key authentication with password representing a path to the private key file. There is a downside of overloading `vm_password` parameter but it also keeps amount of parameters small.

That being said I'm open for adding a new parameter specifically for the private key file. 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
