### PR TITLE
[Ubuntu] Switch Clang to the 18 for the Ubuntu 24.04

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -229,7 +229,7 @@
             "17",
             "18"
         ],
-        "default_version": "17"
+        "default_version": "18"
     },
     "gcc": {
         "versions": [


### PR DESCRIPTION
# Description

Let's use latest available compiler by default for the new image.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
