### PR TITLE
[Ubuntu] Add Python to the Ubuntu 24.04 toolcache

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -263,9 +263,7 @@ if (-not $(Test-IsUbuntu24)) {
 $cachedTools = $installedSoftware.AddHeader("Cached Tools")
 $cachedTools.AddToolVersionsList("Go", $(Get-ToolcacheGoVersions), "^\d+\.\d+")
 $cachedTools.AddToolVersionsList("Node.js", $(Get-ToolcacheNodeVersions), "^\d+")
-if (-not $(Test-IsUbuntu24)) {
-    $cachedTools.AddToolVersionsList("Python", $(Get-ToolcachePythonVersions), "^\d+\.\d+")
-}
+$cachedTools.AddToolVersionsList("Python", $(Get-ToolcachePythonVersions), "^\d+\.\d+")
 $cachedTools.AddToolVersionsList("PyPy", $(Get-ToolcachePyPyVersions), "^\d+\.\d+")
 if (-not $(Test-IsUbuntu24)) {
     $cachedTools.AddToolVersionsList("Ruby", $(Get-ToolcacheRubyVersions), "^\d+\.\d+")

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -6,7 +6,12 @@
             "platform" : "linux",
             "platform_version": "24.04",
             "arch": "x64",
-            "versions": []
+            "versions": [
+                "3.9.*",
+                "3.10.*",
+                "3.11.*",
+                "3.12.*"
+            ]
         },
         {
             "name": "PyPy",


### PR DESCRIPTION
# Description

Python available for the latest Ubuntu-24.04 in the external repo. Adding it to the toolcache.

#### Related issue:

## Check list

- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
