### PR TITLE
[Windows] adding .Net Version 8 to Windows-2022

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -316,7 +316,8 @@
     "dotnet": {
         "versions": [
             "6.0",
-            "7.0"
+            "7.0",
+            "8.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }


### PR DESCRIPTION
This PR will add .Net Version 8 to Windows-2022 image along with feature bands.


#### Related issue: [10728](https://github.com/actions/runner-images/issues/10728)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
