### PR TITLE
[Ubuntu] Revert previously removed Docker tests

### DIFF
--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -69,10 +69,25 @@ Describe "Docker" {
     It "docker client" {
         $version=(Get-ToolsetContent).docker.components | Where-Object { $_.package -eq 'docker-ce-cli' } | Select-Object -ExpandProperty version
         If ($version -ne "latest") {
-            $(docker version --format '{{.Client.Version}}') | Should -BeLike "*$version*"
+            $(sudo docker version --format '{{.Client.Version}}') | Should -BeLike "*$version*"
         }else{
-            "docker version --format '{{.Client.Version}}'" | Should -ReturnZeroExitCode
+            "sudo docker version --format '{{.Client.Version}}'" | Should -ReturnZeroExitCode
         }
+    }
+
+    It "docker server" {
+        $version=(Get-ToolsetContent).docker.components | Where-Object { $_.package -eq 'docker-ce' } | Select-Object -ExpandProperty version
+        If ($version -ne "latest") {
+            $(sudo docker version --format '{{.Server.Version}}') | Should -BeLike "*$version*"
+        }else{
+            "sudo docker version --format '{{.Server.Version}}'" | Should -ReturnZeroExitCode
+        }
+    }
+
+    It "docker client/server versions match" {
+        $clientVersion = $(sudo docker version --format '{{.Client.Version}}')
+        $serverVersion = $(sudo docker version --format '{{.Server.Version}}')
+        $clientVersion | Should -Be $serverVersion
     }
 
     It "docker buildx" {


### PR DESCRIPTION
# Description

Fix, made in process of Ubuntu-24.04 addition works fine. Tests could be added in order to unlock `latest` tag for Docker installation.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
