### PR TITLE
Allow array of signatures for Visual Studio

### DIFF
--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -29,7 +29,7 @@ Function Install-VisualStudio {
         [Parameter(Mandatory)] [String] $Channel,
         [Parameter(Mandatory)] [String[]] $RequiredComponents,
         [String] $ExtraArgs = "",
-        [Parameter(Mandatory)] [String] $SignatureThumbprint
+        [Parameter(Mandatory)] [String[]] $SignatureThumbprint
     )
 
     $bootstrapperUrl = "https://aka.ms/vs/${Version}/${Channel}/vs_${Edition}.exe"

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -177,7 +177,10 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "C2048FB509F1C37A8C3E9EC6648118458AA01780",
+        "signature": [
+            "F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE",
+            "C2048FB509F1C37A8C3E9EC6648118458AA01780"
+        ],
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",


### PR DESCRIPTION
# Description
It appears that there are two common Authenticode certificates that are being used to sign the Visual Studio installer.  This can be seen in the following Thumbprints and commits:

- C2048FB509F1C37A8C3E9EC6648118458AA01780 from commits 2a7b21b, 82a37d1
-  F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE from commit 3afd153

This PR updates the toolset json and helper VS installer script to allow for an array of signatures to prevent the need to continually update back and forth between the two Thumbprints.

#### Related issue: https://github.com/actions/runner-images/issues/10201

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)  [NA]
- [x] Documentation is updated (if applicable) [NA]
- [x] Changes are tested and related VM images are successfully generated [Tested in org's local build environment]
