### PR TITLE
[macOS] Adding  Xcode 16.0 Beta 5 for macOS-14 back to the repository

### DIFF
--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -4,6 +4,7 @@
         "x64": {
             "versions": [
                 { "link": "16.1_beta", "version": "16.1.0-Beta+16B5001e", "symlinks": ["16.1"], "install_runtimes": "true", "sha256": "8848aacb32bdc0abbd7e14e4b712e07c98f4b6e5a23a8d77db03ab21dcb3c777"},
+                { "link": "16_beta_5", "version": "16.0.0-Beta.5+16A5221g", "symlinks": ["16.0"], "install_runtimes": "false", "sha256": "00b44d41fcfcacb613575871ceff5c1c07de99b7501f8c48170af002763cd517"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
                 { "link": "15.3", "version": "15.3.0+15E204a", "install_runtimes": "true", "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234"},
                 { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
@@ -15,6 +16,7 @@
         "arm64":{
             "versions": [
                 { "link": "16.1_beta", "version": "16.1.0-Beta+16B5001e", "symlinks": ["16.1"], "install_runtimes": "true", "sha256": "8848aacb32bdc0abbd7e14e4b712e07c98f4b6e5a23a8d77db03ab21dcb3c777"},
+                { "link": "16_beta_5", "version": "16.0.0-Beta.5+16A5221g", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "00b44d41fcfcacb613575871ceff5c1c07de99b7501f8c48170af002763cd517"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
                 { "link": "15.3", "version": "15.3.0+15E204a", "install_runtimes": "true", "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234"},
                 { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},


### PR DESCRIPTION
Adding Xcode 16.0 Beta 5 to macOS 14 so that we can keep track of both Xcode 16.1 and 16.0 beta 5 versions.

#### Related issue:

https://github.com/actions/runner-images/issues/10464

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
