### PR TITLE
Add `sbt` to macOS 13 and macOS 14

### DIFF
--- a/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -104,9 +104,7 @@ $projectManagement = $installedSoftware.AddHeader("Project Management")
 $projectManagement.AddToolVersion("Apache Ant", $(Get-ApacheAntVersion))
 $projectManagement.AddToolVersion("Apache Maven", $(Get-MavenVersion))
 $projectManagement.AddToolVersion("Gradle", $(Get-GradleVersion))
-if ((-not $os.IsVentura) -and (-not $os.IsSonoma)) {
-    $projectManagement.AddToolVersion("Sbt", $(Get-SbtVersion))
-}
+$projectManagement.AddToolVersion("Sbt", $(Get-SbtVersion))
 
 # Utilities
 $utilities = $installedSoftware.AddHeader("Utilities")

--- a/images/macos/scripts/tests/BasicTools.Tests.ps1
+++ b/images/macos/scripts/tests/BasicTools.Tests.ps1
@@ -179,7 +179,7 @@ Describe "Kotlin" {
     }
 }
 
-Describe "sbt" -Skip:($os.IsVentura -or $os.IsSonoma) {
+Describe "sbt" {
     It "sbt" {
         "sbt -version" | Should -ReturnZeroExitCode
     }

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -74,6 +74,7 @@
             "packer",
             "perl",
             "pkg-config",
+            "sbt",
             "swiftformat",
             "zstd",
             "gmp",

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -74,6 +74,7 @@
             "packer",
             "perl",
             "pkg-config",
+            "sbt",
             "swiftformat",
             "zstd",
             "gmp",


### PR DESCRIPTION
# Description
macOS 12 had `sbt` (https://www.scala-sbt.org/) installed by default, see:
https://github.com/actions/runner-images/blob/1a952817bed9a3d317964a9879da9b694e9fc0e1/images/macos/macos-12-Readme.md?plain=1#L60

Unfortunately all your macOS 13 and macOS14 images do not provide `sbt` anymore. Is there any reason for that? Would be nice if you could add it back, thanks!