### PR TITLE
[Windows]  Fix EdgeDriver Signature error for Windows

### DIFF
--- a/images/windows/scripts/build/Install-EdgeDriver.ps1
+++ b/images/windows/scripts/build/Install-EdgeDriver.ps1
@@ -27,7 +27,7 @@ Write-Host "Expand Microsoft Edge WebDriver archive..."
 Expand-7ZipArchive -Path $archivePath -DestinationPath $edgeDriverPath
 
 #Validate the EdgeDriver signature
-$signatureThumbprint = "7920AC8FB05E0FFFE21E8FF4B4F03093BA6AC16E"
+$signatureThumbprint = "0BD8C56733FDCC06F8CB919FF5A200E39B1ACF71"
 Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedThumbprint $signatureThumbprint
 
 Write-Host "Setting the environment variables..."


### PR DESCRIPTION
# Description
Windows builds were failed due to edge driver signature mismatch. This PR will fix the EdgeDriver signature error for both windows 2019 and 2022.

#### Related issue:
[10886](https://github.com/actions/runner-images/issues/10886)
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
