### PR TITLE
[Ubuntu] Fix Openshift CLI version for ubuntu 20

### DIFF
--- a/images/ubuntu/scripts/build/install-oc-cli.sh
+++ b/images/ubuntu/scripts/build/install-oc-cli.sh
@@ -5,10 +5,20 @@
 ################################################################################
 
 # Source the helpers for use with the script
+source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
-# Install the oc CLI
-archive_path=$(download_with_retry "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz")
+if is_ubuntu20; then
+    toolset_version=$(get_toolset_value '.ocCli.version')
+    download_url="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$toolset_version/openshift-client-linux-$toolset_version.tar.gz"
+else 
+
+    # Install the oc CLI
+    download_url="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"   
+fi
+
+archive_path=$(download_with_retry "$download_url")
+
 tar xzf "$archive_path" -C "/usr/local/bin" oc
 
 invoke_tests "CLI.Tools" "OC CLI"

--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -378,5 +378,9 @@
     "aliyunCli": {
         "version": "3.0.174",
         "sha256": "0c51028a7a32fc02c8de855f73e273556f957115eb5624565738f9b9f83a50ba"
-    }
+    },
+    "ocCli": {
+        "version": "4.15.19"
+    } 
+      
 }


### PR DESCRIPTION
# Description

 Ubuntu 20 build failed due to OC CLI version not compatible with GLIBC 2.32 version .

 This PR will pin OC CLI tool version on ubuntu 20 for successful build.

#### Related issue:
[10148](https://github.com/actions/runner-images/issues/10148)
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
