### PR TITLE
Fix #10767 - Missing sbt in the latest Ubuntu and macOS 13, 14 and 15

### DIFF
--- a/images/macos/macos-13-Readme.md
+++ b/images/macos/macos-13-Readme.md
@@ -50,6 +50,7 @@
 - Apache Ant 1.10.15
 - Apache Maven 3.9.9
 - Gradle 8.10.2
+- Sbt 1.10.2
 
 ### Utilities
 - 7-Zip 17.05

--- a/images/macos/macos-13-arm64-Readme.md
+++ b/images/macos/macos-13-arm64-Readme.md
@@ -47,6 +47,7 @@
 - Apache Ant 1.10.15
 - Apache Maven 3.9.9
 - Gradle 8.10.2
+- Sbt 1.10.2
 
 ### Utilities
 - 7-Zip 17.05

--- a/images/macos/macos-14-Readme.md
+++ b/images/macos/macos-14-Readme.md
@@ -49,6 +49,7 @@
 - Apache Ant 1.10.15
 - Apache Maven 3.9.9
 - Gradle 8.10.2
+- Sbt 1.10.2
 
 ### Utilities
 - 7-Zip 17.05

--- a/images/macos/macos-14-arm64-Readme.md
+++ b/images/macos/macos-14-arm64-Readme.md
@@ -47,6 +47,7 @@
 - Apache Ant 1.10.15
 - Apache Maven 3.9.9
 - Gradle 8.10.2
+- Sbt 1.10.2
 
 ### Utilities
 - 7-Zip 17.05

--- a/images/macos/macos-15-Readme.md
+++ b/images/macos/macos-15-Readme.md
@@ -47,6 +47,7 @@
 - Apache Ant 1.10.15
 - Apache Maven 3.9.9
 - Gradle 8.10.2
+- Sbt 1.10.2
 
 ### Utilities
 - 7-Zip 17.05

--- a/images/macos/macos-15-arm64-Readme.md
+++ b/images/macos/macos-15-arm64-Readme.md
@@ -45,6 +45,7 @@
 - Apache Ant 1.10.15
 - Apache Maven 3.9.9
 - Gradle 8.10.2
+- Sbt 1.10.2
 
 ### Utilities
 - 7-Zip 17.05

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -68,6 +68,7 @@
             "gnupg",
             "gnu-tar",
             "kotlin",
+            "sbt",
             "libpq",
             "p7zip",
             "packer",

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -72,6 +72,7 @@
             "gnupg",
             "gnu-tar",
             "kotlin",
+            "sbt",
             "libpq",
             "libsodium",
             "p7zip",

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -60,6 +60,7 @@
             "gnupg",
             "gnu-tar",
             "kotlin",
+            "sbt",
             "libpq",
             "libsodium",
             "p7zip",

--- a/images/ubuntu/Ubuntu2404-Readme.md
+++ b/images/ubuntu/Ubuntu2404-Readme.md
@@ -60,6 +60,7 @@ to accomplish this.
 - Gradle 8.10.2
 - Lerna 8.1.8
 - Maven 3.8.8
+- Sbt 1.10.2
 
 ### Tools
 - Ansible 2.17.4

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -312,6 +312,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",
       "${path.root}/../scripts/build/install-julia.sh",
+      "${path.root}/../scripts/build/install-sbt.sh",
       "${path.root}/../scripts/build/install-selenium.sh",
       "${path.root}/../scripts/build/install-packer.sh",
       "${path.root}/../scripts/build/install-vcpkg.sh",


### PR DESCRIPTION
# Description
Fix #10767 - Missing sbt in the latest Ubuntu, and macOS 13, 14 and 15

Currently, `sbt` is missing in Ubuntu `24.04`, and macOS `13`, `14` and `15`.

I've read `CONTRIBUTING.md`, and I'm sorry, but I really need this, and it's not something new. It's about adding what this repo already had in the older version.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

`sbt` is missing in Ubuntu `24.04`, and macOS `13`, `14` and `15`.

https://github.com/kevin-lee/jdk-sym-link/actions/runs/11304980267/job/31443978394
![Screenshot 2024-10-12 at 9 44 37 pm](https://github.com/user-attachments/assets/af44fee7-8150-46b7-9baa-e41b42c92256)

Any macOS version higher than macOS 12 has this problem.
* [macos-12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#project-management) has `sbt`.
* [macos-13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#project-management) doesn't have it.
* [macos-13-arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-arm64-Readme.md#project-management) doesn't have it.
* [macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#project-management) doesn't have it.
* [macos-14-arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#project-management) doesn't have it.
* [macos-15](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#project-management) doesn't have it.
* [macos-15-arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md#project-management) doesn't have it.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
