### PR TITLE
[macOS] Add tcl-tk to macOS13

### DIFF
--- a/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -293,9 +293,11 @@ if ($os.IsMonterey) {
     $miscellaneous.AddToolVersion("Zlib", $(Get-ZlibVersion))
 }
 
-if ($os.IsSonomaX64 -or $os.IsVenturaX64 -or $os.IsSequoiaX64) {
+if ($os.IsSonoma -or $os.IsVentura) {
     $miscellaneous = $installedSoftware.AddHeader("Miscellaneous")
+    $miscellaneous.AddToolVersion("Tcl/Tk", $(Get-TclTkVersion))
 }
+
 if ($os.IsMonterey -or $os.IsSonomaX64 -or $os.IsVenturaX64) {
 
     Write-Host "Adding environment variables for parallels"

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -74,6 +74,7 @@
             "perl",
             "pkg-config",
             "swiftformat",
+            "tcl-tk",
             "zstd",
             "gmp",
             "yq",

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -79,6 +79,7 @@
             "perl",
             "pkg-config",
             "swiftformat",
+            "tcl-tk",
             "zstd",
             "gmp",
             "yq",


### PR DESCRIPTION
# Description
Setup-actions team currently use Tcl/Tk in macOS12 to generate artifacts for python. Since macOS12 is deprecated adding Tcl/Tk to macOS13.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
