### PR TITLE
[Ubuntu24] Update apt sources

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt-sources.sh
+++ b/images/ubuntu/scripts/build/configure-apt-sources.sh
@@ -4,13 +4,22 @@
 ##  Desc:  Configure apt sources with failover from Azure to Ubuntu archives.
 ################################################################################
 
+source $HELPER_SCRIPTS/os.sh
+
 touch /etc/apt/apt-mirrors.txt
 
 printf "http://azure.archive.ubuntu.com/ubuntu/\tpriority:1\n" | tee -a /etc/apt/apt-mirrors.txt
 printf "http://archive.ubuntu.com/ubuntu/\tpriority:2\n" | tee -a /etc/apt/apt-mirrors.txt
 printf "http://security.ubuntu.com/ubuntu/\tpriority:3\n" | tee -a /etc/apt/apt-mirrors.txt
 
-sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/apt-mirrors.txt/' /etc/apt/sources.list
+if is_ubuntu24; then
+    sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/apt-mirrors.txt/' /etc/apt/sources.list.d/ubuntu.sources
 
-# Apt changes to survive Cloud Init
-cp -f /etc/apt/sources.list /etc/cloud/templates/sources.list.ubuntu.tmpl
+    # Apt changes to survive Cloud Init
+    cp -f /etc/apt/sources.list.d/ubuntu.sources  /etc/cloud/templates/sources.list.ubuntu.deb822.tmpl
+else
+    sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/apt-mirrors.txt/' /etc/apt/sources.list
+
+    # Apt changes to survive Cloud Init
+    cp -f /etc/apt/sources.list /etc/cloud/templates/sources.list.ubuntu.tmpl
+fi


### PR DESCRIPTION
# Description
With ubuntu24 `/etc/apt/sources.list` has been moved to `/etc/apt/sources.list.d/ubuntu.sources` and utilizes `deb822` format.
This PR updates sources list in case of ubuntu24:
1. Modifications to `/etc/apt/sources.list.d/ubuntu.sources`.
2. Modifications to `/etc/cloud/templates/sources.list.ubuntu.deb822.tmpl` for changes to survive cloud-init.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
