### PR TITLE
[macOS] Update Xcode default to 15.2 for macos13

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "15.0.1",
+        "default": "15.2",
         "x64": {
             "versions": [
                 { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},


### PR DESCRIPTION
# Description

Update default Xcode to 15.2 on macOS 13 Ventura

#### Related issue:
[10120](https://github.com/actions/runner-images/issues/10120)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
