### PR TITLE
[windows] Remove Visual Studio 2019 AzCopy component and fix signature

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -250,7 +250,7 @@
         "subversion" : "16",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "C2048FB509F1C37A8C3E9EC6648118458AA01780",
+        "signature": "F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -268,7 +268,6 @@
             "Microsoft.VisualStudio.Component.AspNet45",
             "Microsoft.VisualStudio.Component.Azure.Kubernetes.Tools",
             "Microsoft.VisualStudio.Component.Azure.ServiceFabric.Tools",
-            "Microsoft.VisualStudio.Component.Azure.Storage.AzCopy",
             "Microsoft.VisualStudio.Component.Debugger.JustInTime",
             "Microsoft.VisualStudio.Component.DslTools",
             "Microsoft.VisualStudio.Component.EntityFramework",


### PR DESCRIPTION
# Description
This PR:
1. Temporarily removes `Microsoft.VisualStudio.Component.Azure.Storage.AzCopy` Visual Studio 2019 workload. There is an ongoing issue about package being unavailable https://developercommunity.visualstudio.com/t/PackageId:MicrosoftAzureStorageAzCopy/10679936
2. Updates Visual Studio `16.11.37` signature

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
