### PR TITLE
[Ubuntu 20 and 22] Go version 1.23 added

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -46,9 +46,10 @@
             "platform" : "linux",
             "versions": [
                 "1.21.*",
-                "1.22.*"
+                "1.22.*",
+                "1.23.*"
             ],
-            "default": "1.21.*"
+            "default": "1.23.*"
         },
         {
             "name": "Ruby",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -44,9 +44,10 @@
             "platform" : "linux",
             "versions": [
                 "1.21.*",
-                "1.22.*"
+                "1.22.*",
+                "1.23.*"
             ],
-            "default": "1.21.*"
+            "default": "1.23.*"
         },
         {
             "name": "Ruby",


### PR DESCRIPTION
This PR contains
Added Go 1.23 version to Ubuntu20 and 22 image 
Making 1.23 version as a default in ubuntu20 and 22 image.

#### Related issue:
https://github.com/actions/runner-images/issues/10436

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
