### PR TITLE
[Ubuntu] Revert Podman, buildah and skopeo for Ubuntu-24.04

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -105,9 +105,7 @@ $tools.AddToolVersion("AzCopy", $(Get-AzCopyVersion))
 $tools.AddToolVersion("Bazel", $(Get-BazelVersion))
 $tools.AddToolVersion("Bazelisk", $(Get-BazeliskVersion))
 $tools.AddToolVersion("Bicep", $(Get-BicepVersion))
-if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
-    $tools.AddToolVersion("Buildah", $(Get-BuildahVersion))
-}
+$tools.AddToolVersion("Buildah", $(Get-BuildahVersion))
 $tools.AddToolVersion("CMake", $(Get-CMakeVersion))
 $tools.AddToolVersion("CodeQL Action Bundle", $(Get-CodeQLBundleVersion))
 $tools.AddToolVersion("Docker Amazon ECR Credential Helper", $(Get-DockerAmazonECRCredHelperVersion))
@@ -152,14 +150,12 @@ $tools.AddToolVersion("Parcel", $(Get-ParcelVersion))
 if (Test-IsUbuntu20) {
     $tools.AddToolVersion("PhantomJS", $(Get-PhantomJSVersion))
 }
-if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
-    $tools.AddToolVersion("Podman", $(Get-PodManVersion))
-}
+$tools.AddToolVersion("Podman", $(Get-PodManVersion))
 $tools.AddToolVersion("Pulumi", $(Get-PulumiVersion))
 if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
     $tools.AddToolVersion("R", $(Get-RVersion))
-    $tools.AddToolVersion("Skopeo", $(Get-SkopeoVersion))
 }
+$tools.AddToolVersion("Skopeo", $(Get-SkopeoVersion))
 $tools.AddToolVersion("Sphinx Open Source Search Server", $(Get-SphinxVersion))
 if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
     $tools.AddToolVersion("SVN", $(Get-SVNVersion))

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -329,7 +329,7 @@ Describe "Phantomjs" -Skip:(-not (Test-IsUbuntu20)) {
     }
 }
 
-Describe "Containers" -Skip:((-not (Test-IsUbuntu20)) -and (-not (Test-IsUbuntu22))) {
+Describe "Containers" {
     $testCases = @("podman", "buildah", "skopeo") | ForEach-Object { @{ContainerCommand = $_} }
 
     It "<ContainerCommand>" -TestCases $testCases {

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -286,6 +286,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-clang.sh",
       "${path.root}/../scripts/build/install-cmake.sh",
       "${path.root}/../scripts/build/install-codeql-bundle.sh",
+      "${path.root}/../scripts/build/install-container-tools.sh",
       "${path.root}/../scripts/build/install-dotnetcore-sdk.sh",
       "${path.root}/../scripts/build/install-gcc-compilers.sh",
       "${path.root}/../scripts/build/install-gfortran.sh",


### PR DESCRIPTION
# Description

Add podman, buildah, skopeo to the Ubuntu 24.04 image.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
