### PR TITLE
Descriptive link name for bot comment

### DIFF
--- a/helpers/software-report-base/Calculate-ImagesDifference.ps1
+++ b/helpers/software-report-base/Calculate-ImagesDifference.ps1
@@ -57,7 +57,7 @@ $diff = $comparer.GetMarkdownReport()
 if ($ReleaseBranchName -and $ReadmePath) {
     # https://github.com/actions/runner-images/blob/releases/macOS-12/20221215/images/macos/macos-12-Readme.md
     $ImageDocsUrl = "https://github.com/actions/runner-images/blob/${ReleaseBranchName}/${ReadmePath}"
-    $diff += "`n`n`nFor comprehensive list of software installed on this image please click [here]($ImageDocsUrl)."
+    $diff += "`n`n`nThis comment only shows a part of the list, read the [full list of software installed on this image]($ImageDocsUrl)."
 }
 
 $parentDirectory = Split-Path $OutputFile -Parent


### PR DESCRIPTION
# Description

Bug fixing

## Summary of change:

- Use descriptive link name for bot comment

## Why?

A good link name helps those who use screenreaders, as they will hear what the link is about.

## More info

This is my first contribution here. :wink: 

#### Related issue:

There is no related issue, I'm making a drive by contribution. :smile: 

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
