### PR TITLE
[Ubuntu] Make brew version check consistent

### DIFF
--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -131,7 +131,7 @@ function Get-LernaVersion {
 }
 
 function Get-HomebrewVersion {
-    $result = Get-CommandResult "/home/linuxbrew/.linuxbrew/bin/brew -v"
+    $result = Get-CommandResult "/home/linuxbrew/.linuxbrew/bin/brew --version"
     $result.Output -match "Homebrew (?<version>\d+\.\d+\.\d+)" | Out-Null
     return $Matches.version
 }


### PR DESCRIPTION
`Tools.Tests.ps1` checks the version of `brew` with `--version` argument.

```powershell
Describe "Homebrew" {
    It "homebrew" {
        "/home/linuxbrew/.linuxbrew/bin/brew --version" | Should -ReturnZeroExitCode
    }
}
```

`SoftwareReport.Common.psm1` checks it with `-v` argument.

```powershell
    function Get-HomebrewVersion {
        $result = Get-CommandResult "/home/linuxbrew/.linuxbrew/bin/brew -v"
        $result.Output -match "Homebrew (?<version>\d+\.\d+\.\d+)" | Out-Null
        return $Matches.version
    }
```

Generally, `--version` and `-v` are equivalent. But a recent bug in `brew` makes `-v` returns the output of `brew help`.

https://github.com/Homebrew/brew/pull/17903

It's best to maintain consistency in version checks and explicitly use `--version` in both places.