### PR TITLE
[Ubuntu] Update Shell Script to Verify Azure CLI Availability

### DIFF
--- a/images/ubuntu/scripts/build/install-azure-cli.sh
+++ b/images/ubuntu/scripts/build/install-azure-cli.sh
@@ -12,4 +12,11 @@ echo "azure-cli https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-lin
 rm -f /etc/apt/sources.list.d/azure-cli.list
 rm -f /etc/apt/sources.list.d/azure-cli.list.save
 
+echo "Warmup 'az'"
+az --help > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Command 'az --help' failed"
+    exit 1
+fi
+
 invoke_tests "CLI.Tools" "Azure CLI"


### PR DESCRIPTION
# Description

This PR ensures that Azure CLI ('az') is installed and operational by attempting to retrieve its help information. If the command fails, it provides an error message and exits with a non-zero status, signaling a failure in Azure CLI availability.

#### Related issue:
[10110](https://github.com/actions/runner-images/issues/10110)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
