### PR TITLE
[macOS] Fix for macOS15 Android SDK and Command Line Tools

### DIFF
--- a/images/macos/scripts/docs-gen/SoftwareReport.Android.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Android.psm1
@@ -155,7 +155,7 @@ function Get-AndroidPlatformVersions {
 
 function Get-AndroidCommandLineToolsVersion {
     $commandLineTools = Get-AndroidSDKManagerPath
-    (& $commandLineTools --version | Out-String).Trim() -match "(?<version>^(\d+\.){1,}\d+$)" | Out-Null
+    (& $commandLineTools --version | Out-String).Trim() -match "(?<version>^(\d+\.){1,}\d+(-[a-zA-Z0-9]+)?)$" | Out-Null
     $commandLineToolsVersion = $Matches.Version
     return $commandLineToolsVersion
 }

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -28,7 +28,7 @@
         "cmdline-tools": "commandlinetools-mac-12172612_latest.zip",
         "sdk-tools": "sdk-tools-darwin-4333796.zip",
         "platform_min_version": "35",
-        "build_tools_min_version": "35.0.2",
+        "build_tools_min_version": "35.0.0",
         "extras": [
             "android;m2repository", "google;m2repository", "google;google_play_services"
         ],


### PR DESCRIPTION
# Description

1. Update the Android SDK minimum version to 35.0.0 in macOS 15, as version 35.0.2 is not available yet, resulting in the build-tools not being installed on macOS 15 images.

2. We do not see "Android Command Line Tools" in macOS15 Software report since the code does not account for versions with suffixes such as -alpha01 `( in this case 16.0-alpha01)`. Updated the code to support for versions with a hyphen followed by alphanumeric characters.

#### Related issue:

https://github.com/actions/runner-images/issues/10814

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
