### PR TITLE
[MacOS]Upgrade cmake to 3.31.0

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -42,7 +42,7 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.22.1"
+            "cmake;3.31.0"
         ],
         "ndk": {
             "default": "26",

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -40,7 +40,7 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.22.1"
+            "cmake;3.31.0"
         ],
         "ndk": {
             "default": "26",

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -36,7 +36,7 @@
         ],
         "addons": [],
         "additional_tools": [
-            "cmake;3.22.1"
+            "cmake;3.31.0"
         ],
         "ndk": {
             "default": "27",


### PR DESCRIPTION
# Description
Updating Cmake 3.22.1 to 3.31.0
Related issue [Link](https://github.com/actions/runner-images/issues/10933)

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
