### PR TITLE
updating llvm version to 18 for win19 and win22

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -469,7 +469,7 @@
         "version": "8.3"
     },
     "llvm": {
-        "version": "16"
+        "version": "18"
     },
     "postgresql": {
         "version": "14",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -367,7 +367,7 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "16"
+        "version": "18"
     },
     "php": {
         "version": "8.3"


### PR DESCRIPTION
# Description

Updating llvm version to 18 on windows 2019 and 2022 

#### Related issue:
[10001](https://github.com/actions/runner-images/issues/10001)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
