### PR TITLE
[macOS] Update Xcode 16.2 Beta on macOS15

### DIFF
--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -3,6 +3,7 @@
         "default": "15.4",
         "x64": {
             "versions": [
+                { "link": "16.2_beta_3", "version": "16.2.0-Beta.3+16C5023f", "symlinks": ["16.2"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "04f3a3e3daf5d07e5ecfdf3cd7fc34fcf0a654884388d56f9f69942a9e3b1e66"},
                 { "link": "16.1", "version": "16.1+16B40", "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
                 { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
@@ -14,6 +15,7 @@
         },
         "arm64":{
             "versions": [
+                { "link": "16.2_beta_3", "version": "16.2.0-Beta.3+16C5023f", "symlinks": ["16.2"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "04f3a3e3daf5d07e5ecfdf3cd7fc34fcf0a654884388d56f9f69942a9e3b1e66"},
                 { "link": "16.1", "version": "16.1+16B40", "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
                 { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -3,7 +3,6 @@
         "default": "15.4",
         "x64": {
             "versions": [
-                { "link": "16.2_beta_3", "version": "16.2.0-Beta.3+16C5023f", "symlinks": ["16.2"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "04f3a3e3daf5d07e5ecfdf3cd7fc34fcf0a654884388d56f9f69942a9e3b1e66"},
                 { "link": "16.1", "version": "16.1+16B40", "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
                 { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
@@ -15,7 +14,6 @@
         },
         "arm64":{
             "versions": [
-                { "link": "16.2_beta_3", "version": "16.2.0-Beta.3+16C5023f", "symlinks": ["16.2"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "04f3a3e3daf5d07e5ecfdf3cd7fc34fcf0a654884388d56f9f69942a9e3b1e66"},
                 { "link": "16.1", "version": "16.1+16B40", "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
                 { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"},
                 { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -3,14 +3,14 @@
         "default": "16",
         "x64": {
             "versions": [
-                { "link": "16.2_beta_2", "version": "16.2_beta_2+16C5013f", "symlinks": ["16.2"], "install_runtimes": "true", "sha256": "b04956fca1b4fe468d5de8833b23c651ed787e41fc5a9c0e29f5eadd5b54d923"},
+                { "link": "16.2_beta_3", "version": "16.2.0-Beta.3+16C5023f", "symlinks": ["16.2"], "install_runtimes": "true", "sha256": "04f3a3e3daf5d07e5ecfdf3cd7fc34fcf0a654884388d56f9f69942a9e3b1e66"},
                 { "link": "16.1", "version": "16.1+16B40", "install_runtimes": "true", "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
                 { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"}
             ]
         },
         "arm64":{
             "versions": [
-                { "link": "16.2_beta_2", "version": "16.2_beta_2+16C5013f", "symlinks": ["16.2"], "install_runtimes": "true", "sha256": "b04956fca1b4fe468d5de8833b23c651ed787e41fc5a9c0e29f5eadd5b54d923"},
+                { "link": "16.2_beta_3", "version": "16.2.0-Beta.3+16C5023f", "symlinks": ["16.2"], "install_runtimes": "true", "sha256": "04f3a3e3daf5d07e5ecfdf3cd7fc34fcf0a654884388d56f9f69942a9e3b1e66"},
                 { "link": "16.1", "version": "16.1+16B40", "install_runtimes": "true", "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
                 { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "install_runtimes": "true", "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"}
             ]


### PR DESCRIPTION
# Description
Replace `Xcode 16.2_beta_2` with `Xcode 16.2_beta_3` on macOS15

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
