### PR TITLE
[Ubuntu] Add Microsoft Edge browser to ubuntu 24 image

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -219,10 +219,9 @@ $browsersTools = $installedSoftware.AddHeader("Browsers and Drivers")
 $browsersTools.AddToolVersion("Google Chrome", $(Get-ChromeVersion))
 $browsersTools.AddToolVersion("ChromeDriver", $(Get-ChromeDriverVersion))
 $browsersTools.AddToolVersion("Chromium", $(Get-ChromiumVersion))
-if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
-    $browsersTools.AddToolVersion("Microsoft Edge", $(Get-EdgeVersion))
-    $browsersTools.AddToolVersion("Microsoft Edge WebDriver", $(Get-EdgeDriverVersion))
-}
+$browsersTools.AddToolVersion("Microsoft Edge", $(Get-EdgeVersion))
+$browsersTools.AddToolVersion("Microsoft Edge WebDriver", $(Get-EdgeDriverVersion))
+
 $browsersTools.AddToolVersion("Selenium server", $(Get-SeleniumVersion))
 if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
     $browsersTools.AddToolVersion("Mozilla Firefox", $(Get-FirefoxVersion))

--- a/images/ubuntu/scripts/tests/Browsers.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Browsers.Tests.ps1
@@ -24,7 +24,7 @@ Describe "Chrome" {
     }
 }
 
-Describe "Edge" -Skip:((-not (Test-IsUbuntu20)) -and (-not (Test-IsUbuntu22))) {
+Describe "Edge" {
     It "Edge" {
         "microsoft-edge --version" | Should -ReturnZeroExitCode
     }

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -289,6 +289,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-codeql-bundle.sh",
       "${path.root}/../scripts/build/install-container-tools.sh",
       "${path.root}/../scripts/build/install-dotnetcore-sdk.sh",
+      "${path.root}/../scripts/build/install-microsoft-edge.sh",
       "${path.root}/../scripts/build/install-gcc-compilers.sh",
       "${path.root}/../scripts/build/install-gfortran.sh",
       "${path.root}/../scripts/build/install-git.sh",


### PR DESCRIPTION
# Description
This PR adds Microsoft Edge browser to the ubuntu 24 image. This will allow users to test their applications on the Microsoft Edge browser.



#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
