### PR TITLE
Switch null builder to the SSH password auth

### DIFF
--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -53,6 +53,11 @@ variable "vm_password" {
   sensitive = true
 }
 
+variable "vm_key_file" {
+  type      = string
+  default   = ""
+}
+
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -96,7 +101,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_key_file}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -53,11 +53,6 @@ variable "vm_password" {
   sensitive = true
 }
 
-variable "vm_key_file" {
-  type      = string
-  default   = ""
-}
-
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -101,7 +96,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_key_file}"
+  ssh_password = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -53,6 +53,11 @@ variable "vm_password" {
   sensitive = true
 }
 
+variable "vm_key_file" {
+  type      = string
+  default   = ""
+}
+
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -96,7 +101,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_key_file}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -53,11 +53,6 @@ variable "vm_password" {
   sensitive = true
 }
 
-variable "vm_key_file" {
-  type      = string
-  default   = ""
-}
-
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -101,7 +96,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_key_file}"
+  ssh_password = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -53,6 +53,11 @@ variable "vm_password" {
   sensitive = true
 }
 
+variable "vm_key_file" {
+  type      = string
+  default   = ""
+}
+
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -97,7 +102,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_key_file}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -53,11 +53,6 @@ variable "vm_password" {
   sensitive = true
 }
 
-variable "vm_key_file" {
-  type      = string
-  default   = ""
-}
-
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -102,7 +97,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_key_file}"
+  ssh_password = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -53,6 +53,11 @@ variable "vm_password" {
   sensitive = true
 }
 
+variable "vm_key_file" {
+  type      = string
+  default   = ""
+}
+
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -96,7 +101,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_key_file}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -53,11 +53,6 @@ variable "vm_password" {
   sensitive = true
 }
 
-variable "vm_key_file" {
-  type      = string
-  default   = ""
-}
-
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -101,7 +96,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_key_file}"
+  ssh_password = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -48,11 +48,6 @@ variable "vm_username" {
   sensitive = true
 }
 
-variable "vm_password" {
-  type      = string
-  sensitive = true
-}
-
 variable "vm_key_file" {
   type      = string
   default   = ""
@@ -102,7 +97,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_key_file}"
+  ssh_password = "${var.vm_password}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -53,6 +53,11 @@ variable "vm_password" {
   sensitive = true
 }
 
+variable "vm_key_file" {
+  type      = string
+  default   = ""
+}
+
 variable "github_api_pat" {
   type    = string
   default = ""
@@ -97,7 +102,7 @@ source "null" "template" {
   ssh_host = "${var.source_vm_name}"
   ssh_port = "${var.source_vm_port}"
   ssh_username = "${var.vm_username}"
-  ssh_private_key_file = "${var.vm_password}"
+  ssh_private_key_file = "${var.vm_key_file}"
   ssh_proxy_host = "${var.socks_proxy}"
 }
 

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -48,9 +48,9 @@ variable "vm_username" {
   sensitive = true
 }
 
-variable "vm_key_file" {
+variable "vm_password" {
   type      = string
-  default   = ""
+  sensitive = true
 }
 
 variable "github_api_pat" {


### PR DESCRIPTION
# Description

We encountered some issues with the SSH RSA key auth.  After VM is rebooted Packer fails to reconnect to it. Password auth works just fine.

We decided to not spend much time troubleshooting it because Packer scripts still require VM admin password in some places so we have to provide it anyway. Once we get rid of those places we can switch back to the RSA key auth.


<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
