### PR TITLE
[ubuntu 24] added rlang.sh  dependency for gfortran

### DIFF
--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -305,6 +305,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",
+      "${path.root}/../scripts/build/install-rlang.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",
       "${path.root}/../scripts/build/install-julia.sh",


### PR DESCRIPTION
during the issue it was observed gfortran alias not available only on ubuntu 24.04 , hence  added rlang.sh to resolve the issue. [10025](https://github.com/actions/runner-images/issues/10025)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
