### PR TITLE
 [Ubuntu-24] Node.js version 16 removed and version 22 added.

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -28,9 +28,9 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "16.*",
                 "18.*",
-                "20.*"
+                "20.*",
+                "22.*"
             ]
         },
         {
@@ -263,7 +263,7 @@
         "version": "4"
     },
     "node": {
-        "default": "20"
+        "default": "22"
     },
     "node_modules": [
         {


### PR DESCRIPTION

This PR deprecates Node.js version 16, adds the latest version 22, and sets version 22 as the default for Ubuntu 24.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
