### PR TITLE
[Ubuntu] simplify yarn/npm checks

### DIFF
--- a/images/ubuntu/scripts/build/configure-system.sh
+++ b/images/ubuntu/scripts/build/configure-system.sh
@@ -24,11 +24,11 @@ replace_etc_environment_variable "PATH" "${ENVPATH}"
 echo "Updated /etc/environment: $(cat /etc/environment)"
 
 # Clean yarn and npm cache
-if yarn --version > /dev/null; then
+if type yarn > /dev/null; then
     yarn cache clean
 fi
 
-if npm --version; then
+if type npm > /dev/null; then
     npm cache clean --force
 fi
 


### PR DESCRIPTION
# Description

`--version` checks are really error prone, the type check should be used instead.


#### Related issue: n/a

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
