### PR TITLE
[macOS] Update Xcode 16.0 to RC1 on macOS-15

### DIFF
--- a/images/macos/scripts/tests/Xcode.Tests.ps1
+++ b/images/macos/scripts/tests/Xcode.Tests.ps1
@@ -28,8 +28,8 @@ Describe "Xcode" {
         $defaultXcodeTestCase = @{ DefaultXcode = $defaultXcode }
         It "Default Xcode is <DefaultXcode>" -TestCases $defaultXcodeTestCase {
             "xcodebuild -version" | Should -ReturnZeroExitCode
-            If ($DefaultXcode -ilike "*beta*") {
-                Write-Host "Beta version detected"
+            If ($DefaultXcode -ilike "*_*") {
+                Write-Host "Composite version detected (beta/RC/preview)"
                 $DefaultXcode = $DefaultXcode.split("_")[0]
                 If ($DefaultXcode -notlike "*.*") {
                     $DefaultXcode = "${DefaultXcode}.0"

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,13 +4,13 @@
         "x64": {
             "versions": [
                 { "link": "16.1_beta", "version": "16.1.0-Beta+16B5001e", "symlinks": ["16.1"], "install_runtimes": "false", "sha256": "8848aacb32bdc0abbd7e14e4b712e07c98f4b6e5a23a8d77db03ab21dcb3c777"},
-                { "link": "16_beta_6", "version": "16.0.0-Beta.6+16A5230g", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "ab0b9a4f6d723420ee0e39ff1cf6a628665dfe832053f66b6b72e013a6bbb244"}
+                { "link": "16_Release_Candidate", "version": "16.0.0-Release.Candidate+16A242", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "84588e4d781307191892add603ea51504955de39e05c270a88833a38a929825d"}
             ]
         },
         "arm64":{
             "versions": [
                 { "link": "16.1_beta", "version": "16.1.0-Beta+16B5001e", "symlinks": ["16.1"], "install_runtimes": "true", "sha256": "8848aacb32bdc0abbd7e14e4b712e07c98f4b6e5a23a8d77db03ab21dcb3c777"},
-                { "link": "16_beta_6", "version": "16.0.0-Beta.6+16A5230g", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "ab0b9a4f6d723420ee0e39ff1cf6a628665dfe832053f66b6b72e013a6bbb244"}
+                { "link": "16_Release_Candidate", "version": "16.0.0-Release.Candidate+16A242", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "84588e4d781307191892add603ea51504955de39e05c270a88833a38a929825d"}
             ]
         }
     },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -1,6 +1,6 @@
 {
     "xcode": {
-        "default": "16.1_beta",
+        "default": "16_Release_Candidate",
         "x64": {
             "versions": [
                 { "link": "16.1_beta", "version": "16.1.0-Beta+16B5001e", "symlinks": ["16.1"], "install_runtimes": "false", "sha256": "8848aacb32bdc0abbd7e14e4b712e07c98f4b6e5a23a8d77db03ab21dcb3c777"},


### PR DESCRIPTION
# Description

- Replace Xcode 16.0_beta_6 with Xcode 16.0 Release Candidate
- Update test case to run with all composite versions of Xcode

Note: It will work while version separated by underline, will not work with `12Preview` or `34.5-beta`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
