### PR TITLE
[ubuntu] fix image generation

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -47,4 +47,3 @@ if ! is_ubuntu24; then
     # https://github.com/ilikenwf/apt-fast
     bash -c "$(curl -fsSL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)"
 fi
-mv /usr/local/bin/apt-fast /usr/local/sbin/apt-fast

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -47,3 +47,4 @@ if ! is_ubuntu24; then
     # https://github.com/ilikenwf/apt-fast
     bash -c "$(curl -fsSL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)"
 fi
+mv /usr/local/bin/apt-fast /usr/local/sbin/apt-fast


### PR DESCRIPTION
modified configure-apt.sh file : moving apt-fast back to sbin right after installation

#### Related [9780](https://github.com/actions/runner-images/issues/9780)

## Check list
- [ X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

