### PR TITLE
Disable `rustup` self-updating

### DIFF
--- a/images/macos/scripts/build/install-rust.sh
+++ b/images/macos/scripts/build/install-rust.sh
@@ -15,6 +15,15 @@ rustup-init -y --no-modify-path --default-toolchain=stable --profile=minimal
 echo "Initialize environment variables..."
 CARGO_HOME=$HOME/.cargo
 
+echo "Disable rustup self-updating"
+# This is undesirable because:
+# - We will keep rustup updated (just like any other dependency).
+# - rustup does not need to be the latest and greatest.
+# - Self-updating in CI will introduce longer build times for no benefit.
+# - ... which becomes important because self-updating happens in various
+#   places, including `rustup toolchain install`.
+rustup set auto-self-update disable
+
 echo "Install common tools..."
 rustup component add rustfmt clippy
 

--- a/images/ubuntu/scripts/build/install-rust.sh
+++ b/images/ubuntu/scripts/build/install-rust.sh
@@ -16,6 +16,16 @@ curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profi
 # Initialize environment variables
 source $CARGO_HOME/env
 
+# Disable rustup self-updating
+#
+# This is undesirable because:
+# - We will keep rustup updated (just like any other dependency).
+# - Rustup does not need to be the latest and greatest.
+# - Self-updating in CI will introduce longer build times for no benefit.
+# - ... which becomes important because self-updating happens in various
+#   places, including `rustup toolchain install`.
+rustup set auto-self-update disable
+
 # Install common tools
 rustup component add rustfmt clippy
 

--- a/images/windows/scripts/build/Install-Rust.ps1
+++ b/images/windows/scripts/build/Install-Rust.ps1
@@ -28,6 +28,16 @@ Add-DefaultPathItem "%USERPROFILE%\.cargo\bin"
 # Add Rust binaries to the path
 $env:Path += ";$env:CARGO_HOME\bin"
 
+# Disable rustup self-updating
+#
+# This is undesirable because:
+# - We will keep rustup updated (just like any other dependency).
+# - rustup does not need to be the latest and greatest.
+# - Self-updating in CI will introduce longer build times for no benefit.
+# - ... which becomes important because self-updating happens in various
+#   places, including `rustup toolchain install`.
+rustup set auto-self-update disable
+
 # Add i686 target for building 32-bit binaries
 rustup target add i686-pc-windows-msvc
 


### PR DESCRIPTION
# Description
`rustup` [has a mechanism for self-updating](https://rust-lang.github.io/rustup/basics.html#keeping-rustup-up-to-date), which triggers whenever you request it to install a new toolchain. This is annoying to have happen in CI though, since it increases build time for no benefit (both the check itself, and the eventual update if rustup deems it necessary).

So let's disable this!

Since this is a behavioural change, it [could be considered a breaking change](https://xkcd.com/1172/), though I will argue that it isn't, people shouldn't need to update `rustup` itself during a build (`rustup update` to fetch a newer `rustc`/`cargo` still works fine).

#### Related issue:
https://github.com/actions/runner-images/issues/246, the proposed workaround in there (`--no-self-update`) wouldn't be necessary any more.

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
