### PR TITLE
[macOS] Update Xcode default to 15.4 for macos-14

### DIFF
--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "15.0.1",
+        "default": "15.4",
         "x64": {
             "versions": [
                 { "link": "16.0", "version": "16.0.0-Beta.2+16A5171r", "install_runtimes": "false", "sha256": "86b4fd563d80c997887d37a528f69161f82987932b5ebe6119ad5dd548352ad3"},


### PR DESCRIPTION
# Description

Update default Xcode to 15.4 on macOS 14 Sonoma

#### Related issue:

[ #10121 ](https://github.com/actions/runner-images/issues/10121)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
