### PR TITLE
[Ubuntu] fix overwrite packer files on unpack

### DIFF
--- a/images/ubuntu/scripts/build/install-packer.sh
+++ b/images/ubuntu/scripts/build/install-packer.sh
@@ -10,6 +10,6 @@ source $HELPER_SCRIPTS/install.sh
 # Install Packer
 download_url=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/packer/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
 archive_path=$(download_with_retry "$download_url")
-unzip -qq "$archive_path" -d /usr/local/bin
+unzip -o -qq "$archive_path" -d /usr/local/bin
 
 invoke_tests "Tools" "Packer"


### PR DESCRIPTION
# Description

It has the conflicting LICENSE.txt file.

#### Related issue: https://github.com/actions/runner-images/issues/9742

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
