### PR TITLE
Small filename fix.

### DIFF
--- a/images/windows/scripts/build/Configure-System.ps1
+++ b/images/windows/scripts/build/Configure-System.ps1
@@ -193,4 +193,4 @@ $disableTaskNames | ForEach-Object {
     Disable-ScheduledTask @PSItem -ErrorAction Ignore
 } | Out-Null
 
-Write-Host "Finalize-VM.ps1 - completed"
+Write-Host "Configure-System.ps1 - completed"


### PR DESCRIPTION
# Description
The `Configure-System.ps1` script displayed the wrong filename.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
