### PR TITLE
[Windows] Fix Visual Studio signature issue for windows 2022

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -177,7 +177,7 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "C2048FB509F1C37A8C3E9EC6648118458AA01780",
+        "signature": "F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",


### PR DESCRIPTION
1.Image generation failed due to visual studio cli signature, this PR will update the new Signature.
2.Windows 2022 image generations will be successful.

#### Related issue:
https://github.com/actions/runner-images/issues/10505

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
