### PR TITLE
[Windows] -VS-Signature update in Windows2019 and 2022

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -250,7 +250,7 @@
         "edition" : "Enterprise",
         "channel": "release",
         "signature": ["F9A7CF9FBE13BAC767F4781061332DA6E8B4E0EE",
-                       "C2048FB509F1C37A8C3E9EC6648118458AA01780" 
+                       "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D" 
                     ],
         "workloads": [
             "Component.Dotfuscator",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -179,7 +179,7 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "C2048FB509F1C37A8C3E9EC6648118458AA01780",
+        "signature": "8F985BE8FD256085C90A95D3C74580511A1DB975",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",


### PR DESCRIPTION
This PR updates VS signature thumbprint for windows-2019 , 2022 image.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/6532

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
