### PR TITLE
[macOS] Pin Swiftlint on macOS-12 due to Xcode 15.3 requirements

### DIFF
--- a/images/macos/scripts/build/install-swiftlint.sh
+++ b/images/macos/scripts/build/install-swiftlint.sh
@@ -14,6 +14,13 @@ if is_BigSur; then
 
   curl -fsSL $FORMULA_URL > $(find $(brew --repository) -name swiftlint.rb)
   HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install swiftlint
+elif is_Monterey; then
+  # SwiftLint now requires Xcode 15.3 or higher to build https://github.com/realm/SwiftLint/releases/tag/0.55.1
+  COMMIT=d91dabd087cb0b906c92a825df9e5e5e1a4f59f8
+  FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/s/swiftlint.rb"
+
+  curl -fsSL $FORMULA_URL > $(find $(brew --repository) -name swiftlint.rb)
+  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install swiftlint
 else
   brew_smart_install "swiftlint"
 fi


### PR DESCRIPTION
# Description

In order to unlock builds

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
