### PR TITLE
[macOS] Workaround issue with Xamarin Pester tests discovery

### DIFF
--- a/images/macos/scripts/tests/Xamarin.Tests.ps1
+++ b/images/macos/scripts/tests/Xamarin.Tests.ps1
@@ -15,6 +15,11 @@ if ($os.IsVentura -or $os.IsSonoma) {
     $XAMARIN_ANDROID_VERSIONS = (Get-ToolsetContent).xamarin.android_versions
 } elseif ($os.IsSequoia) {
     Write-Host "Skipping all the Mono and Xamarin tests as deprecated"
+    # Dummy workaround for the issue with the tests discovery
+    $MONO_VERSIONS = @()
+    $XAMARIN_IOS_VERSIONS = @()
+    $XAMARIN_MAC_VERSIONS = @()
+    $XAMARIN_ANDROID_VERSIONS = @()
 }
 
 BeforeAll {


### PR DESCRIPTION
# Description

Pester tests discovering process ignores `-Skip` which leads to an error.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
