### PR TITLE
Configure dependabot to keep self used GHA up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily" 
+  target-branch: "main"


### PR DESCRIPTION
# Description

Some actions based on Node 16 are deprecated.

See 
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
