### PR TITLE
[Windows] Updating AzurecosmoDB checksum and Removing m2repositry in AndriodSDK

### DIFF
--- a/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
+++ b/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
@@ -5,6 +5,6 @@
 
 Install-Binary -Type MSI `
     -Url "https://aka.ms/cosmosdb-emulator" `
-    -ExpectedSHA256Sum "34D8E1968A868CEBBC31D1484C473FC61D3174D6C3B9AB71D4CE94F6618D7670"
+    -ExpectedSHA256Sum "D21A0476B7F3439319BE6A1060935E7C865FEFA87C47943C9A6D595137703F49"
 
 Invoke-PesterTests -TestFile "Tools" -TestName "Azure Cosmos DB Emulator"

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -138,11 +138,7 @@
         "extras": [
             "android;m2repository",
             "google;m2repository",
-            "google;google_play_services",
-            "m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2",
-            "m2repository;com;android;support;constraint;constraint-layout-solver;1.0.1",
-            "m2repository;com;android;support;constraint;constraint-layout;1.0.2",
-            "m2repository;com;android;support;constraint;constraint-layout;1.0.1"
+            "google;google_play_services"
         ],
         "addons": [
             "addon-google_apis-google-24",


### PR DESCRIPTION
# Description
Image generation failed due to checksum issues with Azure Cosmos DB and problems with the m2repository in the Android SDK. This PR addresses the checksum issue and removes the m2repository from the Android SDK after the image generation passes successfully.
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
