### PR TITLE
[Ubuntu] Fix .NET SDK extraction

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -230,7 +230,7 @@ $browsersTools.AddHeader("Environment variables").AddTable($(Build-BrowserWebdri
 
 # .NET Tools
 $netCoreTools = $installedSoftware.AddHeader(".NET Tools")
-$netCoreTools.AddToolVersionsListInline(".NET Core SDK", $(Get-DotNetCoreSdkVersions), "^\d+\.\d+\.\d")
+$netCoreTools.AddToolVersionsListInline(".NET Core SDK", $(Get-DotNetCoreSdkVersions), "^\d+\.\d+\.\d+")
 $netCoreTools.AddNodes($(Get-DotnetTools))
 
 # Databases


### PR DESCRIPTION
# Description

We noticed in our own builds, that the extra home repository sourced .NET SDKs are missing.
This should fix that.

Fixes #10656

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
