### PR TITLE
[Ubuntu] Use the latest version of Docker on Ubuntu

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -236,11 +236,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.9"
+                "version": "latest"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.9"
+                "version": "latest"
             }
         ],
         "plugins": [
@@ -251,7 +251,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.23.3",
+                "version": "latest",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -235,11 +235,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.9"
+                "version": "latest"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.9"
+                "version": "latest"
             }
         ],
         "plugins": [
@@ -250,7 +250,7 @@
             },            
             {
                 "plugin": "compose",
-                "version": "2.23.3",
+                "version": "latest",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -174,11 +174,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "26.1.0"
+                "version": "latest"
             },
             {
                 "package": "docker-ce",
-                "version": "26.1.0"
+                "version": "latest"
             }
         ],
         "plugins": [


### PR DESCRIPTION
# Description

This unpegs Docker from the old v24 and allows it to be latest. This is for https://github.com/actions/runner-images/issues/9773 and I've made it in case you are open to installing the latest version. It can be closed if there are reasons not to update Docker. (I'm aware of some GitHub issues in this repo about later versions of Docker on Windows, but not aware of any problems with the latest version of Docker on Ubuntu. But I understand if there are problems and you don't want to upgrade it.)

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] ~~Tests are written (if applicable)~~
- [ ] ~~Documentation is updated (if applicable)~~
- [ ] Changes are tested and related VM images are successfully generated
