### PR TITLE
[Ubuntu] Patch azure-cli installer for Ubuntu 24.04

### DIFF
--- a/images/ubuntu/scripts/build/install-azure-cli.sh
+++ b/images/ubuntu/scripts/build/install-azure-cli.sh
@@ -4,8 +4,24 @@
 ##  Desc:  Install Azure CLI (az)
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/os.sh
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
+if is_ubuntu24; then
+    apt-get install apt-transport-https       
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
+        gpg --dearmor | \
+        sudo tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null  
+    AZ_DIST="jammy"
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_DIST main" | \
+        sudo tee /etc/apt/sources.list.d/azure-cli.list
+    sudo apt-get update
+    sudo apt-get install azure-cli
+else
+    curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
+fi
+
 echo "azure-cli https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt" >> $HELPER_SCRIPTS/apt-sources.txt
 
 rm -f /etc/apt/sources.list.d/azure-cli.list


### PR DESCRIPTION
# Description

Install from `.deb` while package is not available in repo for `Noble Numbat`.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
