### PR TITLE
[macOS] Pin version for Az powershell module

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -52,7 +52,12 @@
         }
     },
     "powershellModules": [
-        { "name": "Az" },
+        {
+            "name": "Az",
+            "versions": [
+                "12.4.0"
+            ]
+        },
         { "name": "Pester" },
         { "name": "PSScriptAnalyzer" }
     ],

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -54,7 +54,12 @@
         }
     },
     "powershellModules": [
-        { "name": "Az" },
+        {
+            "name": "Az",
+            "versions": [
+                "12.4.0"
+            ]
+        },
         { "name": "Pester" },
         { "name": "PSScriptAnalyzer" }
     ],

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -46,7 +46,12 @@
         }
     },
     "powershellModules": [
-        { "name": "Az" },
+        {
+            "name": "Az",
+            "versions": [
+                "12.4.0"
+            ]
+        },
         { "name": "Pester" },
         { "name": "PSScriptAnalyzer" }
     ],


### PR DESCRIPTION
# Description

Pin version for Az powershell module to `Az: 12.4.0` for all macOS images.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
