### PR TITLE
[Ubuntu] Display APT sources on 24 properly

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -38,7 +38,11 @@ EOF
 apt-get purge unattended-upgrades
 
 echo 'APT sources'
-cat /etc/apt/sources.list
+if ! is_ubuntu24; then
+    cat /etc/apt/sources.list
+else
+    cat /etc/apt/sources.list.d/ubuntu.sources
+fi
 
 apt-get update
 # Install jq


### PR DESCRIPTION
# Description


The file has moved to the new path since 24

#### Related issue: n/a

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
