### PR TITLE
modified ports for Apache and Nginx

### DIFF
--- a/images/windows/scripts/build/Install-Apache.ps1
+++ b/images/windows/scripts/build/Install-Apache.ps1
@@ -8,7 +8,7 @@ Stop-Service -Name w3svc
 
 # Install latest apache in chocolatey
 $installDir = "C:\tools"
-Install-ChocoPackage apache-httpd -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
+Install-ChocoPackage apache-httpd -ArgumentList "--force", "--params", "/installLocation:$installDir /port:8080"
 
 # Stop and disable Apache service
 Stop-Service -Name Apache

--- a/images/windows/scripts/build/Install-Nginx.ps1
+++ b/images/windows/scripts/build/Install-Nginx.ps1
@@ -8,7 +8,7 @@ Stop-Service -Name w3svc
 
 # Install latest nginx in chocolatey
 $installDir = "C:\tools"
-Install-ChocoPackage nginx -ArgumentList "--force", "--params", "/installLocation:$installDir /port:80"
+Install-ChocoPackage nginx -ArgumentList "--force", "--params", "/installLocation:$installDir /port:8081"
 
 # Stop and disable Nginx service
 Stop-Service -Name nginx


### PR DESCRIPTION
The Apache and Nginx services are conflicting with the default port 80, which is typically used in Windows server,8080 for Apache and 8081 for [Nginx]This allows the user to run both Apache and Nginx services on the same Windows servers (19 and 22) without any issues.[9915](https://github.com/actions/runner-images/issues/9915)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
