### PR TITLE
[macOS] Fix automationmodetool for macOS14.7

### DIFF
--- a/images/macos/scripts/build/configure-autologin.sh
+++ b/images/macos/scripts/build/configure-autologin.sh
@@ -9,6 +9,7 @@
 echo "Enabling automatic GUI login for the '$USERNAME' user.."
 python3 $HOME/bootstrap/kcpassword.py "$PASSWORD"
 /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser "$USERNAME"
+/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUserScreenLocked -bool false
 
 : '
 The MIT License (MIT)

--- a/images/macos/scripts/build/configure-machine.sh
+++ b/images/macos/scripts/build/configure-machine.sh
@@ -50,21 +50,18 @@ done
 rm -f ./add-certificate
 
 # enable-automationmode-without-authentication
-
+brew install expect
 retry=10
 while [[ $retry -gt 0 ]]; do
 {
-osascript <<EOF
-    tell application "Terminal"
-        activate
-        do script "automationmodetool enable-automationmode-without-authentication"
-        delay 2
-        tell application "System Events"
-            keystroke "${PASSWORD}"
-            keystroke return
-        end tell
-    end tell
-    delay 5
+    /usr/bin/expect <<EOF
+        spawn automationmodetool enable-automationmode-without-authentication
+        expect "password"
+        send "${PASSWORD}\r"
+        expect {
+            "succeeded." { puts "Automation mode enabled successfully"; exit 0 }
+            eof
+        }
 EOF
 } && break
 
@@ -77,9 +74,15 @@ EOF
 done
 
 echo "Getting terminal windows"
-term_service=$(launchctl list | grep -i terminal | cut -f3)
-echo "Close terminal windows: gui/501/${term_service}"
-launchctl bootout gui/501/${term_service} && sleep 5
+launchctl_output=$(launchctl list | grep -i terminal || true)
+
+if [ -n "$launchctl_output" ]; then
+    term_service=$(echo "$launchctl_output" | cut -f3)
+    echo "Close terminal windows: gui/501/${term_service}"
+    launchctl bootout gui/501/${term_service} && sleep 5
+else
+    echo "No open terminal windows found."
+fi
 
 # test enable-automationmode-without-authentication
 if [[ ! "$(automationmodetool)" =~ "DOES NOT REQUIRE" ]]; then

--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -50,3 +50,6 @@ sudo rm -f /usr/local/bin/invoke_tests
 
 # Clean Homebrew downloads
 sudo rm -rf /Users/$USER/Library/Caches/Homebrew/downloads/*
+
+# Uninstall expect used in configure-machine.sh
+brew uninstall expect

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -178,6 +178,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
       "${path.root}/../scripts/build/configure-auto-updates.sh",
       "${path.root}/../scripts/build/configure-ntpconf.sh",
       "${path.root}/../scripts/build/configure-shell.sh"

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -179,6 +179,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
       "${path.root}/../scripts/build/configure-auto-updates.sh",
       "${path.root}/../scripts/build/configure-ntpconf.sh",
       "${path.root}/../scripts/build/configure-shell.sh"

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -178,6 +178,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
       "${path.root}/../scripts/build/configure-auto-updates.sh",
       "${path.root}/../scripts/build/configure-ntpconf.sh",
       "${path.root}/../scripts/build/configure-shell.sh"

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -180,6 +180,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
       "${path.root}/../scripts/build/configure-auto-updates.sh",
       "${path.root}/../scripts/build/configure-ntpconf.sh",
       "${path.root}/../scripts/build/configure-shell.sh"

--- a/images/macos/templates/macOS-15.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.anka.pkr.hcl
@@ -174,6 +174,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
       "${path.root}/../scripts/build/configure-auto-updates.sh",
       "${path.root}/../scripts/build/configure-ntpconf.sh",
       "${path.root}/../scripts/build/configure-shell.sh"
@@ -201,6 +202,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     pause_before     = "30s"
     scripts          = [
+      "${path.root}/../scripts/build/configure-windows.sh",
       "${path.root}/../scripts/build/install-powershell.sh",
       "${path.root}/../scripts/build/install-dotnet.sh",
       "${path.root}/../scripts/build/install-python.sh",

--- a/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
@@ -176,6 +176,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-autologin.sh",
       "${path.root}/../scripts/build/configure-auto-updates.sh",
       "${path.root}/../scripts/build/configure-ntpconf.sh",
       "${path.root}/../scripts/build/configure-shell.sh"


### PR DESCRIPTION
# Description
Details of the two changes done below:

1. Replace 'osascript' with 'expect' for enabling automationmodetool. osascript was not working as expected with macOS 14.7. Hence replacing for all images.

2. Include `configure-autologin.sh` script for all images and set `autoLoginUserScreenLocked` value to 'false'.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
