### PR TITLE
Set EDGEDRIVER_VERSION environment variable

### DIFF
--- a/images/macos/scripts/build/install-edge.sh
+++ b/images/macos/scripts/build/install-edge.sh
@@ -34,6 +34,7 @@ unzip -qq $edge_driver_archive_path -d $EDGE_DRIVER_DIR
 ln -s $EDGE_DRIVER_DIR/msedgedriver /usr/local/bin/msedgedriver
 
 echo "export EDGEWEBDRIVER=${EDGE_DRIVER_DIR}" >> ${HOME}/.bashrc
+echo "export EDGEDRIVER_VERSION=${edge_driver_latest_version}" >> ${HOME}/.bashrc
 
 # Configure Edge Updater to prevent auto update
 # https://learn.microsoft.com/en-us/deployedge/edge-learnmore-edgeupdater-for-macos

--- a/images/macos/scripts/docs-gen/SoftwareReport.Browsers.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Browsers.psm1
@@ -101,6 +101,10 @@ function Build-BrowserWebdriversEnvironmentTable {
             "Value" = $env:EDGEWEBDRIVER
         },
         @{
+            "Name" = "EDGEDRIVER_VERSION"
+            "Value" = $env:EDGEDRIVER_VERSION
+        },
+        @{
             "Name" = "GECKOWEBDRIVER"
             "Value" = $env:GECKOWEBDRIVER
         }

--- a/images/ubuntu/scripts/build/install-microsoft-edge.sh
+++ b/images/ubuntu/scripts/build/install-microsoft-edge.sh
@@ -46,5 +46,6 @@ chmod +x $edgedriver_bin
 ln -s $edgedriver_bin /usr/bin
 
 set_etc_environment_variable "EDGEWEBDRIVER" "${EDGEDRIVER_DIR}"
+set_etc_environment_variable "EDGEDRIVER_VERSION" "${edgedriver_latest_version}"
 
 invoke_tests "Browsers" "Edge"

--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Browsers.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Browsers.psm1
@@ -49,6 +49,10 @@ function Build-BrowserWebdriversEnvironmentTable {
             "Value" = $env:EDGEWEBDRIVER
         },
         [PSCustomObject] @{
+            "Name"  = "EDGEDRIVER_VERSION"
+            "Value" = $env:EDGEDRIVER_VERSION
+        },
+        [PSCustomObject] @{
             "Name"  = "GECKOWEBDRIVER"
             "Value" = $env:GECKOWEBDRIVER
         },

--- a/images/windows/scripts/build/Install-EdgeDriver.ps1
+++ b/images/windows/scripts/build/Install-EdgeDriver.ps1
@@ -32,6 +32,7 @@ Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedThumbprint 
 
 Write-Host "Setting the environment variables..."
 [Environment]::SetEnvironmentVariable("EdgeWebDriver", $EdgeDriverPath, "Machine")
+[Environment]::SetEnvironmentVariable("EDGEDRIVER_VERSION", $latestVersion, "Machine")
 Add-MachinePathItem "$edgeDriverPath\"
 
 Invoke-PesterTests -TestFile "Browsers" -TestName "Edge"

--- a/images/windows/scripts/docs-gen/SoftwareReport.Browsers.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Browsers.psm1
@@ -84,6 +84,10 @@ function Build-BrowserWebdriversEnvironmentTable {
             "Value" = $env:EDGEWEBDRIVER
         },
         @{
+            "Name" = "EDGEDRIVER_VERSION"
+            "Value" = $env:EDGEDRIVER_VERSION
+        },
+        @{
             "Name" = "GECKOWEBDRIVER"
             "Value" = $env:GECKOWEBDRIVER
         },


### PR DESCRIPTION
# Description

Set the EDGEDRIVER_VERSION environment variable. This environment variable is used by npm's edgedriver: https://github.com/webdriverio-community/node-edgedriver/blob/7b2b44946f422b86e4c937d277f412a380394a1c/src/install.ts#L24

#### Related issue:
#10380


## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
