### PR TITLE
[Ubuntu20] Pin public_suffix gem to 5.1.1

### DIFF
--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -11,7 +11,7 @@ source $HELPER_SCRIPTS/install.sh
 apt-get install ruby-full
 
 # temporary fix for fastlane installation https://github.com/sporkmonger/addressable/issues/541
-if isUbuntu20 ; then
+if is_ubuntu20; then
     gem install public_suffix -v 5.1.1
 fi
 

--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -10,6 +10,11 @@ source $HELPER_SCRIPTS/install.sh
 
 apt-get install ruby-full
 
+# temporary fix for fastlane installation https://github.com/sporkmonger/addressable/issues/541
+if isUbuntu20 ; then
+    gem install public_suffix -v 5.1.1
+fi
+
 # Install ruby gems from toolset
 gems_to_install=$(get_toolset_value ".rubygems[] .name")
 if [[ -n "$gems_to_install" ]]; then


### PR DESCRIPTION
# Description
This PR pins `public_suffix` gem version to 5.1.1 for ubuntu-20.04

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
