### PR TITLE
[macOS] Add parallels desktop extension to macOS13 and macOS14 intel machines

### DIFF
--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -11,7 +11,8 @@ close_finder_window
 
 # Remove Parallels Desktop
 # https://github.com/actions/runner-images/issues/6105
-if is_Monterey; then
+# https://github.com/actions/runner-images/issues/10143
+if is_Monterey || is_SonomaX64 || is_VenturaX64; then
     brew uninstall parallels
 fi
 

--- a/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -290,7 +290,13 @@ if ($os.IsMonterey) {
     $miscellaneous.AddToolVersion("Zlib", $(Get-ZlibVersion))
 }
 
-if ($os.IsMonterey) {
+if ($os.IsSonomaX64 -or $os.IsVenturaX64) {
+    $miscellaneous = $installedSoftware.AddHeader("Miscellaneous")
+}
+if ($os.IsMonterey -or $os.IsSonomaX64 -or $os.IsVenturaX64) {
+
+    Write-Host "Adding environment variables for parallels"
+
     $miscellaneousEnv = $miscellaneous.AddHeader("Environment variables")
     $miscellaneousEnv.AddTable($(Build-MiscellaneousEnvironmentTable))
 

--- a/images/macos/scripts/helpers/confirm-identified-developers-macos13.scpt
+++ b/images/macos/scripts/helpers/confirm-identified-developers-macos13.scpt
@@ -1,0 +1,34 @@
+# This AppleScript clicks "Allow" for "System Software from developer "Parallels International GmbH"
+# Steps:
+# - Open System Settings -> Privacy & Security
+# - Click 'Allow' for 'System Software from developer "Parallels International GmbH'
+# - Enter password for runner
+
+on run argv
+  set userpassword to item 1 of argv
+
+  tell application "System Settings"
+    activate
+    delay 5
+  end tell
+
+  tell application "System Events"
+    tell process "System Settings"
+      set frontmost to true
+      repeat until exists window 1
+        delay 2
+      end repeat
+
+      tell splitter group 1 of group 1 of window 1
+          select row 20 of outline 1 of scroll area 1 of group 1
+          delay 5
+          click UI Element 2 of group 4 of scroll area 1 of group 1 of group 2
+          delay 5
+          keystroke userpassword
+          delay 5
+          keystroke return
+          delay 5
+      end tell
+    end tell
+  end tell
+end run

--- a/images/macos/scripts/helpers/confirm-identified-developers-macos14.scpt
+++ b/images/macos/scripts/helpers/confirm-identified-developers-macos14.scpt
@@ -1,0 +1,34 @@
+# This AppleScript clicks "Allow" for "System Software from developer "Parallels International GmbH"
+# Steps:
+# - Open System Settings -> Privacy & Security
+# - Click 'Allow' for 'System Software from developer "Parallels International GmbH'
+# - Enter password for runner
+
+on run argv
+  set userpassword to item 1 of argv
+
+  tell application "System Settings"
+    activate
+    delay 5
+  end tell
+
+  tell application "System Events"
+    tell process "System Settings"
+      set frontmost to true
+      repeat until exists window 1
+        delay 2
+      end repeat
+
+      tell splitter group 1 of group 1 of window 1
+          select row 18 of outline 1 of scroll area 1 of group 1
+          delay 5
+          click UI Element 2 of group 5 of scroll area 1 of group 1 of group 2
+          delay 5
+          keystroke userpassword
+          delay 5
+          keystroke return
+          delay 5
+      end tell
+    end tell
+  end tell
+end run

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -157,7 +157,7 @@ build {
       "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
       "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/confirm-identified-developers-macos13.scpt ~/utils",
       "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
       "mv ${local.image_folder}/helpers/utils.sh ~/utils",
       "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -157,7 +157,7 @@ build {
       "mv ${local.image_folder}/docs-gen ${local.image_folder}/software-report",
       "mv ${local.image_folder}/xamarin-selector ${local.image_folder}/assets",
       "mkdir ~/utils",
-      "mv ${local.image_folder}/helpers/confirm-identified-developers.scpt ~/utils",
+      "mv ${local.image_folder}/helpers/confirm-identified-developers-macos14.scpt ~/utils",
       "mv ${local.image_folder}/helpers/invoke-tests.sh ~/utils",
       "mv ${local.image_folder}/helpers/utils.sh ~/utils",
       "mv ${local.image_folder}/helpers/xamarin-utils.sh ~/utils"

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -82,7 +82,7 @@
             "xcodes"
         ],
         "cask_packages": [
-            ""
+            "parallels"
         ]
     },
     "gcc": {

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -85,7 +85,7 @@
             "xcodes"
         ],
         "cask_packages": [
-            ""
+            "parallels"
         ]
     },
     "gcc": {


### PR DESCRIPTION
# Description

Add Parallels Desktop extension:

1. Install Parallels
2. Approve the Parallels Kernel Extension
3. Reboot
4. Uninstall Parallels

**Related issue:**

[ #10143 ](https://github.com/actions/runner-images/issues/10143)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
