### PR TITLE
[macOS] Disable removing default Xcode CLT for macOS-15

### DIFF
--- a/images/macos/scripts/build/install-bicep.sh
+++ b/images/macos/scripts/build/install-bicep.sh
@@ -6,11 +6,6 @@
 
 source ~/utils/utils.sh
 
-if is_Sequoia; then
-    sudo rm -rf /Library/Developer/CommandLineTools
-    sudo xcode-select --install
-fi
-
 echo "Installing bicep cli..."
 brew tap azure/bicep
 brew_smart_install bicep


### PR DESCRIPTION
# Description

Removing temporary functionality designed to compensate for incompatibility with the previous version of Xcode CLT

#### Related issue:

https://github.com/actions/runner-images/issues/10686

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
