### PR TITLE
Update job conditions for GitHub CI workflows

### DIFF
--- a/.github/workflows/ubuntu2004.yml
+++ b/.github/workflows/ubuntu2004.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   Ubuntu_2004:
-    if: contains(github.event.pull_request.labels.*.name, 'CI ubuntu-all') || contains(github.event.pull_request.labels.*.name, 'CI ubuntu-2004')
+    if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2004'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'ubuntu2004'

--- a/.github/workflows/ubuntu2204.yml
+++ b/.github/workflows/ubuntu2204.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   Ubuntu_2204:
-    if: contains(github.event.pull_request.labels.*.name, 'CI ubuntu-all') || contains(github.event.pull_request.labels.*.name, 'CI ubuntu-2204')
+    if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2204'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'ubuntu2204'

--- a/.github/workflows/ubuntu2404.yml
+++ b/.github/workflows/ubuntu2404.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   Ubuntu_2404:
-    if: contains(github.event.pull_request.labels.*.name, 'CI ubuntu-all') || contains(github.event.pull_request.labels.*.name, 'CI ubuntu-2404')
+    if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2404'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'ubuntu2404'

--- a/.github/workflows/windows2019.yml
+++ b/.github/workflows/windows2019.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   Windows_2019:
-    if: contains(github.event.pull_request.labels.*.name, 'CI windows-all') || contains(github.event.pull_request.labels.*.name, 'CI windows-2019')
+    if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2019'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'windows2019'

--- a/.github/workflows/windows2022.yml
+++ b/.github/workflows/windows2022.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   Windows_2022:
-    if: contains(github.event.pull_request.labels.*.name, 'CI windows-all') || contains(github.event.pull_request.labels.*.name, 'CI windows-2022')
+    if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2022'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'windows2022'


### PR DESCRIPTION
# Description
This PR updates job conditions for GitHub CI workflows from using `github.event.pull_request.labels.*.name` context to `github.event.label.name`.
This allows to avoid workflows executing till completion twice in certain labeling scenarios.

#### Related issue: https://github.com/actions/runner-images-internal/issues/6340

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
