### PR TITLE
[ubuntu] Add new Swift GPG key to unlock Ubuntu builds

### DIFF
--- a/images/ubuntu/scripts/build/install-swift.sh
+++ b/images/ubuntu/scripts/build/install-swift.sh
@@ -27,7 +27,8 @@ gpg --keyserver hkp://keyserver.ubuntu.com \
       '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
       'A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561' \
       '8A74 9566 2C3C D4AE 18D9  5637 FAF6 989E 1BC1 6FEA' \
-      'E813 C892 820A 6FA1 3755  B268 F167 DF1A CF9C E069'
+      'E813 C892 820A 6FA1 3755  B268 F167 DF1A CF9C E069' \
+      '52BB 7E3D E28A 71BE 22EC  05FF EF80 A866 B47A 981F'
 gpg --keyserver hkp://keyserver.ubuntu.com --refresh-keys Swift
 
 # Download and verify signature


### PR DESCRIPTION
# Description
Ubuntu-20.04 image generation is failing due to the swift failure. This PR fixes the issue by updating the swift version signature for the latest version.


#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
