### PR TITLE
[Windows] Update script to install emulator separately

### DIFF
--- a/images/windows/scripts/build/Install-AndroidSDK.ps1
+++ b/images/windows/scripts/build/Install-AndroidSDK.ps1
@@ -119,6 +119,9 @@ $buildToolsList = Get-AndroidBuildToolPackages `
     -minVersion $androidToolset.build_tools_min_version
 Install-AndroidSDKPackages $buildToolsList
 
+# Install Android Emulator
+Install-AndroidSDKPackages "emulator"
+
 # Install extras, add-ons and additional tools
 Write-Host "Installing Android SDK extras, add-ons and additional tools..."
 Install-AndroidSDKPackages ($androidToolset.extras | ForEach-Object { "extras;$_" })


### PR DESCRIPTION
# Description
Update script to install emulator separately.
The latest [diff ](https://github.com/actions/runner-images/pull/9945/files)exposed that Android emulator is missed in the system.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
