### PR TITLE
[Ubuntu24] Modify pipx installation method

### DIFF
--- a/images/ubuntu/scripts/build/install-python.sh
+++ b/images/ubuntu/scripts/build/install-python.sh
@@ -12,24 +12,22 @@ source $HELPER_SCRIPTS/os.sh
 # Install Python, Python 3, pip, pip3
 apt-get install --no-install-recommends python3 python3-dev python3-pip python3-venv
 
-# Install pipx
-# Set pipx custom directory
-export PIPX_BIN_DIR=/opt/pipx_bin
-export PIPX_HOME=/opt/pipx
 if is_ubuntu24; then
-    apt-get install --no-install-recommends pipx
-    pipx ensurepath
-
 # Create temporary workaround to allow user to continue using pip
     sudo cat <<EOF > /etc/pip.conf
 [global]
 break-system-packages = true
 EOF
-
-else
-    python3 -m pip install pipx
-    python3 -m pipx ensurepath
 fi
+
+# Install pipx
+# Set pipx custom directory
+export PIPX_BIN_DIR=/opt/pipx_bin
+export PIPX_HOME=/opt/pipx
+
+python3 -m pip install pipx
+python3 -m pipx ensurepath
+
 # Update /etc/environment
 set_etc_environment_variable "PIPX_BIN_DIR" $PIPX_BIN_DIR
 set_etc_environment_variable "PIPX_HOME" $PIPX_HOME


### PR DESCRIPTION
# Description
This PR modifies the installation method of `pipx` on ubuntu-24.04 to use `pip` instead of `apt`, bumping version to `1.7.1` as of time of this PR.

#### Related issue: https://github.com/actions/runner-images/issues/10783

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
