### PR TITLE
[Ubuntu] Add libyaml-dev library

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -122,6 +122,7 @@
             "gnupg2",
             "iproute2",
             "iputils-ping",
+            "libyaml-dev",
             "libtool",
             "libssl-dev",
             "locales",


### PR DESCRIPTION
# Description
Add "libyaml-dev" library to Ubuntu 24.04

#### Related issue: https://github.com/actions/runner-images/issues/9895

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
