### PR TITLE
[Ubuntu, Windows] Add RUNNER_TOOL_CACHE environment variable

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -31,6 +31,7 @@ sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost ip6-localhost ip6-loo
 AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 mkdir $AGENT_TOOLSDIRECTORY
 set_etc_environment_variable "AGENT_TOOLSDIRECTORY" "${AGENT_TOOLSDIRECTORY}"
+set_etc_environment_variable "RUNNER_TOOL_CACHE" "${AGENT_TOOLSDIRECTORY}"
 chmod -R 777 $AGENT_TOOLSDIRECTORY
 
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

--- a/images/windows/scripts/build/Configure-SystemEnvironment.ps1
+++ b/images/windows/scripts/build/Configure-SystemEnvironment.ps1
@@ -7,6 +7,7 @@ $variables = @{
     "ImageVersion"                        = $env:IMAGE_VERSION
     "ImageOS"                             = $env:IMAGE_OS
     "AGENT_TOOLSDIRECTORY"                = $env:AGENT_TOOLSDIRECTORY
+    "RUNNER_TOOL_CACHE"                   = $env:AGENT_TOOLSDIRECTORY
 }
 
 $variables.GetEnumerator() | ForEach-Object {


### PR DESCRIPTION
# Description
Add the `RUNNER_TOOL_CACHE` environment variable for Ubuntu and Windows images.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/6459

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
