### PR TITLE
[MacOS] Change PIPX_HOME for arm64

### DIFF
--- a/images/macos/scripts/build/install-python.sh
+++ b/images/macos/scripts/build/install-python.sh
@@ -44,7 +44,7 @@ echo "Installing pipx"
 
 if is_Arm64; then
     export PIPX_BIN_DIR="$HOME/.local/bin"
-    export PIPX_HOME="$HOME/Library/Application\ Support/pipx"
+    export PIPX_HOME="$HOME/.local/pipx"
 else
     export PIPX_BIN_DIR=/usr/local/opt/pipx_bin
     export PIPX_HOME=/usr/local/opt/pipx


### PR DESCRIPTION
# Description
Change PIPX_HOME for arm64 for avoiding whitespaces 

#### Related issue:
https://github.com/actions/runner-images/issues/9703

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
