### PR TITLE
[Ubuntu 24.04] Remove needrestart package from image

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -37,6 +37,9 @@ EOF
 # Uninstall unattended-upgrades
 apt-get purge unattended-upgrades
 
+# Uninstall needrestart: https://github.com/actions/runner-images/issues/9937
+is_ubuntu24 && apt-get purge needrestart
+
 echo 'APT sources'
 cat /etc/apt/sources.list
 


### PR DESCRIPTION
# Description
This removes the `needrestart` package from image, since it triggers a restart of all systemd services, including the `runner-provisioner`, crashing the workflow, whenever packages from the OpenSSL/LibSSL package source are upgraded.

Solves: #9937

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
