### PR TITLE
[Windows] Fix WDK image generation failure for win-22

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -260,6 +260,7 @@
             "Microsoft.VisualStudio.Workload.VisualStudioExtension",
             "Component.MDD.Linux",
             "Component.MDD.Linux.GCC.arm",
+            "Component.Microsoft.Windows.DriverKit",
             "wasm.tools"
         ],
         "vsix": [


### PR DESCRIPTION
# Description
This PR will fix the WDK image generation failure for win-22. The issue was caused by the missing Visual Studio Component for WDK. This PR adds the Visual Studio Component  to the image, which will fix the WDK image generation failure for win-22.



#### Related issue:
[10444](https://github.com/actions/runner-images/issues/10444)
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
