### PR TITLE
[Windows] Update VS2022 code signature

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -176,7 +176,7 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE",
+        "signature": "C2048FB509F1C37A8C3E9EC6648118458AA01780",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",


### PR DESCRIPTION
# Description

In order to unblock deployment since:
```
    azure-arm.image: Downloading package from https://aka.ms/vs/17/release/vs_Enterprise.exe to C:\Users\INSTAL~1\AppData\Local\Temp\vs_Enterprise.exe...
    azure-arm.image: Package downloaded in 0.64 seconds
    azure-arm.image: Signature thumbprint do not match expected.
```

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
