### PR TITLE
[MacOS]Update php-8.3 to php-8.4

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -234,7 +234,7 @@
         "version": "15"
     },
     "php": {
-        "version": "8.3"
+        "version": "8.4"
     },
     "mono": {
         "framework":{

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -222,7 +222,7 @@
         "version": "15"
     },
     "php": {
-        "version": "8.3"
+        "version": "8.4"
     },
     "pwsh": {
         "version": "7.4"

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -209,7 +209,7 @@
         "version": "18"
     },
     "php": {
-        "version": "8.3"
+        "version": "8.4"
     },
     "pwsh": {
         "version": "7.4"


### PR DESCRIPTION
# Description
Updated php-8.3 to php-8.4

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
