### PR TITLE
[Ubuntu] Pin Helm 3.14.4 due to unusual release of 3.15.0

### DIFF
--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -27,7 +27,13 @@ sudo apt-get update -y && sudo apt-get install -y kubectl
 rm -f /etc/apt/sources.list.d/kubernetes.list
 
 # Install Helm
-curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+# Temporary pin version v3.14.4 due to strange release of v3.15.0
+helm_version="v3.14.4"
+download_with_retry "https://get.helm.sh/helm-$helm_version-linux-amd64.tar.gz" /tmp/helm.tar.gz
+mkdir -p /tmp/helm
+tar xzf /tmp/helm.tar.gz -C /tmp/helm
+cp /tmp/helm/linux-amd64/helm /usr/local/bin/helm
+chmod +x /usr/local/bin/helm
 
 # Download minikube
 curl -fsSL -O https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64


### PR DESCRIPTION
# Description

New v3.15.0 version somehow returns an incorrect version when executing `helm version`.

#### Related issue:

https://github.com/actions/runner-images/issues/9865

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
