### PR TITLE
Add Windows SDK 26100 to toolset-2022.json

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -237,6 +237,7 @@
             "Microsoft.VisualStudio.Component.Windows10SDK.20348",
             "Microsoft.VisualStudio.Component.Windows11SDK.22000",
             "Microsoft.VisualStudio.Component.Windows11SDK.22621",
+            "Microsoft.VisualStudio.Component.Windows11SDK.26100",
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices",
             "Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools",


### PR DESCRIPTION
# Description
Includes latest Windows 11 SDK 26100 (which was released in May 2024)

**For new tools, please provide total size and installation time.**

#### Related issue: https://github.com/actions/runner-images/issues/10349

Not sure if
- this should also be added to Windows Server 2019
- we should update the Windows Driver Kit as part of this
  - unlike the Windows 11 SDK, it doesn't look like multiple versions of the WDK can be installed at the same time


## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
