### PR TITLE
[Ubuntu] disable apparmor

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -68,3 +68,7 @@ fi
 if is_ubuntu22; then
     sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
 fi
+
+# Disable apparmor
+systemctl is-active --quiet apparmor.service && systemctl stop apparmor.service
+systemctl disable apparmor.service

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -6,3 +6,9 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
         $freeSpace | Should -BeGreaterOrEqual 17GB
     }
 }
+
+Describe "Apparmor is disabled" {
+    It "Apparmor is disabled" {
+        systemctl is-active apparmor | Should -Be "inactive"
+    }
+}


### PR DESCRIPTION
# Description

Strictly speaking we do not need any means of 3rd party hardening on runners (selinux/apparmor) so lets just disable it so it does not change system's behaviour.

#### Related issue: https://github.com/actions/runner-images/issues/10015

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
