### PR TITLE
Added try catch block added for azlogin

### DIFF
--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -240,6 +240,11 @@ Function GenerateResourcesAndImage {
 
     try {
         # Login to Azure subscription
+         try {
+            $azAccount = az account show -o none
+            Write-Warning "Already logged in..."
+        }
+        catch {
         if ([string]::IsNullOrEmpty($AzureClientId)) {
             Write-Verbose "No AzureClientId was provided, will use interactive login."
             az login --output none
@@ -247,6 +252,7 @@ Function GenerateResourcesAndImage {
         else {
             Write-Verbose "AzureClientId was provided, will use service principal login."
             az login --service-principal --username $AzureClientId --password=$AzureClientSecret --tenant $AzureTenantId --output none
+          }
         }
         az account set --subscription $SubscriptionId
         if ($LastExitCode -ne 0) {

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -240,19 +240,19 @@ Function GenerateResourcesAndImage {
 
     try {
         # Login to Azure subscription
-         try {
-            $azAccount = az account show -o none
-            Write-Warning "Already logged in..."
+        try {
+            az account show -o none
+            Write-Verbose "Already logged in..."
         }
         catch {
-        if ([string]::IsNullOrEmpty($AzureClientId)) {
-            Write-Verbose "No AzureClientId was provided, will use interactive login."
-            az login --output none
-        }
-        else {
-            Write-Verbose "AzureClientId was provided, will use service principal login."
-            az login --service-principal --username $AzureClientId --password=$AzureClientSecret --tenant $AzureTenantId --output none
-          }
+            if ([string]::IsNullOrEmpty($AzureClientId)) {
+                Write-Verbose "No AzureClientId was provided, will use interactive login."
+                az login --output none
+            }
+            else {
+                Write-Verbose "AzureClientId was provided, will use service principal login."
+                az login --service-principal --username $AzureClientId --password=$AzureClientSecret --tenant $AzureTenantId --output none
+            }
         }
         az account set --subscription $SubscriptionId
         if ($LastExitCode -ne 0) {


### PR DESCRIPTION
This PR adds a try-catch block for the azlogin function. * If an account is already logged in, it prints a message "Already logged in...". * If the login fails, it prints an error message "Login failed...". This change will help to handle the login process more gracefully and provide better user feedback.
#### Related issue:
https://github.com/actions/runner-images/issues/10236

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
