### PR TITLE
[Windows] Pin the version of gitversion package for Windows 2019 image

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -424,7 +424,7 @@
             { "name": "aria2" },
             { "name": "azcopy10" },
             { "name": "Bicep" },
-            { "name": "gitversion.portable" },
+            { "name": "gitversion.portable", "args": [ "--version", "5.12.0"] },
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },


### PR DESCRIPTION
# Description

This PR will be the Temporary fix for gitversion build failure of windows 2019 by pin the previous version 5.12.0.

#### Related issue:
[10331](https://github.com/actions/runner-images/issues/10331)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [] Changes are tested and related VM images are successfully generated
