### PR TITLE
[macOS] Install ant, kotlin and sbt after XCode installation

### DIFF
--- a/images/macos/scripts/build/install-compilable-brew-packages.sh
+++ b/images/macos/scripts/build/install-compilable-brew-packages.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e -o pipefail
+################################################################################
+##  File:  install-compilable-brew-packages.sh
+##  Desc:  Install compilable brew packages
+################################################################################
+
+source ~/utils/utils.sh
+
+compilable_packages=$(get_toolset_value '.brew.compilable_packages[]')
+for package in $compilable_packages; do
+    echo "Installing $package..."
+    brew_smart_install "$package"
+done
+
+invoke_tests "Common" "Compiled"

--- a/images/macos/scripts/tests/BasicTools.Tests.ps1
+++ b/images/macos/scripts/tests/BasicTools.Tests.ps1
@@ -87,7 +87,7 @@ Describe "7-Zip" {
     }
 }
 
-Describe "Apache Ant" {
+Describe "Apache Ant" -Skip:($os.IsMonterey) {
     It "Apache Ant" {
         "ant -version" | Should -ReturnZeroExitCode
     }
@@ -159,17 +159,11 @@ Describe "Homebrew" {
     }
 }
 
-Describe "Kotlin" {
+Describe "Kotlin" -Skip:($os.IsMonterey) {
     $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlinc-jvm", "kotlin-dce-js")
 
     It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
         "$toolName -version" | Should -ReturnZeroExitCode
-    }
-}
-
-Describe "sbt" -Skip:($os.IsVentura -or $os.IsSonoma -or $os.IsSequoia) {
-    It "sbt" {
-        "sbt -version" | Should -ReturnZeroExitCode
     }
 }
 

--- a/images/macos/scripts/tests/Common.Tests.ps1
+++ b/images/macos/scripts/tests/Common.Tests.ps1
@@ -146,3 +146,19 @@ Describe "Colima" -Skip:($os.IsVentura -or $os.IsSonoma -or $os.IsSequoia) {
         "colima version" | Should -ReturnZeroExitCode
     }
 }
+
+Describe "Compiled" -Skip:(-not $os.IsMonterey) {
+    It "Apache Ant" {
+        "ant -version" | Should -ReturnZeroExitCode
+    }
+
+    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlinc-jvm", "kotlin-dce-js")
+
+    It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
+        "$toolName -version" | Should -ReturnZeroExitCode
+    }
+
+    It "sbt" {
+        "sbt -version" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -266,7 +266,8 @@ build {
       "${path.root}/../scripts/build/install-pypy.sh",
       "${path.root}/../scripts/build/install-pipx-packages.sh",
       "${path.root}/../scripts/build/install-bicep.sh",
-      "${path.root}/../scripts/build/install-codeql-bundle.sh"
+      "${path.root}/../scripts/build/install-codeql-bundle.sh",
+      "${path.root}/../scripts/build/install-compilable-brew-packages.sh"
     ]
   }
 

--- a/images/macos/toolsets/toolset-12.json
+++ b/images/macos/toolsets/toolset-12.json
@@ -184,7 +184,6 @@
     },
     "brew": {
         "common_packages": [
-            "ant",
             "aria2",
             "azure-cli",
             "bazelisk",
@@ -194,13 +193,11 @@
             "gh",
             "gnupg",
             "gnu-tar",
-            "kotlin",
             "libpq",
             "p7zip",
             "packer",
             "perl",
             "pkg-config",
-            "sbt",
             "subversion",
             "swiftformat",
             "swig",
@@ -222,6 +219,11 @@
             "vagrant",
             "virtualbox",
             "parallels"
+        ],
+        "compilable_packages": [
+            "ant",
+            "kotlin",
+            "sbt"
         ]
     },
     "gcc": {


### PR DESCRIPTION
# Description
Since Homebrew no longer supports macOS 12 for Ant, Kotlin, and SBT, we are installing all three after Xcode installation.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
