### PR TITLE
[Ubuntu] do not wrap apt-fast in mock script

### DIFF
--- a/images/ubuntu/scripts/build/cleanup.sh
+++ b/images/ubuntu/scripts/build/cleanup.sh
@@ -31,7 +31,7 @@ rm -f /usr/local/bin/invoke_tests
 
 # remove apt mock
 prefix=/usr/local/bin
-for tool in apt apt-get apt-fast apt-key;do
+for tool in apt apt-get apt-key;do
     sudo rm -f $prefix/$tool
 done
 

--- a/images/ubuntu/scripts/build/configure-apt-mock.sh
+++ b/images/ubuntu/scripts/build/configure-apt-mock.sh
@@ -2,12 +2,12 @@
 ################################################################################
 ##  File:  configure-apt-mock.sh
 ##  Desc:  A temporary workaround for https://github.com/Azure/azure-linux-extensions/issues/1238.
-##         Cleaned up during configure-cleanup.sh.
+##         Cleaned up during cleanup.sh.
 ################################################################################
 
 prefix=/usr/local/bin
 
-for real_tool in /usr/bin/apt /usr/bin/apt-get /usr/bin/apt-fast /usr/bin/apt-key; do
+for real_tool in /usr/bin/apt /usr/bin/apt-get /usr/bin/apt-key; do
     tool=$(basename $real_tool)
     cat >$prefix/$tool <<EOT
 #!/bin/sh


### PR DESCRIPTION
# Description


We are wrapping up multiple apt tools into a mock retries script tp avoid race condition caused by apt during images generation. While it works for the most of the tools, for apt-fast it is not, because we are referencing the `/usr/bin` tools into the `/usr/local/bin` directory. apt-fast is not the official deb-based bistro tool and never belonged to the `/usr/bin` directory (not to say that apt-mocking this tool is pointless as it is not being used during images generation).

Previously, apt-fast has been installed into the `/usr/local/sbin` directory, but since recently, upstream has changed its installation destination to the `/usr/local/bin` one, in turn, we are cleaning up the `/usr/local/bin/apt-fast` file in our `cleanup.sh` script, as we expect it to be a mock alternative of the actual tool, but in reality we are removing the tool from the image entirely. We should not wrap apt-fast anyhow so I propose we stop doing this.



#### Related issue: https://github.com/actions/runner-images/issues/9780

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
