### PR TITLE
Updating thumbprint for both Azcli and geckodriver

### DIFF
--- a/images/windows/scripts/build/Install-AzureCli.ps1
+++ b/images/windows/scripts/build/Install-AzureCli.ps1
@@ -15,7 +15,7 @@ New-Item -ItemType 'Directory' -Path $azureCliExtensionPath | Out-Null
 
 Install-Binary -Type MSI `
     -Url 'https://aka.ms/installazurecliwindowsx64' `
-    -ExpectedSignature 'F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE'
+    -ExpectedSignature 'C2048FB509F1C37A8C3E9EC6648118458AA01780'
 
 Update-Environment
 

--- a/images/windows/scripts/build/Install-Firefox.ps1
+++ b/images/windows/scripts/build/Install-Firefox.ps1
@@ -53,7 +53,7 @@ Write-Host "Expand Gecko WebDriver archive..."
 Expand-7ZipArchive -Path $geckoDriverArchPath -DestinationPath $geckoDriverPath
 
 # Validate Gecko WebDriver signature
-$geckoDriverSignatureThumbprint = "1326B39C3D5D2CA012F66FB439026F7B59CB1974"
+$geckoDriverSignatureThumbprint = "40890F2FE1ACAE18072FA7F3C0AE456AACC8570D"
 Test-FileSignature -Path "$geckoDriverPath/geckodriver.exe" -ExpectedThumbprint $geckoDriverSignatureThumbprint
 
 Write-Host "Setting the environment variables..."


### PR DESCRIPTION
# Description
Image generation failed due to Azcli and geckodriver signature, this PR will update the new Signature.
#### Related issue:
https://github.com/actions/runner-images/issues/10403
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
