### PR TITLE
[macOS] Fix Xcode-16 naming on macOS-14

### DIFF
--- a/images/macos/scripts/build/install-powershell.sh
+++ b/images/macos/scripts/build/install-powershell.sh
@@ -10,6 +10,8 @@ echo Installing PowerShell...
 arch=$(get_arch)
 
 metadata_json_path=$(download_with_retry "https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json")
+echo $metadata_json_path
+cat $metadata_json_path
 pwshVersionToolset=$(get_toolset_value '.pwsh.version')
 pwshVersions=$(jq -r '.LTSReleaseTag[]' $metadata_json_path)
 

--- a/images/macos/scripts/build/install-powershell.sh
+++ b/images/macos/scripts/build/install-powershell.sh
@@ -10,8 +10,6 @@ echo Installing PowerShell...
 arch=$(get_arch)
 
 metadata_json_path=$(download_with_retry "https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json")
-echo $metadata_json_path
-cat $metadata_json_path
 pwshVersionToolset=$(get_toolset_value '.pwsh.version')
 pwshVersions=$(jq -r '.LTSReleaseTag[]' $metadata_json_path)
 

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -3,7 +3,7 @@
         "default": "15.0.1",
         "x64": {
             "versions": [
-                { "link": "16.0", "version": "16.0.0-Beta.2+16A5171r", "install_runtimes": "false", "sha256": "86b4fd563d80c997887d37a528f69161f82987932b5ebe6119ad5dd548352ad3"},
+                { "link": "16_beta_2", "version": "16.0.0-Beta.2+16A5171r", "symlinks": ["16.0"], "install_runtimes": "false", "sha256": "86b4fd563d80c997887d37a528f69161f82987932b5ebe6119ad5dd548352ad3"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
                 { "link": "15.3", "version": "15.3.0+15E204a", "install_runtimes": "true", "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234"},
                 { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
@@ -14,7 +14,7 @@
         },
         "arm64":{
             "versions": [
-                { "link": "16.0", "version": "16.0.0-Beta.2+16A5171r", "install_runtimes": "true", "sha256": "86b4fd563d80c997887d37a528f69161f82987932b5ebe6119ad5dd548352ad3"},
+                { "link": "16_beta_2", "version": "16.0.0-Beta.2+16A5171r", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "86b4fd563d80c997887d37a528f69161f82987932b5ebe6119ad5dd548352ad3"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
                 { "link": "15.3", "version": "15.3.0+15E204a", "install_runtimes": "true", "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234"},
                 { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},


### PR DESCRIPTION
# Description
This PR updates `link` property for Xcode 16 beta to reflect Apple download links. This help with automating XCode download. We use `symlinks` property to keep files available under `16.0` location

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
