### PR TITLE
[windows] Pin PostgreSQL and Update LLVM

### DIFF
--- a/images/windows/scripts/build/Install-PostgreSQL.ps1
+++ b/images/windows/scripts/build/Install-PostgreSQL.ps1
@@ -11,34 +11,33 @@ $pgPwd = "root"
 [Environment]::SetEnvironmentVariable("PGUSER", $pgUser, "Machine")
 [Environment]::SetEnvironmentVariable("PGPASSWORD", $pgPwd, "Machine")
 
-# Define latest available version to install based on version specified in the toolset
 $toolsetVersion = (Get-ToolsetContent).postgresql.version
-$getPostgreReleases = Invoke-WebRequest -Uri "https://git.postgresql.org/gitweb/?p=postgresql.git;a=tags" -UseBasicParsing
-# Getting all links matched to the pattern (e.g.a=log;h=refs/tags/REL_14)
-$targetReleases = $getPostgreReleases.Links.href | Where-Object { $_ -match "a=log;h=refs/tags/REL_$toolsetVersion" }
-[Int32] $outNumber = $null
-$minorVersions = @()
-foreach ($release in $targetReleases) {
-    $version = $release.split('/')[-1]
-    # Checking if the latest symbol of the release version is actually a number. If yes, add to $minorVersions array
-    if ([Int32]::TryParse($($version.Split('_')[-1]), [ref] $outNumber)) {
-        $minorVersions += $outNumber
-    }
-}
-# Sorting and getting the last one
-$targetMinorVersions = ($minorVersions | Sort-Object)[-1]
-
-# In order to get rid of error messages (we know we will have them), force ErrorAction to SilentlyContinue
-$errorActionOldValue = $ErrorActionPreference
-$ErrorActionPreference = 'SilentlyContinue'
-
-$versionMatches = $toolsetVersion | Select-String -Pattern '\d+\.\d+\.\d+'
-if ($null -ne $versionMatches) {
+if ($null -ne ($toolsetVersion | Select-String -Pattern '\d+\.\d+\.\d+')) {
     $majorVersion = ([version]$toolsetVersion).Major
     $minorVersion = ([version]$toolsetVersion).Minor
     $patchVersion = ([version]$toolsetVersion).Build
     $installerUrl = "https://get.enterprisedb.com/postgresql/postgresql-$majorVersion.$minorVersion-$patchVersion-windows-x64.exe"
 } else {
+    # Define latest available version to install based on version specified in the toolset
+    $getPostgreReleases = Invoke-WebRequest -Uri "https://git.postgresql.org/gitweb/?p=postgresql.git;a=tags" -UseBasicParsing
+    # Getting all links matched to the pattern (e.g.a=log;h=refs/tags/REL_14)
+    $targetReleases = $getPostgreReleases.Links.href | Where-Object { $_ -match "a=log;h=refs/tags/REL_$toolsetVersion" }
+    [Int32] $outNumber = $null
+    $minorVersions = @()
+    foreach ($release in $targetReleases) {
+        $version = $release.split('/')[-1]
+        # Checking if the latest symbol of the release version is actually a number. If yes, add to $minorVersions array
+        if ([Int32]::TryParse($($version.Split('_')[-1]), [ref] $outNumber)) {
+            $minorVersions += $outNumber
+        }
+    }
+    # Sorting and getting the last one
+    $targetMinorVersions = ($minorVersions | Sort-Object)[-1]
+
+    # In order to get rid of error messages (we know we will have them), force ErrorAction to SilentlyContinue
+    $errorActionOldValue = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+
     # Install latest PostgreSQL
     # Starting from number 9 and going down, check if the installer is available. If yes, break the loop.
     # If an installer with $targetMinorVersions is not to be found, the $targetMinorVersions will be decreased by 1

--- a/images/windows/scripts/tests/Databases.Tests.ps1
+++ b/images/windows/scripts/tests/Databases.Tests.ps1
@@ -72,8 +72,8 @@ Describe "PostgreSQL" {
     }
 
     Context "PostgreSQL version" {
-        It "PostgreSQL version should correspond to the version in the toolset" {
-            $toolsetVersion = (Get-ToolsetContent).postgresql.version
+        It "PostgreSQL version should correspond to the Major version in the toolset" {
+            $toolsetVersion = (Get-ToolsetContent).postgresql.version.Split(".")[0]
             # Client version
             (& $env:PGBIN\psql --version).split()[-1] | Should -BeLike "$toolsetVersion*"
             # Server version

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -469,7 +469,7 @@
         "version": "8.3"
     },
     "llvm": {
-        "version": "16"
+        "version": "18"
     },
     "postgresql": {
         "version": "14.12.1",

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -472,7 +472,7 @@
         "version": "16"
     },
     "postgresql": {
-        "version": "14",
+        "version": "14.12.1",
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
     },
     "kotlin": {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -373,7 +373,7 @@
         "version": "8.3"
     },
     "postgresql": {
-        "version": "14",
+        "version": "14.12.1",
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
     },
     "kotlin": {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -367,7 +367,7 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "16"
+        "version": "18"
     },
     "php": {
         "version": "8.3"


### PR DESCRIPTION
# Description
This PR:
1. temporarily pins PostgreSQL version to `14.12.1` on Windows.
2. Update LLVM to 18* on Windows

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
