### PR TITLE
Add allowed_inbound_ip_addresses packer option to build-image.ps1

### DIFF
--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -10,7 +10,8 @@ param(
     [String] [Parameter (Mandatory=$true)] $TenantId,
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkName,
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkRG,
-    [String] [Parameter (Mandatory=$false)] $VirtualNetworkSubnet
+    [String] [Parameter (Mandatory=$false)] $VirtualNetworkSubnet,
+    [String] [Parameter (Mandatory=$false)] $AllowedInboundIpAddresses = "[]"
 )
 
 if (-not (Test-Path $TemplatePath))
@@ -54,6 +55,7 @@ packer build    -var "client_id=$ClientId" `
                 -var "virtual_network_name=$VirtualNetworkName" `
                 -var "virtual_network_resource_group_name=$VirtualNetworkRG" `
                 -var "virtual_network_subnet_name=$VirtualNetworkSubnet" `
+                -var "allowed_inbound_ip_addresses=$($AllowedInboundIpAddresses)" `
                 -color=false `
                 $TemplatePath `
         | Where-Object {


### PR DESCRIPTION
# Description
This PR adds packer's `allowed_inbound_ip_addresses` option usage to `build-image.ps1` script.
Enables build scenario without `virtual_network_name`.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
