### PR TITLE
[macOS] Update android commandlinetools for macOS 15

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -25,10 +25,10 @@
         }
     },
     "android": {
-        "cmdline-tools": "commandlinetools-mac-12172612_latest.zip",
+        "cmdline-tools": "commandlinetools-mac-12266719_latest.zip",
         "sdk-tools": "sdk-tools-darwin-4333796.zip",
         "platform_min_version": "35",
-        "build_tools_min_version": "35.0.2",
+        "build_tools_min_version": "35.0.0",
         "extras": [
             "android;m2repository", "google;m2repository", "google;google_play_services"
         ],


### PR DESCRIPTION
# Description
The command line tools for android SDK were updated.

#### Related issue:
https://github.com/actions/runner-images/issues/10814

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
