### PR TITLE
[macOS] Clean up Homebrew downloads folder

### DIFF
--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -47,3 +47,6 @@ echo "Indexing completed"
 
 # delete symlink for tests running
 sudo rm -f /usr/local/bin/invoke_tests
+
+# Clean Homebrew downloads
+sudo rm -rf /Users/$USER/Library/Caches/Homebrew/downloads/*


### PR DESCRIPTION
# Description
Clean up Homebrew downloads folder to save disk space on macOS-14 runners.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
