### PR TITLE
[Ubuntu 2404] Allow pip to install packages in default environment

### DIFF
--- a/images/ubuntu/scripts/build/install-python.sh
+++ b/images/ubuntu/scripts/build/install-python.sh
@@ -19,6 +19,13 @@ export PIPX_HOME=/opt/pipx
 if is_ubuntu24; then
     apt-get install --no-install-recommends pipx
     pipx ensurepath
+
+# Create temporary workaround to allow user to continue using pip
+    sudo cat <<EOF > /etc/pip.conf
+[global]
+break-system-packages = true
+EOF
+
 else
     python3 -m pip install pipx
     python3 -m pipx ensurepath


### PR DESCRIPTION
# Description
This is a temporary workaround put in place to allow users of ubuntu-24.04 runner images use pip install in the default environment.

#### Related issue:

[runner-images/issues#10781](https://github.com/actions/runner-images/issues/10781)
[c2c-actions-support/issues#4413](https://github.com/github/c2c-actions-support/issues/4413)

VM image is successfully [generated](https://github.com/actions/runner-images-ci/actions/runs/11354988709).
VM image is successfully [deployed](https://github.com/actions/runner-images-ci/actions/runs/11355755511).


## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
