### PR TITLE
Add Google Cloud CLI (gcloud) to Ubuntu 24.04 runner

### DIFF
--- a/images/ubuntu/Ubuntu2404-Readme.md
+++ b/images/ubuntu/Ubuntu2404-Readme.md
@@ -107,6 +107,7 @@ to accomplish this.
 - Azure CLI 2.64.0
 - Azure CLI (azure-devops) 1.0.1
 - GitHub CLI 2.58.0
+- Google Cloud CLI 495.0.0
 
 ### Java
 | Version             | Environment Variable |
@@ -312,4 +313,3 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | xz-utils               | 5.6.1+really5.4.5-1build0.1 |
 | zip                    | 3.0-13build1                |
 | zsync                  | 0.6.2-5build1               |
-

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -297,6 +297,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-git-lfs.sh",
       "${path.root}/../scripts/build/install-github-cli.sh",
       "${path.root}/../scripts/build/install-google-chrome.sh",
+      "${path.root}/../scripts/build/install-google-cloud-cli.sh",
       "${path.root}/../scripts/build/install-haskell.sh",
       "${path.root}/../scripts/build/install-java-tools.sh",
       "${path.root}/../scripts/build/install-kubernetes-tools.sh",


### PR DESCRIPTION
Fix #10769 , This PR adds the installation of the Google Cloud CLI (gcloud) to the Ubuntu 24.04 GitHub runner, as it is currently missing from the ubuntu-latest image.