### PR TITLE
uninstalling needrestart package from ubuntu 24.04

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -37,6 +37,9 @@ EOF
 # Uninstall unattended-upgrades
 apt-get purge unattended-upgrades
 
+# Uninstall needrestart
+is_ubuntu24 && apt-get purge needrestart
+
 echo 'APT sources'
 cat /etc/apt/sources.list
 


### PR DESCRIPTION
# Description
Uninstalling the needrestart package from the image, as it is stopping package upgradation.
#### Related issue:

## Check list
- [ 1 ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
