### PR TITLE
[Ubuntu] exclude apt-fast from sw report on 24

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -100,7 +100,9 @@ if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
 # Tools
 $tools = $installedSoftware.AddHeader("Tools")
 $tools.AddToolVersion("Ansible", $(Get-AnsibleVersion))
-$tools.AddToolVersion("apt-fast", $(Get-AptFastVersion))
+if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
+    $tools.AddToolVersion("apt-fast", $(Get-AptFastVersion))
+}
 $tools.AddToolVersion("AzCopy", $(Get-AzCopyVersion))
 $tools.AddToolVersion("Bazel", $(Get-BazelVersion))
 $tools.AddToolVersion("Bazelisk", $(Get-BazeliskVersion))


### PR DESCRIPTION
# Description


As we fixed apt-fast's installation condition on Ubuntu 24.04, it is no longer being installed so we do not need it in the software report / it does not work there.

#### Related issue: n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
