### PR TITLE
[windows] Fix Cloud-Foundry signature for windows

### DIFF
--- a/images/windows/scripts/build/Install-CloudFoundryCli.ps1
+++ b/images/windows/scripts/build/Install-CloudFoundryCli.ps1
@@ -20,7 +20,7 @@ Expand-7ZipArchive -Path $cloudFoundryArchPath -DestinationPath $cloudFoundryCli
 Add-MachinePathItem $cloudFoundryCliPath
 
 # Validate cf signature
-$cloudFoundrySignatureThumbprint = "4C69EDD13930ED01B83DD1D17B09C434DC1F2177"
+$cloudFoundrySignatureThumbprint = "2C6B2F1562698503A6E4A25F2DF058E12E23A190"
 Test-FileSignature -Path "$cloudFoundryCliPath\cf.exe" -ExpectedThumbprint $cloudFoundrySignatureThumbprint
 
 Invoke-PesterTests -TestFile "CLI.Tools" -TestName "CloudFoundry CLI"


### PR DESCRIPTION
# Description

 Build Failed because of Cloud-Foundry Signature  :  [Windows-2019](https://github.visualstudio.com/runner-images/_build/results?buildId=136231&view=results)

This PR Updates Cloud-Foundry signature for successful build.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
