### PR TITLE
Update macos-14-Readme.md

### DIFF
--- a/images/macos/macos-14-Readme.md
+++ b/images/macos/macos-14-Readme.md
@@ -284,7 +284,7 @@
 #### Environment variables
 | Name                    | Value                                               |
 | ----------------------- | --------------------------------------------------- |
-| ANDROID_HOME            | /Users/runner/Library/Android/sdk                   |
+| ANDROID_HOME            | /Users/runner/Library/Android/sdk                  |
 | ANDROID_NDK             | /Users/runner/Library/Android/sdk/ndk/26.3.11579264 |
 | ANDROID_NDK_HOME        | /Users/runner/Library/Android/sdk/ndk/26.3.11579264 |
 | ANDROID_NDK_LATEST_HOME | /Users/runner/Library/Android/sdk/ndk/27.1.12297006 |


### PR DESCRIPTION
### Added

- macOS 14.7 (23H124) support with Darwin Kernel Version 23.6.0.
- Multiple .NET Core SDK versions: 7.0.102, 7.0.202, 7.0.306, 7.0.410, 8.0.101, 8.0.204, 8.0.303, 8.0.402.
- New environment variables for Android SDK/NDK setup.
- Updated Xcode versions including 16.1 (beta), 16.0, and various 15.x versions.
- Added multiple simulators for iOS, tvOS, watchOS, and visionOS.

### Updated

- Updated various package management tools including Bundler, Carthage, CocoaPods, Composer, Homebrew, NPM, NuGet, Pip3, Pipx, RubyGems, Yarn.
- Updated language runtimes like Bash, Clang/LLVM, GCC, Kotlin, Mono, Node.js, Perl, PHP, Python3, Ruby.
- Updated project management tools: Apache Ant, Apache Maven, Gradle.
- Updated utilities: 7-Zip, aria2, azcopy, bazel, bazelisk, bsdtar, Curl, Git, Git LFS, GitHub CLI, GNU Tar, GNU Wget, gpg, jq, OpenSSL, Packer, pkg-config, yq, zstd.
- Updated tools: AWS CLI, AWS SAM CLI, AWS Session Manager CLI, Azure CLI, Azure CLI (azure-devops), Bicep CLI, Cmake, CodeQL Action Bundle, Fastlane, SwiftFormat, Xcbeautify, Xcode Command Line Tools, Xcodes.
- Updated linters: SwiftLint.
- Updated browsers and drivers: Safari, Google Chrome, ChromeDriver, Microsoft Edge, Microsoft Edge WebDriver, Mozilla Firefox, geckodriver, Selenium server.
- Updated Java versions and environment variables.
- Updated cached tools for Ruby, Python, Node.js, Go.
- Updated Rust tools and packages.
- Updated PowerShell tools and modules.

# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
