### PR TITLE
Update Windows/Ubuntu image generation pipeline to use OIDC

### DIFF
--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -59,11 +59,13 @@ jobs:
       arguments: -RepoUrl $(CUSTOM_REPOSITORY_URL) `
                  -RepoBranch $(CUSTOM_REPOSITORY_BRANCH)
 
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     displayName: 'Set variables'
     inputs:
-      targetType: 'inline'
-      script: |
+      TargetAzurePs: LatestVersion
+      azureSubscription: 'spn-hosted-runners'
+      ScriptType: 'InlineScript'
+      Inline: |
         $ImageType = "${{ parameters.image_type }}"
         $TemplateDirectoryName = if ($ImageType.StartsWith("ubuntu")) { "ubuntu/templates" } else { "windows/templates" }
         $TemplateDirectoryPath = Join-Path "images" $TemplateDirectoryName | Resolve-Path
@@ -79,13 +81,16 @@ jobs:
         $TempResourceGroupName = "packer-temp-$ManagedImageName"
         Write-Host "##vso[task.setvariable variable=TempResourceGroupName;]$TempResourceGroupName"
 
+        $clientSecret = $(az keyvault secret show --name "spnhostedrunners" --vault-name "gh-imagegeneration" --query value -o tsv)
+        Write-Host "##vso[task.setvariable variable=ClientSecret;issecret=true]$clientSecret"
+
   - task: PowerShell@2
     displayName: 'Build VM'
     inputs:
       targetType: filePath
       filePath: ./images.CI/linux-and-win/build-image.ps1
       arguments: -ClientId $(CLIENT_ID) `
-                 -ClientSecret $(CLIENT_SECRET) `
+                 -ClientSecret "$(ClientSecret)" `
                  -TemplatePath $(TemplatePath) `
                  -ImageName "$(ManagedImageName)" `
                  -ImageResourceGroupName $(AZURE_RESOURCE_GROUP) `
@@ -172,5 +177,5 @@ jobs:
       arguments: -TempResourceGroupName "$(TempResourceGroupName)" `
                  -SubscriptionId $(AZURE_SUBSCRIPTION) `
                  -ClientId $(CLIENT_ID) `
-                 -ClientSecret $(CLIENT_SECRET) `
+                 -ClientSecret "$(ClientSecret)" `
                  -TenantId $(AZURE_TENANT)


### PR DESCRIPTION
# Description

Update test pipelines to use OIDC

#### Related issue:

[#5919](https://github.com/actions/runner-images-internal/issues/5919)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
