### PR TITLE
[Windows] fix gitversion.portable version issue for Windows 2019 image

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -420,7 +420,7 @@
             { "name": "aria2" },
             { "name": "azcopy10" },
             { "name": "Bicep" },
-            { "name": "gitversion.portable", "args": [ "--version", "5.12.0"] },
+            { "name": "gitversion.portable"},
             { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },


### PR DESCRIPTION
# Description

This PR will be the fix for gitversion build failure of windows 2019 with latest version of gitversion.portable.

#### Related issue:
[10331](https://github.com/actions/runner-images/issues/10331)
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
