### PR TITLE
[Ubuntu] Fix Swift installer

### DIFF
--- a/images/ubuntu/scripts/build/install-swift.sh
+++ b/images/ubuntu/scripts/build/install-swift.sh
@@ -17,16 +17,25 @@ archive_url="https://swift.org/builds/swift-${swift_version}-release/${image_lab
 archive_path=$(download_with_retry "$archive_url")
 
 # Verifying PGP signature using official Swift PGP key. Referring to https://www.swift.org/install/linux/#Installation-via-Tarball
-# Download and import Swift PGP key
-pgp_key_path=$(download_with_retry "https://swift.org/keys/all-keys.asc")
-gpg --no-default-keyring --keyring swift --import "$pgp_key_path"
+# Download and import Swift PGP keys
+gpg --keyserver hkp://keyserver.ubuntu.com \
+      --recv-keys \
+      '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD' \
+      '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F' \
+      'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
+      '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
+      '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
+      'A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561' \
+      '8A74 9566 2C3C D4AE 18D9  5637 FAF6 989E 1BC1 6FEA' \
+      'E813 C892 820A 6FA1 3755  B268 F167 DF1A CF9C E069'
+gpg --keyserver hkp://keyserver.ubuntu.com --refresh-keys Swift
 
 # Download and verify signature
 signature_path=$(download_with_retry "${archive_url}.sig")
-gpg --no-default-keyring --keyring swift --verify "$signature_path" "$archive_path"
+gpg --verify "$signature_path" "$archive_path"
 
 # Remove Swift PGP public key with temporary keyring
-rm ~/.gnupg/swift
+rm -rf ~/.gnupg
 
 # Extract and install swift
 tar xzf "$archive_path" -C /tmp


### PR DESCRIPTION
# Description

Use key-server instead of key-file when installing Swift.

#### Related issue:

https://github.com/actions/runner-images/issues/9664

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
