### PR TITLE
VisualStudioHelpers.ps1: stop enabling 8.3 filename creation

### DIFF
--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -44,15 +44,6 @@ Function Install-VisualStudio {
     Test-FileSignature -Path $bootstrapperFilePath -ExpectedThumbprint $SignatureThumbprint
 
     try {
-        Write-Host "Enable short name support on Windows needed for Xamarin Android AOT, defaults appear to have been changed in Azure VMs"
-        $shortNameEnableProcess = Start-Process -FilePath fsutil.exe -ArgumentList ('8dot3name', 'set', '0') -Wait -PassThru
-
-        $shortNameEnableExitCode = $shortNameEnableProcess.ExitCode
-        if ($shortNameEnableExitCode -ne 0) {
-            Write-Host "Enabling short name support on Windows failed. This needs to be enabled prior to VS 2017 install for Xamarin Andriod AOT to work."
-            exit $shortNameEnableExitCode
-        }
-
         $responseData = @{
             "channelUri" = $channelUri
             "channelId"  = $channelId


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

The bug that prompted enabling 8.3 filename creation was fixed 5 years ago, see https://github.com/xamarin/xamarin-android/issues/3407:
> Fix included in Xamarin.Android 10.1.0.30.
>
> Fix included on Windows in Visual Studio 2019 version 16.4.

We're on VS 2019 16.11: https://github.com/actions/runner-images/blob/98150396188d19c21a7d7c596cf4a4d7609bb12a/images/windows/Windows2019-Readme.md?plain=1#L233

8.3 filename creation is known to hurt file creation performance, especially when there are a large number of similarly named files in the same folder:
* https://learn.microsoft.com/en-us/archive/blogs/josebda/windows-server-2012-file-server-tip-disable-8-3-naming-and-strip-those-short-names-too
* https://www.linkedin.com/pulse/dont-forget-disable-short-filenames-83-servers-folders-wes-brown
* https://deep.data.blog/2013/06/19/debugging-story-slowness-due-to-ntfs-short-file-8-3-name-generation/

I created a new VM with the base Azure Marketplace Windows 2019 image and confirmed that 8.3 name generation is disabled by default for both the OS and temp disk:
```
fsutil 8dot3name query C:
The volume state is: 1 (8dot3 name creation is disabled).
The registry state is: 2 (Per volume setting - the default).

Based on the above settings, 8dot3 name creation is disabled on C:

fsutil 8dot3name query D:
The volume state is: 1 (8dot3 name creation is disabled).
The registry state is: 2 (Per volume setting - the default).

Based on the above settings, 8dot3 name creation is disabled on D:
```

#### Related issue:

This might help a bit with https://github.com/actions/cache/issues/752, although I haven't tested it, and AFAICT it's unlikely make an order of magnitude difference.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
