### PR TITLE
[macOS] Fix for Homebrew shellenv bug to unlock PATH

### DIFF
--- a/images/macos/scripts/build/configure-shell.sh
+++ b/images/macos/scripts/build/configure-shell.sh
@@ -15,4 +15,6 @@ sudo chsh -s /bin/bash root
 if [[ $arch == "arm64" ]]; then
   echo "Adding Homebrew environment to bash"
   /opt/homebrew/bin/brew shellenv >> ~/.bashrc
+  # Workaround for the issue (#10624) with the Homebrew PATH in the bashrc
+  sed -i '' '/; export PATH;/d' ~/.bashrc
 fi

--- a/images/macos/scripts/build/configure-shell.sh
+++ b/images/macos/scripts/build/configure-shell.sh
@@ -17,4 +17,5 @@ if [[ $arch == "arm64" ]]; then
   /opt/homebrew/bin/brew shellenv >> ~/.bashrc
   # Workaround for the issue (#10624) with the Homebrew PATH in the bashrc
   sed -i '' '/; export PATH;/d' ~/.bashrc
+  echo 'export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"' >> ~/.bashrc
 fi


### PR DESCRIPTION
# Description

`brew shellenv` started to return unpredicted result which block users from updating PATH.  Temporary workaround while fix is in progress in the upstream.

#### Related issue:

#10624

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
