### PR TITLE
[Windows] updated azure cli signature 

### DIFF
--- a/images/windows/scripts/build/Install-AzureCli.ps1
+++ b/images/windows/scripts/build/Install-AzureCli.ps1
@@ -15,7 +15,7 @@ New-Item -ItemType 'Directory' -Path $azureCliExtensionPath | Out-Null
 
 Install-Binary -Type MSI `
     -Url 'https://aka.ms/installazurecliwindowsx64' `
-    -ExpectedSignature 'C2048FB509F1C37A8C3E9EC6648118458AA01780'
+    -ExpectedSignature 'F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE'
 
 Update-Environment
 


### PR DESCRIPTION
Windows -19 and 2022 image generation failed due to AzureCli signature, this PR will update the new Signature.
Windows-19 and Windows 2022 image generations will be successful

#### Related issue:
https://github.com/actions/runner-images/issues/10547

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
