### PR TITLE
[Windows] Add windows 2025 image

### DIFF
--- a/images/windows/scripts/build/Configure-ImageDataFile.ps1
+++ b/images/windows/scripts/build/Configure-ImageDataFile.ps1
@@ -15,7 +15,11 @@ $imageMinorVersion = $imageVersionComponents[1]
 $imageDataFile = $env:IMAGEDATA_FILE
 $githubUrl = "https://github.com/actions/runner-images/blob"
 
-if (Test-IsWin22) {
+if (Test-IsWin25) {
+  $imageLabel = "windows-2025"
+  $softwareUrl = "${githubUrl}/win25/$imageMajorVersion.$imageMinorVersion/images/windows/Windows2025-Readme.md"
+  $releaseUrl = "https://github.com/actions/runner-images/releases/tag/win25%2F$imageMajorVersion.$imageMinorVersion"
+} elseif (Test-IsWin22) {
     $imageLabel = "windows-2022"
     $softwareUrl = "${githubUrl}/win22/$imageMajorVersion.$imageMinorVersion/images/windows/Windows2022-Readme.md"
     $releaseUrl = "https://github.com/actions/runner-images/releases/tag/win22%2F$imageMajorVersion.$imageMinorVersion"

--- a/images/windows/scripts/build/Configure-System.ps1
+++ b/images/windows/scripts/build/Configure-System.ps1
@@ -144,27 +144,4 @@ $disableTaskNames | ForEach-Object {
     Disable-ScheduledTask @PSItem -ErrorAction Ignore
 } | Out-Null
 
-if (Test-IsWin25) {
-    $directoriesToCompact = @(
-        'C:\ProgramData\Microsoft\VisualStudio\Packages',
-        'C:\ProgramData\Package Cache',
-        'C:\Windows\assembly',
-        'C:\Windows\WinSxS'
-    )
-    Write-Host "Starting Image slimming process"
-    $start = get-date
-    $ErrorActionPreviousValue = $ErrorActionPreference
-    $ErrorActionPreference = 'SilentlyContinue'
-    Write-Host "Removing 'C:\Windows\Installer' directory"
-    Remove-Item "$env:windir\Installer" -Recurse -Force | Out-Null
-    foreach ($directory in $directoriesToCompact) {
-        Write-Host "Compressing '$directory' directory"
-        & compact /s:"$directory" /c /a /i /EXE:LZX * | Out-Null
-    }
-    $ErrorActionPreference = $ErrorActionPreviousValue
-    $finish = get-date
-    $time = "$(($finish - $start).Minutes):$(($finish - $start).Seconds)"
-    Write-Host "The process took a total of $time (in minutes:seconds)"
-}
-
 Write-Host "Configure-System.ps1 - completed"

--- a/images/windows/scripts/build/Configure-User.ps1
+++ b/images/windows/scripts/build/Configure-User.ps1
@@ -27,18 +27,26 @@ if ($LASTEXITCODE -ne 0) {
     throw "Failed to copy HKCU\Software\Microsoft\VisualStudio to HKLM\DEFAULT\Software\Microsoft\VisualStudio"
 }
 
-# disable TSVNCache.exe
-$registryKeyPath = 'HKCU:\Software\TortoiseSVN'
-if (-not(Test-Path -Path $registryKeyPath)) {
-    New-Item -Path $registryKeyPath -ItemType Directory -Force
-}
+# TortoiseSVN not installed on Windows 2025 image due to Sysprep issues
+if (-not (Test-IsWin25)) {
+    # disable TSVNCache.exe
+    $registryKeyPath = 'HKCU:\Software\TortoiseSVN'
+    if (-not(Test-Path -Path $registryKeyPath)) {
+        New-Item -Path $registryKeyPath -ItemType Directory -Force
+    }
 
-New-ItemProperty -Path $registryKeyPath -Name CacheType -PropertyType DWORD -Value 0
-reg.exe copy HKCU\Software\TortoiseSVN HKLM\DEFAULT\Software\TortoiseSVN /s
-if ($LASTEXITCODE -ne 0) {
-    throw "Failed to copy HKCU\Software\TortoiseSVN to HKLM\DEFAULT\Software\TortoiseSVN"
+    New-ItemProperty -Path $registryKeyPath -Name CacheType -PropertyType DWORD -Value 0
+    reg.exe copy HKCU\Software\TortoiseSVN HKLM\DEFAULT\Software\TortoiseSVN /s
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to copy HKCU\Software\TortoiseSVN to HKLM\DEFAULT\Software\TortoiseSVN"
+    }
 }
-
 Dismount-RegistryHive "HKLM\DEFAULT"
+
+# Remove the "installer" (var.install_user) user profile for Windows 2025 image
+if (Test-IsWin25) {
+    Get-CimInstance -ClassName Win32_UserProfile | where-object {$_.LocalPath -match $env:INSTALL_USER} | Remove-CimInstance -Confirm:$false
+    & net user $env:INSTALL_USER /DELETE
+}
 
 Write-Host "Configure-User.ps1 - completed"

--- a/images/windows/scripts/build/Install-Docker.ps1
+++ b/images/windows/scripts/build/Install-Docker.ps1
@@ -41,16 +41,18 @@ if ($LastExitCode -ne 0) {
 # https://github.com/Azure/azure-cli/issues/18766
 New-Item -ItemType SymbolicLink -Path "C:\Windows\SysWOW64\docker.exe" -Target "C:\Windows\System32\docker.exe"
 
-Write-Host "Download docker images"
-$dockerImages = (Get-ToolsetContent).docker.images
-foreach ($dockerImage in $dockerImages) {
-    Write-Host "Pulling docker image $dockerImage ..."
-    docker pull $dockerImage
+if (-not (Test-IsWin25)) {
+    Write-Host "Download docker images"
+    $dockerImages = (Get-ToolsetContent).docker.images
+    foreach ($dockerImage in $dockerImages) {
+        Write-Host "Pulling docker image $dockerImage ..."
+        docker pull $dockerImage
 
-    if (!$?) {
-        throw "Docker pull failed with a non-zero exit code ($LastExitCode)"
+        if (!$?) {
+            throw "Docker pull failed with a non-zero exit code ($LastExitCode)"
+        }
     }
+    Invoke-PesterTests -TestFile "Docker" -TestName "DockerImages"
 }
 
 Invoke-PesterTests -TestFile "Docker" -TestName "Docker"
-Invoke-PesterTests -TestFile "Docker" -TestName "DockerImages"

--- a/images/windows/scripts/build/Install-Haskell.ps1
+++ b/images/windows/scripts/build/Install-Haskell.ps1
@@ -29,10 +29,15 @@ Add-MachinePathItem "$ghcupPrefix\ghcup\bin"
 Add-MachinePathItem "$cabalDir\bin"
 Update-Environment
 
-# Get 3 latest versions of GHC
+# Get 1 or 3 latest versions of GHC depending on the OS version
+If (Test-IsWin25) {
+    $numberOfVersions = 1
+} else {
+    $numberOfVersions = 3
+}
 $versions = ghcup list -t ghc -r | Where-Object { $_ -notlike "prerelease" }
 $versionsOutput = [version[]]($versions | ForEach-Object { $_.Split(' ')[1]; })
-$latestMajorMinor = $versionsOutput | Group-Object { $_.ToString(2) } | Sort-Object { [Version] $_.Name } | Select-Object -last 3
+$latestMajorMinor = $versionsOutput | Group-Object { $_.ToString(2) } | Sort-Object { [Version] $_.Name } | Select-Object -last $numberOfVersions
 $versionsList = $latestMajorMinor | ForEach-Object { $_.Group | Select-Object -Last 1 } | Sort-Object
 
 # The latest version will be installed as a default

--- a/images/windows/scripts/build/Install-Mingw64.ps1
+++ b/images/windows/scripts/build/Install-Mingw64.ps1
@@ -27,13 +27,13 @@ if (Test-IsWin19) {
         $path = "C:\$_\bin\mingw32-make.exe" | Get-Item
         Copy-Item -Path $path -Destination (Join-Path $path.Directory 'make.exe')
     }
-    
+
     Add-MachinePathItem "C:\mingw64\bin"
 
 }
 
-if (Test-IsWin22) {
-    # If Windows 2022, install version specified in the toolset
+if (-not (Test-IsWin19)) {
+    # If Windows 2022 0r 2025 install version specified in the toolset
     $version = (Get-ToolsetContent).mingw.version
     $runtime = (Get-ToolsetContent).mingw.runtime
 

--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -39,4 +39,18 @@ $mongodbService.WaitForStatus('Running', '00:01:00')
 Stop-Service $mongodbService
 $mongodbService | Set-Service -StartupType Disabled
 
+# Install mongodb shell for mongodb > 5 version
+if (Test-IsWin25) {
+    $mongoshVersion = (Get-GithubReleasesByVersion -Repo "mongodb-js/mongosh" -Version "latest").version
+
+    $mongoshDownloadUrl = Resolve-GithubReleaseAssetUrl `
+        -Repo "mongodb-js/mongosh" `
+        -Version $mongoshVersion `
+        -UrlMatchPattern "mongosh-*-x64.msi"
+
+    Install-Binary -Type MSI `
+    -Url $mongoshDownloadUrl `
+    -ExpectedSignature 'F2D7C28591847BB2CB2B1C2A0C59459FDC728A38'
+}
+
 Invoke-PesterTests -TestFile "Databases" -TestName "MongoDB"

--- a/images/windows/scripts/build/Install-Rust.ps1
+++ b/images/windows/scripts/build/Install-Rust.ps1
@@ -39,13 +39,13 @@ rustup component add rustfmt clippy
 if ($LASTEXITCODE -ne 0) {
     throw "Rust component installation failed with exit code $LASTEXITCODE"
 }
-
-cargo install bindgen-cli cbindgen cargo-audit cargo-outdated
-if ($LASTEXITCODE -ne 0) {
-    throw "Rust tools installation failed with exit code $LASTEXITCODE"
+if (-not (Test-IsWin25)) {
+    cargo install bindgen-cli cbindgen cargo-audit cargo-outdated
+    if ($LASTEXITCODE -ne 0) {
+        throw "Rust tools installation failed with exit code $LASTEXITCODE"
+    }
+    # Cleanup Cargo crates cache
+    Remove-Item "${env:CARGO_HOME}\registry\*" -Recurse -Force
 }
-
-# Cleanup Cargo crates cache
-Remove-Item "${env:CARGO_HOME}\registry\*" -Recurse -Force
 
 Invoke-PesterTests -TestFile "Rust"

--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -39,15 +39,18 @@ if (Test-IsWin19) {
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/p/?linkid=2196241' `
         -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-        -ExpectedSignature 'E4C5C5FCDB68B930EE4E19BC25D431EF6D864C51'   
+        -ExpectedSignature 'E4C5C5FCDB68B930EE4E19BC25D431EF6D864C51'
 }
 
-if (Test-IsWin22) {    
+if (Test-IsWin22) {
     # Install Windows 10 SDK version 10.0.17763
     Install-Binary -Type EXE `
-        -Url 'https://go.microsoft.com/fwlink/p/?LinkID=2033908' `
-        -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-        -ExpectedSignature '7535269B94C1FEA4A5EF6D808E371DA242F27936'
+    -Url 'https://go.microsoft.com/fwlink/p/?LinkID=2033908' `
+    -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
+    -ExpectedSignature '7535269B94C1FEA4A5EF6D808E371DA242F27936'
+}
+
+if (-not (Test-IsWin19)) {
      # Install Windows 11 SDK version 10.0.26100
      Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/?linkid=2286561' `

--- a/images/windows/scripts/build/Invoke-Cleanup.ps1
+++ b/images/windows/scripts/build/Invoke-Cleanup.ps1
@@ -49,3 +49,24 @@ cmd /c "npm cache clean --force 2>&1" | Out-Null
 if ($LASTEXITCODE -ne 0) {
     throw "Failed to clean npm cache"
 }
+
+if (Test-IsWin25) {
+    $directoriesToCompact = @(
+        'C:\Windows\assembly',
+        'C:\Windows\WinSxS'
+    )
+    Write-Host "Starting Image slimming process"
+    $start = get-date
+    $ErrorActionPreviousValue = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    Write-Host "Removing 'C:\Windows\Installer' directory"
+    Remove-Item "$env:windir\Installer" -Recurse -Force | Out-Null
+    foreach ($directory in $directoriesToCompact) {
+        Write-Host "Compressing '$directory' directory"
+        & compact /s:"$directory" /c /a /i /EXE:LZX * | Out-Null
+    }
+    $ErrorActionPreference = $ErrorActionPreviousValue
+    $finish = get-date
+    $time = "$(($finish - $start).Minutes):$(($finish - $start).Seconds)"
+    Write-Host "The process took a total of $time (in minutes:seconds)"
+}

--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -80,16 +80,22 @@ if (Test-IsWin19) {
     $tools.AddToolVersion("Google Cloud CLI", $(Get-GoogleCloudCLIVersion))
 }
 $tools.AddToolVersion("ImageMagick", $(Get-ImageMagickVersion))
-$tools.AddToolVersion("InnoSetup", $(Get-InnoSetupVersion))
+if (-not (Test-IsWin25)) {
+    $tools.AddToolVersion("InnoSetup", $(Get-InnoSetupVersion))
+}
 $tools.AddToolVersion("jq", $(Get-JQVersion))
 $tools.AddToolVersion("Kind", $(Get-KindVersion))
 $tools.AddToolVersion("Kubectl", $(Get-KubectlVersion))
-$tools.AddToolVersion("Mercurial", $(Get-MercurialVersion))
+if (-not (Test-IsWin25)) {
+    $tools.AddToolVersion("Mercurial", $(Get-MercurialVersion))
+}
 $tools.AddToolVersion("gcc", $(Get-GCCVersion))
 $tools.AddToolVersion("gdb", $(Get-GDBVersion))
 $tools.AddToolVersion("GNU Binutils", $(Get-GNUBinutilsVersion))
 $tools.AddToolVersion("Newman", $(Get-NewmanVersion))
-$tools.AddToolVersion("NSIS", $(Get-NSISVersion))
+if (-not (Test-IsWin25)) {
+    $tools.AddToolVersion("NSIS", $(Get-NSISVersion))
+}
 $tools.AddToolVersion("OpenSSL", $(Get-OpenSSLVersion))
 $tools.AddToolVersion("Packer", $(Get-PackerVersion))
 if (Test-IsWin19) {
@@ -99,7 +105,9 @@ $tools.AddToolVersion("Pulumi", $(Get-PulumiVersion))
 $tools.AddToolVersion("R", $(Get-RVersion))
 $tools.AddToolVersion("Service Fabric SDK", $(Get-ServiceFabricSDKVersion))
 $tools.AddToolVersion("Stack", $(Get-StackVersion))
-$tools.AddToolVersion("Subversion (SVN)", $(Get-SVNVersion))
+if (-not (Test-IsWin25)) {
+    $tools.AddToolVersion("Subversion (SVN)", $(Get-SVNVersion))
+}
 $tools.AddToolVersion("Swig", $(Get-SwigVersion))
 $tools.AddToolVersion("VSWhere", $(Get-VSWhereVersion))
 $tools.AddToolVersion("WinAppDriver", $(Get-WinAppDriver))
@@ -109,7 +117,9 @@ $tools.AddToolVersion("zstd", $(Get-ZstdVersion))
 
 # CLI Tools
 $cliTools = $installedSoftware.AddHeader("CLI Tools")
-$cliTools.AddToolVersion("Alibaba Cloud CLI", $(Get-AlibabaCLIVersion))
+if (-not (Test-IsWin25)) {
+    $cliTools.AddToolVersion("Alibaba Cloud CLI", $(Get-AlibabaCLIVersion))
+}
 $cliTools.AddToolVersion("AWS CLI", $(Get-AWSCLIVersion))
 $cliTools.AddToolVersion("AWS SAM CLI", $(Get-AWSSAMVersion))
 $cliTools.AddToolVersion("AWS Session Manager CLI", $(Get-AWSSessionManagerVersion))
@@ -129,10 +139,12 @@ $rustTools.AddToolVersion("Rustdoc", $(Get-RustdocVersion))
 $rustTools.AddToolVersion("Rustup", $(Get-RustupVersion))
 
 $rustToolsPackages = $rustTools.AddHeader("Packages")
-$rustToolsPackages.AddToolVersion("bindgen", $(Get-BindgenVersion))
-$rustToolsPackages.AddToolVersion("cargo-audit", $(Get-CargoAuditVersion))
-$rustToolsPackages.AddToolVersion("cargo-outdated", $(Get-CargoOutdatedVersion))
-$rustToolsPackages.AddToolVersion("cbindgen", $(Get-CbindgenVersion))
+if (-not (Test-IsWin25)) {
+    $rustToolsPackages.AddToolVersion("bindgen", $(Get-BindgenVersion))
+    $rustToolsPackages.AddToolVersion("cargo-audit", $(Get-CargoAuditVersion))
+    $rustToolsPackages.AddToolVersion("cargo-outdated", $(Get-CargoOutdatedVersion))
+    $rustToolsPackages.AddToolVersion("cbindgen", $(Get-CbindgenVersion))
+}
 $rustToolsPackages.AddToolVersion("Clippy", $(Get-RustClippyVersion))
 $rustToolsPackages.AddToolVersion("Rustfmt", $(Get-RustfmtVersion))
 
@@ -179,6 +191,9 @@ $databaseTools.AddToolVersion("DacFx", $(Get-DacFxVersion))
 $databaseTools.AddToolVersion("MySQL", $(Get-MySQLVersion))
 $databaseTools.AddToolVersion("SQL OLEDB Driver", $(Get-SQLOLEDBDriverVersion))
 $databaseTools.AddToolVersion("SQLPS", $(Get-SQLPSVersion))
+if (Test-IsWin25) {
+    $databaseTools.AddToolVersion("MongoDB Shell (mongosh)", $(Get-MongoshVersion))
+}
 
 # Web Servers
 $installedSoftware.AddHeader("Web Servers").AddTable($(Build-WebServersSection))
@@ -222,7 +237,9 @@ Azure PowerShell module 2.1.0 and AzureRM PowerShell module 2.1.0 are installed
 and are available via 'Get-Module -ListAvailable'.
 All other versions are saved but not installed.
 '@
-$psModules.AddNote($azPsNotes)
+if (-not (Test-IsWin25)) {
+    $psModules.AddNote($azPsNotes)
+}
 
 # Android
 $android = $installedSoftware.AddHeader("Android")
@@ -231,7 +248,9 @@ $android.AddTable($(Build-AndroidTable))
 $android.AddHeader("Environment variables").AddTable($(Build-AndroidEnvironmentTable))
 
 # Cached Docker images
-$installedSoftware.AddHeader("Cached Docker images").AddTable($(Get-CachedDockerImagesTableData))
+if (-not (Test-IsWin25)) {
+    $installedSoftware.AddHeader("Cached Docker images").AddTable($(Get-CachedDockerImagesTableData))
+}
 
 # Generate reports
 $softwareReport.ToJson() | Out-File -FilePath "C:\software-report.json" -Encoding UTF8NoBOM

--- a/images/windows/scripts/docs-gen/SoftwareReport.Databases.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Databases.psm1
@@ -21,8 +21,13 @@ function Get-PostgreSQLTable
 function Get-MongoDBTable
 {
     $name = "MongoDB"
+    if (Test-IsWin25) {
+        $command = "mongod"
+    } else {
+        $command = "mongo"
+    }
     $mongoService = Get-Service -Name $name
-    $mongoVersion = (Get-Command -Name 'mongo').Version.ToString()
+    $mongoVersion = (Get-Command -Name $command).Version.ToString()
     return [PSCustomObject]@{
         Version = $mongoVersion
         ServiceName = $name

--- a/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
@@ -314,3 +314,7 @@ function Get-ImageMagickVersion {
     $magickVersion = $Matches.Version
     return $magickVersion
 }
+
+function Get-MongoshVersion {
+    return $(mongosh --version)
+}

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -22,6 +22,7 @@ Export-ModuleMember -Function @(
     'Get-ToolsetContent'
     'Get-TCToolPath'
     'Get-TCToolVersionPath'
+    'Test-IsWin25'
     'Test-IsWin22'
     'Test-IsWin19'
     'Expand-7ZipArchive'

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -307,6 +307,22 @@ function Get-TCToolVersionPath {
     return Join-Path $foundVersion $Arch
 }
 
+function Test-IsWin25 {
+    <#
+    .SYNOPSIS
+        Checks if the current Windows operating system is Windows Server 2025.
+    .DESCRIPTION
+        This function uses the Get-CimInstance cmdlet to retrieve information
+        about the current Windows operating system. It then checks if the Caption
+        property of the Win32_OperatingSystem class contains the string "2025",
+        indicating that the operating system is Windows Server 2025.
+    .OUTPUTS
+        Returns $true if the current Windows operating system is Windows Server 2025.
+        Otherwise, returns $false.
+    #>
+    (Get-CimInstance -ClassName Win32_OperatingSystem).Caption -match "2025"
+}
+
 function Test-IsWin22 {
     <#
     .SYNOPSIS

--- a/images/windows/scripts/tests/CLI.Tools.Tests.ps1
+++ b/images/windows/scripts/tests/CLI.Tools.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Azure DevOps CLI" {
     }
 }
 
-Describe "Aliyun CLI" {
+Describe "Aliyun CLI" -Skip:(Test-IsWin25) {
     It "Aliyun CLI" {
         "aliyun version" | Should -ReturnZeroExitCode
     }
@@ -39,7 +39,7 @@ Describe "GitHub CLI" {
     }
 }
 
-Describe "CloudFoundry CLI" -Skip:(Test-IsWin22) {
+Describe "CloudFoundry CLI" -Skip:(-not (Test-IsWin19)) {
     It "cf is located in C:\cf-cli" {
         "C:\cf-cli\cf.exe" | Should -Exist
     }

--- a/images/windows/scripts/tests/ChocoPackages.Tests.ps1
+++ b/images/windows/scripts/tests/ChocoPackages.Tests.ps1
@@ -22,13 +22,13 @@ Describe "Bicep" {
     }
 }
 
-Describe "GitVersion" -Skip:(Test-IsWin22) {
+Describe "GitVersion" -Skip:(-not (Test-IsWin19)) {
     It "gitversion is installed" {
         "gitversion /version" | Should -ReturnZeroExitCode
     }
 }
 
-Describe "InnoSetup" {
+Describe "InnoSetup" -Skip:(Test-IsWin25) {
     It "InnoSetup" {
         (Get-Command -Name iscc).CommandType | Should -BeExactly "Application"
     }
@@ -64,7 +64,7 @@ Describe "Pulumi" {
     }
 }
 
-Describe "Svn" {
+Describe "Svn" -Skip:(Test-IsWin25) {
     It "svn" {
         "svn --version --quiet" | Should -ReturnZeroExitCode
     }

--- a/images/windows/scripts/tests/Databases.Tests.ps1
+++ b/images/windows/scripts/tests/Databases.Tests.ps1
@@ -1,7 +1,11 @@
 Describe "MongoDB" {
     Context "Version" {
         It "<ToolName>" -TestCases @(
-            @{ ToolName = "mongo" }
+            if (Test-IsWin25) {
+                @{ ToolName = "mongos" }
+            } else {
+                @{ ToolName = "mongo" }
+            }
             @{ ToolName = "mongod" }
         ) {
             $toolsetVersion = (Get-ToolsetContent).mongodb.version
@@ -24,6 +28,10 @@ Describe "MongoDB" {
         It "<Name> service is disabled" -TestCases $mongoServiceTests {
             $StartType | Should -Be "Disabled"
         }
+    }
+
+    Context "Shell" -Skip:(-not (Test-IsWin19) -or -not (Test-IsWin22)) {
+        "mongosh --version" | Should -Not -BeNullOrEmpty
     }
 }
 

--- a/images/windows/scripts/tests/Docker.Tests.ps1
+++ b/images/windows/scripts/tests/Docker.Tests.ps1
@@ -25,7 +25,7 @@ Describe "DockerWinCred" {
     }
 }
 
-Describe "DockerImages" {
+Describe "DockerImages" -Skip:(Test-IsWin25) {
     Context "docker images" {
         $testCases = (Get-ToolsetContent).docker.images | ForEach-Object { @{ ImageName = $_ } }
 

--- a/images/windows/scripts/tests/Haskell.Tests.ps1
+++ b/images/windows/scripts/tests/Haskell.Tests.ps1
@@ -24,12 +24,18 @@ Describe "Haskell" {
         @{envVar = "GHCUP_MSYS2"}
     )
 
+    If (Test-IsWin25) {
+        $numberOfVersions = 1
+    } else {
+        $numberOfVersions = 3
+    }
+
     It "<envVar> environment variable exists" -TestCases $ghcupEnvExists {
         Test-Path env:\$envVar
     }
 
-    It "Accurate 3 versions of GHC are installed" -TestCases @{ghcCount = $ghcCount} {
-        $ghcCount | Should -BeExactly 3
+    It "Accurate $numberOfVersions versions of GHC are installed" -TestCases @{ghcCount = $ghcCount; numberOfVersions = $numberOfVersions} {
+        $ghcCount | Should -BeExactly $numberOfVersions
     }
 
     It "GHC <ghcVersion> is installed" -TestCases $ghcTestCases {

--- a/images/windows/scripts/tests/Rust.Tests.ps1
+++ b/images/windows/scripts/tests/Rust.Tests.ps1
@@ -5,15 +5,23 @@ Describe "Rust" {
         $env:Path += ";$env:CARGO_HOME\bin"
     }
 
-    $rustTools = @(
-        @{ToolName = "rustup"; binPath = "C:\Users\Default\.cargo\bin\rustup.exe"}
-        @{ToolName = "rustc"; binPath = "C:\Users\Default\.cargo\bin\rustc.exe"}
-        @{ToolName = "bindgen.exe"; binPath = "C:\Users\Default\.cargo\bin\bindgen.exe"}
-        @{ToolName = "cbindgen.exe"; binPath = "C:\Users\Default\.cargo\bin\cbindgen.exe"}
-        @{ToolName = "cargo"; binPath = "C:\Users\Default\.cargo\bin\cargo.exe"}
-        @{ToolName = "cargo audit"; binPath = "C:\Users\Default\.cargo\bin\cargo-audit.exe"}
-        @{ToolName = "cargo outdated"; binPath = "C:\Users\Default\.cargo\bin\cargo-outdated.exe"}
-    )
+    if (Test-IsWin25) {
+        $rustTools = @(
+            @{ToolName = "rustup"; binPath = "C:\Users\Default\.cargo\bin\rustup.exe"}
+            @{ToolName = "rustc"; binPath = "C:\Users\Default\.cargo\bin\rustc.exe"}
+            @{ToolName = "cargo"; binPath = "C:\Users\Default\.cargo\bin\cargo.exe"}
+        )
+    } else {
+        $rustTools = @(
+            @{ToolName = "rustup"; binPath = "C:\Users\Default\.cargo\bin\rustup.exe"}
+            @{ToolName = "rustc"; binPath = "C:\Users\Default\.cargo\bin\rustc.exe"}
+            @{ToolName = "bindgen.exe"; binPath = "C:\Users\Default\.cargo\bin\bindgen.exe"}
+            @{ToolName = "cbindgen.exe"; binPath = "C:\Users\Default\.cargo\bin\cbindgen.exe"}
+            @{ToolName = "cargo"; binPath = "C:\Users\Default\.cargo\bin\cargo.exe"}
+            @{ToolName = "cargo audit"; binPath = "C:\Users\Default\.cargo\bin\cargo-audit.exe"}
+            @{ToolName = "cargo outdated"; binPath = "C:\Users\Default\.cargo\bin\cargo-outdated.exe"}
+        )
+    }
 
     $rustEnvNotExists = @(
         @{envVar = "RUSTUP_HOME"}

--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -55,19 +55,19 @@ Describe "DACFx" {
         "${sqlPackagePath}" | Should -Exist
     }
 
-    It "SqlLocalDB" -Skip:(Test-IsWin22) {
+    It "SqlLocalDB" -Skip:(-not (Test-IsWin19)) {
         $sqlLocalDBPath = 'C:\Program Files\Microsoft SQL Server\130\Tools\Binn\SqlLocalDB.exe'
         "${sqlLocalDBPath}" | Should -Exist
     }
 }
 
-Describe "DotnetTLS" -Skip:(Test-IsWin22) {
+Describe "DotnetTLS" -Skip:(-not (Test-IsWin19)) {
     It "Tls 1.2 is enabled" {
         [Net.ServicePointManager]::SecurityProtocol -band "Tls12" | Should -Be Tls12
     }
 }
 
-Describe "Mercurial" {
+Describe "Mercurial" -Skip:(Test-IsWin25) {
     It "Mercurial" {
         "hg --version" | Should -ReturnZeroExitCode
     }
@@ -101,7 +101,7 @@ Describe "Mingw64" {
     }
 }
 
-Describe "GoogleCloudCLI" -Skip:(Test-IsWin22) {
+Describe "GoogleCloudCLI" -Skip:(-not (Test-IsWin19)) {
     It "<ToolName>" -TestCases @(
         @{ ToolName = "bq" }
         @{ ToolName = "gcloud" }
@@ -117,7 +117,7 @@ Describe "NET48" {
     }
 }
 
-Describe "NSIS" {
+Describe "NSIS" -Skip:(Test-IsWin25) {
     It "NSIS" {
         "makensis /VERSION" | Should -ReturnZeroExitCode
     }
@@ -175,7 +175,7 @@ Describe "Vcpkg" {
     }
 }
 
-Describe "VCRedist" -Skip:(Test-IsWin22) {
+Describe "VCRedist" -Skip:(-not (Test-IsWin19)) {
     It "vcredist_2010_x64" {
         "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1D8E6291-B0D5-35EC-8441-6616F567A0F7}" | Should -Exist
         "C:\Windows\System32\msvcr100.dll" | Should -Exist

--- a/images/windows/scripts/tests/VisualStudio.Tests.ps1
+++ b/images/windows/scripts/tests/VisualStudio.Tests.ps1
@@ -25,20 +25,20 @@ Describe "Visual Studio" {
     }
 }
 
-Describe "Windows 10 SDK" {
-    It "Verifies 17763 SDK is installed" -Skip:(Test-IsWin19) {
+Describe "Windows 10 SDK" -Skip:((Test-IsWin19) -or (Test-IsWin25)) {
+    It "Verifies 17763 SDK is installed" {
         "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.17763.0\UAP.props" | Should -Exist
     }
 }
 
-Describe "Windows 11 SDK" {
-    It "Verifies 22621 SDK is installed" -Skip:(Test-IsWin22) {
+Describe "Windows 11 SDK" -Skip:(-not (Test-IsWin19)) {
+    It "Verifies 22621 SDK is installed" {
         "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.22621.0\UAP.props" | Should -Exist
     }
 }
 
-Describe "Windows 11 SDK" {
-    It "Verifies 26100 SDK is installed" -Skip:(Test-IsWin19) {
+Describe "Windows 11 SDK" -Skip:(Test-IsWin19) {
+    It "Verifies 26100 SDK is installed" {
         "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.26100.0\UAP.props" | Should -Exist
     }
 }

--- a/images/windows/scripts/tests/WDK.Tests.ps1
+++ b/images/windows/scripts/tests/WDK.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "WDK" {
+Describe "WDK" -Skip:(Test-IsWin25) {
   It "WDK exists" {
     $regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
     $installedApplications = Get-ItemProperty -Path $regKey

--- a/images/windows/templates/windows-2025.pkr.hcl
+++ b/images/windows/templates/windows-2025.pkr.hcl
@@ -1,0 +1,451 @@
+packer {
+  required_plugins {
+    azure = {
+      source  = "github.com/hashicorp/azure"
+      version = "1.4.5"
+    }
+  }
+}
+
+locals {
+  managed_image_name = var.managed_image_name != "" ? var.managed_image_name : "packer-${var.image_os}-${var.image_version}"
+}
+variable "agent_tools_directory" {
+  type    = string
+  default = "C:\\hostedtoolcache\\windows"
+}
+
+variable "allowed_inbound_ip_addresses" {
+  type    = list(string)
+  default = []
+}
+
+variable "azure_tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "build_resource_group_name" {
+  type    = string
+  default = "${env("BUILD_RESOURCE_GROUP_NAME")}"
+}
+
+variable "client_cert_path" {
+  type    = string
+  default = "${env("ARM_CLIENT_CERT_PATH")}"
+}
+
+variable "client_id" {
+  type    = string
+  default = "${env("ARM_CLIENT_ID")}"
+}
+
+variable "client_secret" {
+  type      = string
+  default   = "${env("ARM_CLIENT_SECRET")}"
+  sensitive = true
+}
+
+variable "helper_script_folder" {
+  type    = string
+  default = "C:\\Program Files\\WindowsPowerShell\\Modules\\"
+}
+
+variable "image_folder" {
+  type    = string
+  default = "C:\\image"
+}
+
+variable "image_os" {
+  type    = string
+  default = "win22"
+}
+
+variable "image_version" {
+  type    = string
+  default = "dev"
+}
+
+variable "imagedata_file" {
+  type    = string
+  default = "C:\\imagedata.json"
+}
+
+variable "install_password" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "install_user" {
+  type    = string
+  default = "installer"
+}
+
+variable "location" {
+  type    = string
+  default = "${env("ARM_RESOURCE_LOCATION")}"
+}
+
+variable "managed_image_name" {
+  type    = string
+  default = ""
+}
+
+variable "managed_image_resource_group_name" {
+  type    = string
+  default = "${env("ARM_RESOURCE_GROUP")}"
+}
+
+variable "managed_image_storage_account_type" {
+  type    = string
+  default = "Premium_LRS"
+}
+
+variable "object_id" {
+  type    = string
+  default = "${env("ARM_OBJECT_ID")}"
+}
+
+variable "private_virtual_network_with_public_ip" {
+  type    = bool
+  default = false
+}
+
+variable "subscription_id" {
+  type    = string
+  default = "${env("ARM_SUBSCRIPTION_ID")}"
+}
+
+variable "temp_resource_group_name" {
+  type    = string
+  default = "${env("TEMP_RESOURCE_GROUP_NAME")}"
+}
+
+variable "tenant_id" {
+  type    = string
+  default = "${env("ARM_TENANT_ID")}"
+}
+
+variable "virtual_network_name" {
+  type    = string
+  default = "${env("VNET_NAME")}"
+}
+
+variable "virtual_network_resource_group_name" {
+  type    = string
+  default = "${env("VNET_RESOURCE_GROUP")}"
+}
+
+variable "virtual_network_subnet_name" {
+  type    = string
+  default = "${env("VNET_SUBNET")}"
+}
+
+variable "vm_size" {
+  type    = string
+  default = "Standard_F8s_v2"
+}
+
+source "azure-arm" "image" {
+  allowed_inbound_ip_addresses           = "${var.allowed_inbound_ip_addresses}"
+  build_resource_group_name              = "${var.build_resource_group_name}"
+  client_cert_path                       = "${var.client_cert_path}"
+  client_id                              = "${var.client_id}"
+  client_secret                          = "${var.client_secret}"
+  communicator                           = "winrm"
+  image_offer                            = "WindowsServer"
+  image_publisher                        = "MicrosoftWindowsServer"
+  image_sku                              = "2025-Datacenter"
+  location                               = "${var.location}"
+  managed_image_name                     = "${local.managed_image_name}"
+  managed_image_resource_group_name      = "${var.managed_image_resource_group_name}"
+  managed_image_storage_account_type     = "${var.managed_image_storage_account_type}"
+  object_id                              = "${var.object_id}"
+  os_disk_size_gb                        = "150"
+  os_type                                = "Windows"
+  private_virtual_network_with_public_ip = "${var.private_virtual_network_with_public_ip}"
+  subscription_id                        = "${var.subscription_id}"
+  temp_resource_group_name               = "${var.temp_resource_group_name}"
+  tenant_id                              = "${var.tenant_id}"
+  virtual_network_name                   = "${var.virtual_network_name}"
+  virtual_network_resource_group_name    = "${var.virtual_network_resource_group_name}"
+  virtual_network_subnet_name            = "${var.virtual_network_subnet_name}"
+  vm_size                                = "${var.vm_size}"
+  winrm_insecure                         = "true"
+  winrm_use_ssl                          = "true"
+  winrm_username                         = "packer"
+
+  dynamic "azure_tag" {
+    for_each = var.azure_tags
+    content {
+      name  = azure_tag.key
+      value = azure_tag.value
+    }
+  }
+}
+
+build {
+  sources = ["source.azure-arm.image"]
+
+  provisioner "powershell" {
+    inline = ["New-Item -Path ${var.image_folder} -ItemType Directory -Force"]
+  }
+
+  provisioner "file" {
+    destination = "${var.image_folder}\\"
+    sources     = [
+      "${path.root}/../assets",
+      "${path.root}/../scripts",
+      "${path.root}/../toolsets"
+    ]
+  }
+
+  provisioner "file" {
+    destination = "${var.image_folder}\\scripts\\docs-gen\\"
+    source      = "${path.root}/../../../helpers/software-report-base"
+  }
+
+  provisioner "powershell" {
+    inline = [
+      "Move-Item '${var.image_folder}\\assets\\post-gen' 'C:\\post-generation'",
+      "Remove-Item -Recurse '${var.image_folder}\\assets'",
+      "Move-Item '${var.image_folder}\\scripts\\docs-gen' '${var.image_folder}\\SoftwareReport'",
+      "Move-Item '${var.image_folder}\\scripts\\helpers' '${var.helper_script_folder}\\ImageHelpers'",
+      "New-Item -Type Directory -Path '${var.helper_script_folder}\\TestsHelpers\\'",
+      "Move-Item '${var.image_folder}\\scripts\\tests\\Helpers.psm1' '${var.helper_script_folder}\\TestsHelpers\\TestsHelpers.psm1'",
+      "Move-Item '${var.image_folder}\\scripts\\tests' '${var.image_folder}\\tests'",
+      "Remove-Item -Recurse '${var.image_folder}\\scripts'",
+      "Move-Item '${var.image_folder}\\toolsets\\toolset-2025.json' '${var.image_folder}\\toolset.json'",
+      "Remove-Item -Recurse '${var.image_folder}\\toolsets'"
+    ]
+  }
+
+  provisioner "windows-shell" {
+    inline = [
+      "net user ${var.install_user} ${var.install_password} /add /passwordchg:no /passwordreq:yes /active:yes /Y",
+      "net localgroup Administrators ${var.install_user} /add",
+      "winrm set winrm/config/service/auth @{Basic=\"true\"}",
+      "winrm get winrm/config/service/auth"
+    ]
+  }
+
+  provisioner "powershell" {
+    inline = ["if (-not ((net localgroup Administrators) -contains '${var.install_user}')) { exit 1 }"]
+  }
+
+  provisioner "powershell" {
+    elevated_password = "${var.install_password}"
+    elevated_user     = "${var.install_user}"
+    inline            = ["bcdedit.exe /set TESTSIGNING ON"]
+  }
+
+  provisioner "powershell" {
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_OS=${var.image_os}", "AGENT_TOOLSDIRECTORY=${var.agent_tools_directory}", "IMAGEDATA_FILE=${var.imagedata_file}", "IMAGE_FOLDER=${var.image_folder}"]
+    execution_policy = "unrestricted"
+    scripts          = [
+      "${path.root}/../scripts/build/Configure-WindowsDefender.ps1",
+      "${path.root}/../scripts/build/Configure-PowerShell.ps1",
+      "${path.root}/../scripts/build/Install-PowerShellModules.ps1",
+      "${path.root}/../scripts/build/Install-WindowsFeatures.ps1",
+      "${path.root}/../scripts/build/Install-Chocolatey.ps1",
+      "${path.root}/../scripts/build/Configure-BaseImage.ps1",
+      "${path.root}/../scripts/build/Configure-ImageDataFile.ps1",
+      "${path.root}/../scripts/build/Configure-SystemEnvironment.ps1",
+      "${path.root}/../scripts/build/Configure-DotnetSecureChannel.ps1"
+    ]
+  }
+
+  provisioner "windows-restart" {
+    check_registry        = true
+    restart_check_command = "powershell -command \"& {while ( (Get-WindowsOptionalFeature -Online -FeatureName Containers -ErrorAction SilentlyContinue).State -ne 'Enabled' ) { Start-Sleep 30; Write-Output 'InProgress' }}\""
+    restart_timeout       = "10m"
+  }
+
+  provisioner "powershell" {
+    inline = ["Set-Service -Name wlansvc -StartupType Manual", "if ($(Get-Service -Name wlansvc).Status -eq 'Running') { Stop-Service -Name wlansvc}"]
+  }
+
+  provisioner "powershell" {
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    scripts          = [
+      "${path.root}/../scripts/build/Install-Docker.ps1",
+      "${path.root}/../scripts/build/Install-DockerWinCred.ps1",
+      "${path.root}/../scripts/build/Install-DockerCompose.ps1",
+      "${path.root}/../scripts/build/Install-PowershellCore.ps1",
+      "${path.root}/../scripts/build/Install-WebPlatformInstaller.ps1",
+      "${path.root}/../scripts/build/Install-Runner.ps1"
+    ]
+  }
+
+  provisioner "windows-restart" {
+    restart_timeout = "30m"
+  }
+
+  provisioner "powershell" {
+    elevated_password = "${var.install_password}"
+    elevated_user     = "${var.install_user}"
+    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}"]
+    scripts           = [
+      "${path.root}/../scripts/build/Install-VisualStudio.ps1",
+      "${path.root}/../scripts/build/Install-KubernetesTools.ps1"
+    ]
+    valid_exit_codes  = [0, 3010]
+  }
+
+  provisioner "windows-restart" {
+    check_registry  = true
+    restart_timeout = "10m"
+  }
+
+  provisioner "powershell" {
+    pause_before     = "2m0s"
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    scripts          = [
+      "${path.root}/../scripts/build/Install-Wix.ps1",
+      "${path.root}/../scripts/build/Install-VSExtensions.ps1",
+      "${path.root}/../scripts/build/Install-AzureCli.ps1",
+      "${path.root}/../scripts/build/Install-AzureDevOpsCli.ps1",
+      "${path.root}/../scripts/build/Install-ChocolateyPackages.ps1",
+      "${path.root}/../scripts/build/Install-JavaTools.ps1",
+      "${path.root}/../scripts/build/Install-Kotlin.ps1",
+      "${path.root}/../scripts/build/Install-OpenSSL.ps1"
+    ]
+  }
+
+  provisioner "powershell" {
+    execution_policy = "remotesigned"
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    scripts          = ["${path.root}/../scripts/build/Install-ServiceFabricSDK.ps1"]
+  }
+
+  provisioner "windows-restart" {
+    restart_timeout = "10m"
+  }
+
+  provisioner "powershell" {
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    scripts          = [
+      "${path.root}/../scripts/build/Install-ActionsCache.ps1",
+      "${path.root}/../scripts/build/Install-Ruby.ps1",
+      "${path.root}/../scripts/build/Install-PyPy.ps1",
+      "${path.root}/../scripts/build/Install-Toolset.ps1",
+      "${path.root}/../scripts/build/Configure-Toolset.ps1",
+      "${path.root}/../scripts/build/Install-NodeJS.ps1",
+      "${path.root}/../scripts/build/Install-AndroidSDK.ps1",
+      "${path.root}/../scripts/build/Install-PowershellAzModules.ps1",
+      "${path.root}/../scripts/build/Install-Pipx.ps1",
+      "${path.root}/../scripts/build/Install-Git.ps1",
+      "${path.root}/../scripts/build/Install-GitHub-CLI.ps1",
+      "${path.root}/../scripts/build/Install-PHP.ps1",
+      "${path.root}/../scripts/build/Install-Rust.ps1",
+      "${path.root}/../scripts/build/Install-Sbt.ps1",
+      "${path.root}/../scripts/build/Install-Chrome.ps1",
+      "${path.root}/../scripts/build/Install-EdgeDriver.ps1",
+      "${path.root}/../scripts/build/Install-Firefox.ps1",
+      "${path.root}/../scripts/build/Install-Selenium.ps1",
+      "${path.root}/../scripts/build/Install-IEWebDriver.ps1",
+      "${path.root}/../scripts/build/Install-Apache.ps1",
+      "${path.root}/../scripts/build/Install-Nginx.ps1",
+      "${path.root}/../scripts/build/Install-Msys2.ps1",
+      "${path.root}/../scripts/build/Install-WinAppDriver.ps1",
+      "${path.root}/../scripts/build/Install-R.ps1",
+      "${path.root}/../scripts/build/Install-AWSTools.ps1",
+      "${path.root}/../scripts/build/Install-DACFx.ps1",
+      "${path.root}/../scripts/build/Install-MysqlCli.ps1",
+      "${path.root}/../scripts/build/Install-SQLPowerShellTools.ps1",
+      "${path.root}/../scripts/build/Install-SQLOLEDBDriver.ps1",
+      "${path.root}/../scripts/build/Install-DotnetSDK.ps1",
+      "${path.root}/../scripts/build/Install-Mingw64.ps1",
+      "${path.root}/../scripts/build/Install-Haskell.ps1",
+      "${path.root}/../scripts/build/Install-Stack.ps1",
+      "${path.root}/../scripts/build/Install-Miniconda.ps1",
+      "${path.root}/../scripts/build/Install-AzureCosmosDbEmulator.ps1",
+      "${path.root}/../scripts/build/Install-Zstd.ps1",
+      "${path.root}/../scripts/build/Install-Vcpkg.ps1",
+      "${path.root}/../scripts/build/Install-Bazel.ps1",
+      "${path.root}/../scripts/build/Install-RootCA.ps1",
+      "${path.root}/../scripts/build/Install-MongoDB.ps1",
+      "${path.root}/../scripts/build/Install-CodeQLBundle.ps1",
+      "${path.root}/../scripts/build/Configure-Diagnostics.ps1"
+    ]
+  }
+
+  provisioner "powershell" {
+    elevated_password = "${var.install_password}"
+    elevated_user     = "${var.install_user}"
+    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}"]
+    scripts           = [
+      "${path.root}/../scripts/build/Install-PostgreSQL.ps1",
+      "${path.root}/../scripts/build/Install-WindowsUpdates.ps1",
+      "${path.root}/../scripts/build/Configure-DynamicPort.ps1",
+      "${path.root}/../scripts/build/Configure-GDIProcessHandleQuota.ps1",
+      "${path.root}/../scripts/build/Configure-Shell.ps1",
+      "${path.root}/../scripts/build/Configure-DeveloperMode.ps1",
+      "${path.root}/../scripts/build/Install-LLVM.ps1"
+    ]
+  }
+
+  provisioner "windows-restart" {
+    check_registry        = true
+    restart_check_command = "powershell -command \"& {if ((-not (Get-Process TiWorker.exe -ErrorAction SilentlyContinue)) -and (-not [System.Environment]::HasShutdownStarted) ) { Write-Output 'Restart complete' }}\""
+    restart_timeout       = "30m"
+  }
+
+  provisioner "powershell" {
+    pause_before     = "2m0s"
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    scripts          = [
+      "${path.root}/../scripts/build/Install-WindowsUpdatesAfterReboot.ps1",
+      "${path.root}/../scripts/tests/RunAll-Tests.ps1"
+    ]
+  }
+
+  provisioner "powershell" {
+    inline = ["if (-not (Test-Path ${var.image_folder}\\tests\\testResults.xml)) { throw '${var.image_folder}\\tests\\testResults.xml not found' }"]
+  }
+
+  provisioner "powershell" {
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_FOLDER=${var.image_folder}"]
+    inline           = ["pwsh -File '${var.image_folder}\\SoftwareReport\\Generate-SoftwareReport.ps1'"]
+  }
+
+  provisioner "powershell" {
+    inline = ["if (-not (Test-Path C:\\software-report.md)) { throw 'C:\\software-report.md not found' }", "if (-not (Test-Path C:\\software-report.json)) { throw 'C:\\software-report.json not found' }"]
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../Windows2025-Readme.md"
+    direction   = "download"
+    source      = "C:\\software-report.md"
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../software-report.json"
+    direction   = "download"
+    source      = "C:\\software-report.json"
+  }
+
+  provisioner "powershell" {
+    environment_vars = ["INSTALL_USER=${var.install_user}"]
+    scripts          = [
+      "${path.root}/../scripts/build/Install-NativeImages.ps1",
+      "${path.root}/../scripts/build/Configure-System.ps1",
+      "${path.root}/../scripts/build/Configure-User.ps1"
+    ]
+    skip_clean       = true
+  }
+
+  provisioner "windows-restart" {
+    restart_timeout = "10m"
+  }
+
+  provisioner "powershell" {
+    inline = [
+      "if( Test-Path $env:SystemRoot\\System32\\Sysprep\\unattend.xml ){ rm $env:SystemRoot\\System32\\Sysprep\\unattend.xml -Force}",
+      "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quiet /quit",
+      "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10 } else { break } }"
+    ]
+  }
+
+}

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -130,7 +130,7 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D",
+        "signature": "8F985BE8FD256085C90A95D3C74580511A1DB975",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -1,0 +1,328 @@
+{
+    "toolcache": [
+        {
+            "name": "Ruby",
+            "arch": "x64",
+            "platform" : "win32",
+            "versions": [
+                "3.1",
+                "3.2",
+                "3.3"
+            ],
+            "default": "3.3"
+        },
+        {
+            "name": "Python",
+            "url" : "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
+            "arch": "x64",
+            "platform" : "win32",
+            "versions": [
+                "3.9.*",
+                "3.10.*",
+                "3.11.*",
+                "3.12.*",
+                "3.13.*"
+            ],
+            "default": "3.9.*"
+        },
+        {
+            "name": "PyPy",
+            "arch": "x86",
+            "platform" : "win64",
+            "versions": [
+                "3.9",
+                "3.10"
+            ]
+        },
+        {
+            "name": "node",
+            "url" : "https://raw.githubusercontent.com/actions/node-versions/main/versions-manifest.json",
+            "arch": "x64",
+            "platform" : "win32",
+            "versions": [
+                "18.*",
+                "20.*",
+                "22.*"
+            ]
+        },
+        {
+            "name": "go",
+            "url" : "https://raw.githubusercontent.com/actions/go-versions/main/versions-manifest.json",
+            "arch": "x64",
+            "platform" : "win32",
+            "versions": [
+                "1.21.*",
+                "1.22.*",
+                "1.23.*"
+            ],
+            "default": "1.23.*"
+        }
+    ],
+    "powershellModules": [
+        { "name": "DockerMsftProvider" },
+        { "name": "MarkdownPS" },
+        { "name": "Pester" },
+        { "name": "PowerShellGet" },
+        { "name": "PSScriptAnalyzer" },
+        { "name": "PSWindowsUpdate" },
+        { "name": "SqlServer" },
+        { "name": "VSSetup" },
+        { "name": "Microsoft.Graph" },
+        {"name": "AWSPowershell"}
+    ],
+    "azureModules": [
+        {
+            "name": "az",
+            "versions": [
+                "12.4.0"
+            ],
+            "zip_versions": []
+        }
+    ],
+    "java": {
+        "default": "17",
+        "versions": [ "8", "11", "17", "21"]
+    },
+    "android": {
+        "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-12266719_latest.zip",
+        "hash": "F9088C04A44F1F37A8A3A228A7663E11AE9445FA07529C96CEF38ACB985A88F3",
+        "platform_min_version": "35",
+        "build_tools_min_version": "35.0.0",
+        "extras": [
+            "android;m2repository",
+            "google;m2repository",
+            "google;google_play_services"
+        ],
+        "addons": [],
+        "additional_tools": [
+            "cmake;3.22.1",
+            "cmake;3.30.5"
+        ],
+        "ndk": {
+            "default": "27",
+            "versions": [
+                "26", "27"
+            ]
+        }
+    },
+    "mingw": {
+        "version": "14.2.0",
+        "runtime": "ucrt"
+    },
+    "MsysPackages": {
+        "msys2": [],
+        "mingw": []
+    },
+    "windowsFeatures": [
+        { "name": "Containers" },
+        { "name": "Microsoft-Windows-Subsystem-Linux", "optionalFeature": true },
+        { "name": "VirtualMachinePlatform", "optionalFeature": true },
+        { "name": "NET-Framework-45-Features", "includeAllSubFeatures": true },
+        { "name": "Client-ProjFS", "optionalFeature": true },
+        { "name": "NET-Framework-Features", "includeAllSubFeatures": true },
+        { "name": "Hyper-V", "includeAllSubFeatures": true },
+        { "name": "HypervisorPlatform", "optionalFeature": true },
+        { "name": "Hyper-V-PowerShell" },
+        { "name": "Wireless-Networking" }
+    ],
+    "visualStudio": {
+        "version" : "2022",
+        "subversion" : "17",
+        "edition" : "Enterprise",
+        "channel": "release",
+        "signature": "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D",
+        "workloads": [
+            "Component.Dotfuscator",
+            "Component.Linux.CMake",
+            "Component.UnityEngine.x64",
+            "Microsoft.Component.VC.Runtime.UCRTSDK",
+            "Microsoft.Net.Component.4.7.TargetingPack",
+            "Microsoft.Net.Component.4.7.2.TargetingPack",
+            "Microsoft.Net.Component.4.8.1.SDK",
+            "Microsoft.Net.Component.4.8.1.TargetingPack",
+            "Microsoft.VisualStudio.Component.AspNet45",
+            "Microsoft.VisualStudio.Component.Azure.ServiceFabric.Tools",
+            "Microsoft.VisualStudio.Component.Debugger.JustInTime",
+            "Microsoft.VisualStudio.Component.EntityFramework",
+            "Microsoft.VisualStudio.Component.DslTools",
+            "Microsoft.VisualStudio.Component.LinqToSql",
+            "Microsoft.VisualStudio.Component.SQL.SSDT",
+            "Microsoft.VisualStudio.Component.Sharepoint.Tools",
+            "Microsoft.VisualStudio.Component.PortableLibrary",
+            "Microsoft.VisualStudio.Component.TeamOffice",
+            "Microsoft.VisualStudio.Component.TestTools.CodedUITest",
+            "Microsoft.VisualStudio.Component.TestTools.WebLoadTest",
+            "Microsoft.VisualStudio.Component.UWP.VC.ARM64",
+            "Microsoft.VisualStudio.Component.UWP.VC.ARM64EC",
+            "Microsoft.VisualStudio.Component.VC.CLI.Support",
+            "Microsoft.VisualStudio.Component.VC.CMake.Project",
+            "Microsoft.VisualStudio.Component.VC.DiagnosticTools",
+            "Microsoft.VisualStudio.Component.VC.Llvm.Clang",
+            "Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset",
+            "Microsoft.VisualStudio.Component.VC.TestAdapterForBoostTest",
+            "Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest",
+            "Microsoft.VisualStudio.Component.VC.Tools.ARM",
+            "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
+            "Microsoft.VisualStudio.Component.VC.Tools.ARM64EC",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "Microsoft.VisualStudio.Component.VC.Modules.x86.x64",
+            "Microsoft.VisualStudio.Component.VC.Redist.MSM",
+            "Microsoft.VisualStudio.Component.VC.Runtimes.ARM.Spectre",
+            "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
+            "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64EC.Spectre",
+            "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre",
+            "Microsoft.VisualStudio.Component.VC.MFC.ARM",
+            "Microsoft.VisualStudio.Component.VC.MFC.ARM.Spectre",
+            "Microsoft.VisualStudio.Component.VC.MFC.ARM64",
+            "Microsoft.VisualStudio.Component.VC.MFC.ARM64.Spectre",
+            "Microsoft.VisualStudio.Component.VC.ATLMFC",
+            "Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre",
+            "Microsoft.VisualStudio.Component.VC.ATL",
+            "Microsoft.VisualStudio.Component.VC.ATL.Spectre",
+            "Microsoft.VisualStudio.Component.VC.ATL.ARM",
+            "Microsoft.VisualStudio.Component.VC.ATL.ARM.Spectre",
+            "Microsoft.VisualStudio.Component.VC.ATL.ARM64",
+            "Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre",
+            "Microsoft.VisualStudio.Component.VC.ASAN",
+            "Microsoft.VisualStudio.Component.Windows11SDK.26100",
+            "Microsoft.VisualStudio.Component.Workflow",
+            "Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices",
+            "Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools",
+            "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang",
+            "Microsoft.VisualStudio.ComponentGroup.UWP.VC.v142",
+            "Microsoft.VisualStudio.ComponentGroup.Web.CloudTools",
+            "Microsoft.VisualStudio.Workload.Azure",
+            "Microsoft.VisualStudio.Workload.Data",
+            "Microsoft.VisualStudio.Workload.ManagedDesktop",
+            "Microsoft.VisualStudio.Workload.ManagedGame",
+            "Microsoft.VisualStudio.Workload.NativeCrossPlat",
+            "Microsoft.VisualStudio.Workload.NativeDesktop",
+            "Microsoft.VisualStudio.Workload.NativeGame",
+            "Microsoft.VisualStudio.Workload.NativeMobile",
+            "Microsoft.VisualStudio.Workload.NetCrossPlat",
+            "Microsoft.VisualStudio.Workload.NetWeb",
+            "Microsoft.VisualStudio.Workload.Node",
+            "Microsoft.VisualStudio.Workload.Office",
+            "Microsoft.VisualStudio.Workload.Python",
+            "Microsoft.VisualStudio.Workload.Universal",
+            "Microsoft.VisualStudio.Workload.VisualStudioExtension",
+            "Component.MDD.Linux",
+            "Component.MDD.Linux.GCC.arm",
+            "Component.Microsoft.Windows.DriverKit",
+            "wasm.tools",
+            "Microsoft.Component.MSBuild"
+        ],
+        "vsix": [
+            "SSIS.MicrosoftDataToolsIntegrationServices",
+            "VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects",
+            "WixToolset.WixToolsetVisualStudio2022Extension",
+            "ProBITools.MicrosoftReportProjectsforVisualStudio2022",
+            "ProBITools.MicrosoftAnalysisServicesModelingProjects2022"
+        ]
+    },
+    "docker": {
+        "images": [],
+        "components": {
+            "docker": "26.1.3",
+            "compose": "2.27.1"
+        }
+    },
+    "pipx": [
+        {
+            "package": "yamllint",
+            "cmd": "yamllint --version"
+        }
+    ],
+    "selenium": {
+        "version": "4"
+    },
+    "npm": {
+        "global_packages": [
+            { "name": "yarn", "test": "yarn --version" },
+            { "name": "newman", "test": "newman --version" },
+            { "name": "lerna", "test": "lerna --version" },
+            { "name": "gulp-cli", "test": "gulp --version" },
+            { "name": "grunt-cli", "test": "grunt --version" }
+        ]
+    },
+    "serviceFabric": {
+        "runtime": {
+            "version": "10.1.2493.9590",
+            "checksum": "09C63A971BACDE338282C73B3C9174BED9AAD53E1D3A1B73D44515852C9C00CF"
+        },
+        "sdk": {
+            "version": "7.0.2712",
+            "checksum": "69F54790B63488875513964A88AF38C104D3C0D073FC2A63D590F0ADD2773754"
+        }
+    },
+    "dotnet": {
+        "versions": [
+            "8.0",
+            "9.0"
+        ],
+        "tools": [
+            { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }
+        ],
+        "warmup": false
+    },
+    "choco": {
+        "common_packages": [
+            { "name": "7zip.install" },
+            { "name": "aria2" },
+            { "name": "azcopy10" },
+            { "name": "Bicep" },
+            { "name": "jq" },
+            { "name": "NuGet.CommandLine" },
+            { "name": "packer" },
+            {
+                "name": "strawberryperl" ,
+                "args": [ "--version", "5.40.0.1" ]
+            },
+            { "name": "pulumi" },
+            { "name": "swig" },
+            { "name": "vswhere" },
+            {
+                "name": "julia",
+                "args": [ "--ia", "/DIR=C:\\Julia" ]
+            },
+            {
+                "name": "cmake.install",
+                "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
+            },
+            { "name": "imagemagick" }
+        ]
+    },
+    "node": {
+        "default": "22"
+    },
+    "maven": {
+        "version": "3.9"
+    },
+    "mysql": {
+        "version": "8.0",
+        "signature": "DD34D7C71F160972DE0CE25B695A0D6A9C95BD91"
+    },
+    "mongodb": {
+        "version": "7.0",
+        "signature": "F2D7C28591847BB2CB2B1C2A0C59459FDC728A38"
+    },
+    "llvm": {
+        "version": "19"
+    },
+    "php": {
+        "version": "8.3"
+    },
+    "postgresql": {
+        "version": "17",
+        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
+    },
+    "kotlin": {
+        "version": "latest"
+    },
+    "openssl": {
+        "version": "3.4.0"
+    },
+    "pwsh": {
+        "version": "7.4"
+    }
+}


### PR DESCRIPTION
# Description
This PR adds the Windows 2025 image to the repository.

Release notes:
- Updated software:
    - `mingw` was updated to 14.2.0
    - `Azure Service Fabric` runtime was updated to 10.1.2493.9590
    - `Azure Service Fabric` SDK was updated to 7.0.2712
    - `strawberryperl` was updated to 5.40.0.1
    - `maven` was updated to 3.9
    - `LLVM` was updated to 19
    - `PostgreSQL` was updated to 17
    - `openssl` was updated to 3.4.0
    - `MongoDB` was updated to 7.0

- Removed software/Items:
  - InnoSetup
  - Mercurial
  - NSIS
  - Alibaba Cloud CLI
  - bindgen 
  - cbindgen 
  - cargo-audit 
  - cargo-outdated
  - AzureRM PowerShell module
  - Azure PowerShell module
  - .Net v6.0 and v7.0
  - TortoiseSVN
  - Docker images:
    - mcr.microsoft.com/windows/servercore:ltsc2022
    - mcr.microsoft.com/windows/nanoserver:ltsc2022
    - mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022
    - mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022
    - mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022
  - Visual Studio excluded components:
    - Component.Unreal.Android
    - Component.Xamarin
    - Microsoft.VisualStudio.Component.Windows10SDK.19041
    - Microsoft.VisualStudio.Component.Windows10SDK.20348
    - Microsoft.VisualStudio.Component.Windows11SDK.22000
    - Microsoft.VisualStudio.Component.Windows11SDK.22621

- Added software:
   - MongoDB Shell (mongosh)

- Changes in tool cache
  - Default version of `Ruby` was changed to 3.3 
  - `Ruby` version 3.0 was removed
  - `Python` for x86 architecture was removed
  - `Python` versions 3.7 and 3.8 for x64 architecture were removed
  - `PyPy` versions 2.7, 3.7 and 3.8 were removed
  - Default version of `Node` was changed to 22
  - `Node` version 16 was removed
  - Default version of `Go` was changed to 1.23
  - `Go` version 1.20 was removed
 
- Miscellaneous:
  - `Android platform` minimal version was changed to 35
  - Version of `Android platform` command line tools was updated to the latest
  - `cmake` 3.18.1 was removed 
  - `cmake` 3.30.5 was added
  - Standalone `WDK` installation was deprecated. Starting with `Visual Studio` 17.12, the recommended way to [install](https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk#wdk-nuget-package-support) the `WDK` is via nuget
  - Only the latest version of `Haskell` will be installed on the image.
  - Temporary user `Installed` and its profile were removed from the image
  - `TortoiseSVN` cannot be installed to windows 2025 image due to `Sysprep` issues
  - `mongo.exe` has been removed from `MongoDB` since version 6
  - The following directories were [compressed](https://learn.microsoft.com/en-us/windows/win32/fileio/file-compression-and-decompression):
    - C:\Windows\assembly
    - C:\Windows\WinSxS
   
#### Related issue:
https://github.com/actions/runner-images-internal/issues/6399

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
