### PR TITLE
[macOS] Unlock Cargo crate dependencies due to a bug

### DIFF
--- a/images/macos/scripts/build/install-nvm.sh
+++ b/images/macos/scripts/build/install-nvm.sh
@@ -7,7 +7,16 @@
 source ~/utils/utils.sh
 
 [[ -n $API_PAT ]] && authString=(-H "Authorization: token ${API_PAT}")
-nvm_version=$(curl "${authString[@]}" -fsSL https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+
+nvm_version=$(get_toolset_value '.node.nvm_installer')
+if [[ -z $nvm_version || "$nvm_version" == "latest" ]]; then
+    nvm_version=$(curl "${authString[@]}" -fsSL https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+fi
+
+if [[ $nvm_version != "v*" ]]; then
+    nvm_version="v${nvm_version}"
+fi
+
 nvm_installer_path=$(download_with_retry "https://raw.githubusercontent.com/nvm-sh/nvm/$nvm_version/install.sh")
 
 if bash $nvm_installer_path; then

--- a/images/macos/scripts/build/install-rust.sh
+++ b/images/macos/scripts/build/install-rust.sh
@@ -19,7 +19,7 @@ echo "Install common tools..."
 rustup component add rustfmt clippy
 
 if is_BigSur || is_Monterey; then
-    cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
+    cargo install bindgen-cli cbindgen cargo-audit cargo-outdated
 fi
 
 echo "Cleanup Cargo registry cached data..."

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -339,6 +339,7 @@
     },
     "node": {
         "default": "18",
+        "nvm_installer": "0.39.7",
         "nvm_versions": [
             "16",
             "18",


### PR DESCRIPTION
# Description

It was firstly introduced here: https://github.com/rustsec/rustsec/issues/1217. Still blocks our image generation process.

UPD: This PR also includes a workaround for the issue with the NVM shell script.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
