### PR TITLE
[ Ubuntu 2024 ] Removing Node.js version 16*

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -28,7 +28,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "16.*",
                 "18.*",
                 "20.*"
             ]


### PR DESCRIPTION
# Description

This PR will remove the Node.js version 16*

VM image is successfully [generated](https://github.com/actions/runner-images-ci/actions/runs/11385073691)

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
