### PR TITLE
[Ubuntu] Add missing Java SDKs to Ubuntu 24.04

### DIFF
--- a/images/ubuntu/scripts/build/install-java-tools.sh
+++ b/images/ubuntu/scripts/build/install-java-tools.sh
@@ -70,21 +70,19 @@ echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium
 apt-get update
 
 # While Ubuntu 24.04 binaries are not released in the Adoptium repo, we will not install Java
-if ! is_ubuntu24; then
-    defaultVersion=$(get_toolset_value '.java.default')
-    jdkVersionsToInstall=($(get_toolset_value ".java.versions[]"))
+defaultVersion=$(get_toolset_value '.java.default')
+jdkVersionsToInstall=($(get_toolset_value ".java.versions[]"))
 
-    for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
-        install_open_jdk ${jdkVersionToInstall}
+for jdkVersionToInstall in ${jdkVersionsToInstall[@]}; do
+    install_open_jdk ${jdkVersionToInstall}
 
-        if [[ ${jdkVersionToInstall} == ${defaultVersion} ]]
-        then
-            create_java_environment_variable ${jdkVersionToInstall} True
-        else
-            create_java_environment_variable ${jdkVersionToInstall} False
-        fi
-    done
-fi
+    if [[ ${jdkVersionToInstall} == ${defaultVersion} ]]
+    then
+        create_java_environment_variable ${jdkVersionToInstall} True
+    else
+        create_java_environment_variable ${jdkVersionToInstall} False
+    fi
+done
 
 # Install Ant
 apt-get install -y --no-install-recommends ant ant-optional

--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -191,9 +191,7 @@ if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
 }
 
 # Java
-if (-not $(Test-IsUbuntu24)) {
-    $installedSoftware.AddHeader("Java").AddTable($(Get-JavaVersionsTable))
-}
+$installedSoftware.AddHeader("Java").AddTable($(Get-JavaVersionsTable))
 
 # PHP Tools
 $phpTools = $installedSoftware.AddHeader("PHP Tools")

--- a/images/ubuntu/scripts/tests/Java.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Java.Tests.ps1
@@ -1,6 +1,6 @@
 Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1" -DisableNameChecking
 
-Describe "Java" -Skip:(Test-IsUbuntu24) {
+Describe "Java" {
     $toolsetJava = (Get-ToolsetContent).java
     $defaultVersion = $toolsetJava.default
     $jdkVersions = $toolsetJava.versions

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -56,6 +56,8 @@
         }
     ],
     "java": {
+        "default": "17",
+        "versions": [ "8", "11", "17", "21"],
         "maven": "3.8.8"
     },
     "android": {


### PR DESCRIPTION
# Description

Add Adoptium JDKs to the Ubuntu 24.04 image.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
