### PR TITLE
Update Docker versions to the latest releases

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -236,11 +236,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.9"
+                "version": "26.1.2"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.9"
+                "version": "26.1.2"
             }
         ],
         "plugins": [
@@ -251,7 +251,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.23.3",
+                "version": "latest",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -235,11 +235,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "24.0.9"
+                "version": "26.1.2"
             },
             {
                 "package": "docker-ce",
-                "version": "24.0.9"
+                "version": "26.1.2"
             }
         ],
         "plugins": [
@@ -247,10 +247,10 @@
                 "plugin": "buildx",
                 "version": "latest",
                 "asset": "linux-amd64"
-            },            
+            },
             {
                 "plugin": "compose",
-                "version": "2.23.3",
+                "version": "latest",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -182,11 +182,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "26.1.0"
+                "version": "26.1.2"
             },
             {
                 "package": "docker-ce",
-                "version": "26.1.0"
+                "version": "26.1.2"
             }
         ],
         "plugins": [

--- a/images/windows/scripts/build/Install-DockerCompose.ps1
+++ b/images/windows/scripts/build/Install-DockerCompose.ps1
@@ -17,7 +17,6 @@ Add-MachinePathItem $dockerComposev1Dir
 Update-Environment
 
 Write-Host "Install-Package Docker-Compose v2"
-# Temporaty pinned to v2.23.3 due https://github.com/actions/runner-images/issues/9172
 $toolsetVersion = (Get-ToolsetContent).docker.components.compose
 $composeVersion = (Get-GithubReleasesByVersion -Repo "docker/compose" -Version "${toolsetVersion}").version
 $dockerComposev2Url = "https://github.com/docker/compose/releases/download/v${composeVersion}/docker-compose-windows-x86_64.exe"

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -369,9 +369,9 @@
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
         ],
         "components": {
-            "docker": "24.0.7",
-            "compose": "2.23.3"
-        }   
+            "docker": "26.1.2",
+            "compose": "2.27.0"
+        }
     },
     "pipx": [
         {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -121,7 +121,7 @@
                 "11.3.1"
             ],
             "zip_versions": [
-    
+
             ]
         }
     ],
@@ -332,8 +332,8 @@
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
         ],
         "components": {
-            "docker": "24.0.7",
-            "compose": "2.23.3"
+            "docker": "26.1.2",
+            "compose": "2.27.0"
         }
     },
     "pipx": [


### PR DESCRIPTION
# Description
Improvement
Update Docker tools to the latest versions.
Right now actions using pinned version of compose (since: https://github.com/actions/runner-images/issues/9172), it's quite old and miss a lot of features. Also it's not same across different ubuntu and windows versions

Updates:

- Ubuntu 20/22:
   - `docker-ce-cli` `24.0.9` -> `26.1.2`
   - `docker-ce` `24.0.9` -> `26.1.2`
   - `compose` `2.23.3` -> `latest` (`2.27.0`)
- Ubuntu 24:
   - `docker-ce-cli` `26.1.0` -> `26.1.2`
   - `docker-ce` `26.1.0` -> `26.1.2`
- Windows 2019
  - `docker-ce-cli` `24.0.7` -> `26.1.2`
  - `compose` `2.23.3` -> `2.27.0`
- Windows 2022
  - `docker-ce-cli` `24.0.7` -> `26.1.2`
  - `compose` `2.23.3` -> `2.27.0`

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
