### PR TITLE
[Windows] Update WDK and SDK to latest version on windows 22 image

### DIFF
--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -48,6 +48,11 @@ if (Test-IsWin22) {
         -Url 'https://go.microsoft.com/fwlink/p/?LinkID=2033908' `
         -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
         -ExpectedSignature '7535269B94C1FEA4A5EF6D808E371DA242F27936'
+     # Install Windows 10 SDK version 10.0.26100
+     Install-Binary -Type EXE `
+        -Url 'https://go.microsoft.com/fwlink/?linkid=2286561' `
+        -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
+        -ExpectedSignature '573EF451A68C33FB904346D44551BEF3BB5BBF68'
 }
 
 Invoke-PesterTests -TestFile "VisualStudio"

--- a/images/windows/scripts/build/Install-WDK.ps1
+++ b/images/windows/scripts/build/Install-WDK.ps1
@@ -14,11 +14,13 @@ if (Test-IsWin19) {
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2166289"
     $wdkSignatureThumbprint = "914A09C2E02C696AF394048BCB8D95449BCD5B9E"
     $wdkExtensionPath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"
+
+    # Need to install the VSIX to get the build targets when running VSBuild
+    Install-VSIXFromFile (Resolve-Path -Path $wdkExtensionPath)
 } elseif (Test-IsWin22) {
     # SDK is available through Visual Studio
-    $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2249371"
-    $wdkSignatureThumbprint = "7C94971221A799907BB45665663BBFD587BAC9F8"
-    $wdkExtensionPath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2022\*\WDK.vsix"
+    $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2294834"
+    $wdkSignatureThumbprint = "7920AC8FB05E0FFFE21E8FF4B4F03093BA6AC16E"
 } else {
     throw "Invalid version of Visual Studio is found. Either 2019 or 2022 are required"
 }
@@ -29,7 +31,5 @@ Install-Binary -Type EXE `
     -InstallArgs @("/features", "+", "/quiet") `
     -ExpectedSignature $wdkSignatureThumbprint
 
-# Need to install the VSIX to get the build targets when running VSBuild
-Install-VSIXFromFile (Resolve-Path -Path $wdkExtensionPath)
 
 Invoke-PesterTests -TestFile "WDK"

--- a/images/windows/scripts/tests/VisualStudio.Tests.ps1
+++ b/images/windows/scripts/tests/VisualStudio.Tests.ps1
@@ -36,3 +36,9 @@ Describe "Windows 11 SDK" {
         "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.22621.0\UAP.props" | Should -Exist
     }
 }
+
+Describe "Windows 11 SDK" {
+    It "Verifies 26100 SDK is installed" -Skip:(Test-IsWin19) {
+        "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.26100.0\UAP.props" | Should -Exist
+    }
+}

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -264,7 +264,17 @@
             "Component.MDD.Linux",
             "Component.MDD.Linux.GCC.arm",
             "Component.Microsoft.Windows.DriverKit",
-            "wasm.tools"
+            "wasm.tools",
+            "Microsoft.Component.MSBuild",
+            "Microsoft.VisualStudio.Component.CoreEditor",
+            "Microsoft.VisualStudio.Component.NuGet",
+            "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+            "Microsoft.VisualStudio.Component.TextTemplating",
+            "Microsoft.VisualStudio.Component.VC.CoreIde",
+            "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+            "Microsoft.VisualStudio.Component.Windows10SDK",
+            "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
+            "Microsoft.VisualStudio.Workload.CoreEditor"
         ],
         "vsix": [
             "SSIS.MicrosoftDataToolsIntegrationServices",


### PR DESCRIPTION
# Description
This PR updates

-  The Windows Driver Kit (WDK) and Windows Software Development Kit (SDK) to the latest version on the Windows 2022 image.
- Removed $wdkExtensionPath for windows 2022 image as `wdk.vsix` install with Visual Studio components. 
- Written test cases for the changes and updates the toolset with supported components.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
