### PR TITLE
Use API PAT for downloading actions/cache

### DIFF
--- a/images/macos/scripts/build/install-actions-cache.sh
+++ b/images/macos/scripts/build/install-actions-cache.sh
@@ -12,7 +12,7 @@ if [[ ! -d $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE ]]; then
     mkdir -p $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
 fi
 
-download_url=$(resolve_github_release_asset_url "actions/action-versions" "contains(\"action-versions.tar.gz\")" "latest")
+download_url=$(resolve_github_release_asset_url "actions/action-versions" "contains(\"action-versions.tar.gz\")" "latest" "$API_PAT")
 echo "Downloading action-versions $download_url"
 archive_path=$(download_with_retry $download_url)
 tar -xzf $archive_path -C $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE


### PR DESCRIPTION
# Description

Pass API PAT to make authenticated calls to GitHub APIs with the hope to resolve `403` error which is likely to be caused by throttling.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
