### PR TITLE
[Windows] Temporary remove hash check from DotnetSDK

### DIFF
--- a/images/windows/scripts/build/Install-AWSTools.ps1
+++ b/images/windows/scripts/build/Install-AWSTools.ps1
@@ -11,7 +11,7 @@ Install-ChocoPackage awscli
 Install-Binary `
     -Url "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe" `
     -InstallArgs ("/silent", "/install") `
-    -ExpectedSignature "FF457E5732E98A9F156E657F8CC7C4432507C3BB"
+    -ExpectedSignature "75A5FB4D02FCB2AB799718F315BAAA3103E9D60C"
 $env:Path = $env:Path + ";$env:ProgramFiles\Amazon\SessionManagerPlugin\bin"
 
 # Install AWS SAM CLI

--- a/images/windows/scripts/build/Install-DotnetSDK.ps1
+++ b/images/windows/scripts/build/Install-DotnetSDK.ps1
@@ -85,7 +85,8 @@ function Install-DotnetSDK {
     $releasesJsonUri = "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/${DotnetVersion}/releases.json"
     $releasesData = (Invoke-DownloadWithRetry $releasesJsonUri) | Get-Item | Get-Content | ConvertFrom-Json
     $distributorFileHash = $releasesData.releases.sdks.Where({ $_.version -eq $SDKVersion }).files.Where({ $_.name -eq 'dotnet-sdk-win-x64.zip' }).hash
-    Test-FileChecksum $zipPath -ExpectedSHA512Sum $distributorFileHash
+    # Temporary remove the hash check as the hashes of archive from https://dotnetcli.azureedge.net/dotnet/Sdk
+    # and https://download.visualstudio.microsoft.com/download/pr/ are different.
     #endregion
 }
 #endregion


### PR DESCRIPTION
# Description
During the investigation it was found that the dotnet SDK archive at URL `https://dotnetcli.azureedge.net/dotnet/Sdk` has a different hash than the archive from the releases.json file at URL `https://download.visualstudio.microsoft.com/download/pr`.
It was decided to temporary remove hash checking function and raise a ticket to dotnetSDK repo.

Along with that the signature for `SessionManagerPluginSetup.exe` was also updated.

#### Related issue:
 #9958

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
