### PR TITLE
[macOS] Install packer using tap

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -17,7 +17,12 @@ for package in $common_packages; do
         xcbeautify_path=$(download_with_retry "https://raw.githubusercontent.com/Homebrew/homebrew-core/d3653e83f9c029a3fddb828ac804b07ac32f7b3b/Formula/x/xcbeautify.rb")
         brew install "$xcbeautify_path"
     else
-        brew_smart_install "$package"
+        if [[ $package == "packer" ]]; then
+            # Packer has been deprecated in Homebrew. Use tap to install Packer.
+            brew install hashicorp/tap/packer
+        else
+            brew_smart_install "$package"
+        fi
     fi
 done
 


### PR DESCRIPTION
# Description
Packer is deprecated from Homebrew `Warning: packer has been deprecated! It will be disabled on 2024-09-27.`

Hence we are installing packer using `hashicorp/tap/packer`.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
