### PR TITLE
[Windows] Reorganize temporary file storage and separate cleanup activities

### DIFF
--- a/images/windows/scripts/build/Configure-System.ps1
+++ b/images/windows/scripts/build/Configure-System.ps1
@@ -3,12 +3,6 @@
 ##  Desc:  Applies various configuration settings to the final image
 ################################################################################
 
-Write-Host "Cleanup WinSxS"
-dism.exe /online /Cleanup-Image /StartComponentCleanup /ResetBase
-if ($LASTEXITCODE -ne 0) {
-    throw "Failed to cleanup WinSxS"
-}
-
 # Set default version to 1 for WSL (aka LXSS - Linux Subsystem)
 # The value should be set in the default user registry hive
 # https://github.com/actions/runner-images/issues/5760
@@ -31,51 +25,8 @@ if (Test-IsWin22) {
     $key.SetValue("DefaultVersion", "1", "DWord")
     $key.Handle.Close()
     [System.GC]::Collect()
-    
+
     Dismount-RegistryHive "HKLM\DEFAULT"
-}
-
-Write-Host "Clean up various directories"
-@(
-    "$env:SystemDrive\Recovery",
-    "$env:SystemRoot\logs",
-    "$env:SystemRoot\winsxs\manifestcache",
-    "$env:SystemRoot\Temp",
-    "$env:SystemDrive\Users\$env:INSTALL_USER\AppData\Local\Temp",
-    "$env:TEMP",
-    "$env:AZURE_CONFIG_DIR\logs",
-    "$env:AZURE_CONFIG_DIR\commands",
-    "$env:AZURE_CONFIG_DIR\telemetry"
-) | ForEach-Object {
-    if (Test-Path $_) {
-        Write-Host "Removing $_"
-        cmd /c "takeown /d Y /R /f $_ 2>&1" | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to take ownership of $_"
-        }
-        cmd /c "icacls $_ /grant:r administrators:f /t /c /q 2>&1" | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to grant administrators full control of $_"
-        }
-        Remove-Item $_ -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
-    }
-}
-
-$winInstallDir = "$env:SystemRoot\Installer"
-New-Item -Path $winInstallDir -ItemType Directory -Force | Out-Null
-
-# Remove AllUsersAllHosts profile
-Remove-Item $profile.AllUsersAllHosts -Force -ErrorAction SilentlyContinue | Out-Null
-
-# Clean yarn and npm cache
-cmd /c "yarn cache clean 2>&1" | Out-Null
-if ($LASTEXITCODE -ne 0) {
-    throw "Failed to clean yarn cache"
-}
-
-cmd /c "npm cache clean --force 2>&1" | Out-Null
-if ($LASTEXITCODE -ne 0) {
-    throw "Failed to clean npm cache"
 }
 
 # allow msi to write to temp folder

--- a/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
+++ b/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
@@ -9,7 +9,7 @@ $signatureThumbprint = "8740DF4ACB749640AD318E4BE842F72EC651AD80"
 Write-Host "Downloading BizTalk Project Build Component archive..."
 $zipFile = Invoke-DownloadWithRetry $downloadUrl
 
-$setupPath = Join-Path $env:TEMP "BizTalkBuildComponent"
+$setupPath = Join-Path $env:TEMP_DIR "BizTalkBuildComponent"
 if (-not (Test-Path -Path $setupPath)) {
     New-Item -Path $setupPath -ItemType Directory -Force | Out-Null
 }

--- a/images/windows/scripts/build/Install-Docker.ps1
+++ b/images/windows/scripts/build/Install-Docker.ps1
@@ -23,9 +23,9 @@ $mobyReleaseUrl = $dockerceUrl + $mobyRelease
 
 Write-Host "Install Moby $mobyRelease..."
 $mobyArchivePath = Invoke-DownloadWithRetry $mobyReleaseUrl
-Expand-Archive -Path $mobyArchivePath -DestinationPath $env:TEMP
-$dockerPath = "$env:TEMP\docker\docker.exe"
-$dockerdPath = "$env:TEMP\docker\dockerd.exe"
+Expand-Archive -Path $mobyArchivePath -DestinationPath $env:TEMP_DIR
+$dockerPath = "$env:TEMP_DIR\docker\docker.exe"
+$dockerdPath = "$env:TEMP_DIR\docker\dockerd.exe"
 
 Write-Host "Install Docker CE"
 $instScriptUrl = "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1"

--- a/images/windows/scripts/build/Install-Toolset.ps1
+++ b/images/windows/scripts/build/Install-Toolset.ps1
@@ -13,7 +13,7 @@ Function Install-Asset {
     )
 
     $releaseAssetName = [System.IO.Path]::GetFileNameWithoutExtension($ReleaseAsset.filename)
-    $assetFolderPath = Join-Path $env:TEMP $releaseAssetName
+    $assetFolderPath = Join-Path $env:TEMP_DIR $releaseAssetName
     $assetArchivePath = Invoke-DownloadWithRetry $ReleaseAsset.download_url
 
     Write-Host "Extract $($ReleaseAsset.filename) content..."

--- a/images/windows/scripts/build/Invoke-Cleanup.ps1
+++ b/images/windows/scripts/build/Invoke-Cleanup.ps1
@@ -1,0 +1,51 @@
+################################################################################
+##  File:  Invoke-Cleanup.ps1
+##  Desc:  Cleanup WinSxS, temp, cache and compress some directories
+################################################################################
+
+Write-Host "Cleanup WinSxS"
+dism.exe /online /Cleanup-Image /StartComponentCleanup /ResetBase
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to cleanup WinSxS"
+}
+
+Write-Host "Clean up various directories"
+@(
+    "$env:SystemDrive\Recovery",
+    "$env:SystemRoot\logs",
+    "$env:SystemRoot\winsxs\manifestcache",
+    "$env:SystemRoot\Temp",
+    "$env:SystemRoot\Installer",
+    "$env:SystemDrive\Users\$env:INSTALL_USER\AppData\Local\Temp",
+    "$env:TEMP",
+    "$env:AZURE_CONFIG_DIR\logs",
+    "$env:AZURE_CONFIG_DIR\commands",
+    "$env:AZURE_CONFIG_DIR\telemetry"
+) | ForEach-Object {
+    if (Test-Path $_) {
+        Write-Host "Removing $_"
+        cmd /c "takeown /d Y /R /f $_ 2>&1" | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to take ownership of $_"
+        }
+        cmd /c "icacls $_ /grant:r administrators:f /t /c /q 2>&1" | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to grant administrators full control of $_"
+        }
+        Remove-Item $_ -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
+    }
+}
+
+# Remove AllUsersAllHosts profile
+Remove-Item $profile.AllUsersAllHosts -Force -ErrorAction SilentlyContinue | Out-Null
+
+# Clean yarn and npm cache
+cmd /c "yarn cache clean 2>&1" | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to clean yarn cache"
+}
+
+cmd /c "npm cache clean --force 2>&1" | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to clean npm cache"
+}

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -70,7 +70,7 @@ function Install-Binary {
         } else {
             $fileName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetRandomFileName()) + ".$Type".ToLower()
         }
-        $filePath = Invoke-DownloadWithRetry -Url $Url -Path "${env:Temp}\$fileName"
+        $filePath = Invoke-DownloadWithRetry -Url $Url -Path "${env:TEMP_DIR}\$fileName"
     }
 
     if ($PSBoundParameters.ContainsKey('ExpectedSignature')) {
@@ -92,7 +92,7 @@ function Install-Binary {
     if ($ExtraInstallArgs -and $InstallArgs) {
         throw "InstallArgs and ExtraInstallArgs parameters cannot be used together."
     }
- 
+
     if ($Type -eq "MSI") {
         # MSI binaries should be installed via msiexec.exe
         if ($ExtraInstallArgs) {
@@ -153,7 +153,7 @@ function Invoke-DownloadWithRetry {
     .EXAMPLE
         Invoke-DownloadWithRetry -Url "https://example.com/file.zip"
         Downloads the file from the specified URL and saves it to a temporary path.
-    
+
     .OUTPUTS
         The path where the downloaded file is saved.
     #>
@@ -174,7 +174,7 @@ function Invoke-DownloadWithRetry {
         if ([String]::IsNullOrEmpty($fileName)) {
             $fileName = [System.IO.Path]::GetRandomFileName()
         }
-        $Path = Join-Path -Path "${env:Temp}" -ChildPath $fileName
+        $Path = Join-Path -Path "${env:TEMP_DIR}" -ChildPath $fileName
     }
 
     Write-Host "Downloading package from $Url to $Path..."
@@ -198,7 +198,7 @@ function Invoke-DownloadWithRetry {
                 $retries = 0
             }
         }
-            
+
         if ($retries -eq 0) {
             $totalSeconds = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
             throw "Package download failed after $totalSeconds seconds"
@@ -519,7 +519,7 @@ function Get-GithubReleasesByVersion {
     .PARAMETER AllowPrerelease
         Specifies whether to include prerelease versions in the results. By default,
         prerelease versions are excluded.
-    
+
     .PARAMETER WithAssetsOnly
         Specifies whether to exclude releases without assets. By default, releases without
         assets are included.
@@ -549,7 +549,7 @@ function Get-GithubReleasesByVersion {
         [switch] $WithAssetsOnly
     )
 
-    $localCacheFile = Join-Path ${env:TEMP} "github-releases_$($Repository -replace "/", "_").json"
+    $localCacheFile = Join-Path ${env:TEMP_DIR} "github-releases_$($Repository -replace "/", "_").json"
 
     if (Test-Path $localCacheFile) {
         $releases = Get-Content $localCacheFile | ConvertFrom-Json
@@ -783,7 +783,7 @@ function Get-ChecksumFromGithubRelease {
     }
 
     $hash = $matchedLine | Select-String -Pattern $pattern | ForEach-Object { $_.Matches.Value }
-        
+
     if ([string]::IsNullOrEmpty($hash)) {
         throw "Found '${FileName}' in body of release ${matchedVersion}, but failed to get hash from it.`nLine: ${matchedLine}"
     }
@@ -827,7 +827,7 @@ function Get-ChecksumFromUrl {
         [string] $HashType
     )
 
-    $tempFile = Join-Path -Path $env:TEMP -ChildPath ([System.IO.Path]::GetRandomFileName())
+    $tempFile = Join-Path -Path $env:TEMP_DIR -ChildPath ([System.IO.Path]::GetRandomFileName())
     $checksums = (Invoke-DownloadWithRetry -Url $Url -Path $tempFile | Get-Item | Get-Content) -as [string[]]
     Remove-Item -Path $tempFile
 
@@ -860,30 +860,30 @@ function Test-FileChecksum {
     <#
     .SYNOPSIS
         Verifies the checksum of a file.
-    
+
     .DESCRIPTION
         The Test-FileChecksum function verifies the SHA256 or SHA512 checksum of a file against an expected value. 
         If the checksum does not match the expected value, the function throws an error.
-    
+
     .PARAMETER Path
         The path to the file for which to verify the checksum.
-    
+
     .PARAMETER ExpectedSHA256Sum
         The expected SHA256 checksum. If this parameter is provided, the function will calculate the SHA256 checksum of the file and compare it to this value.
-    
+
     .PARAMETER ExpectedSHA512Sum
         The expected SHA512 checksum. If this parameter is provided, the function will calculate the SHA512 checksum of the file and compare it to this value.
-    
+
     .EXAMPLE
         Test-FileChecksum -Path "C:\temp\file.txt" -ExpectedSHA256Sum "ABC123"
-    
+
         Verifies that the SHA256 checksum of the file at C:\temp\file.txt is ABC123.
-    
+
     .EXAMPLE
         Test-FileChecksum -Path "C:\temp\file.txt" -ExpectedSHA512Sum "DEF456"
-    
+
         Verifies that the SHA512 checksum of the file at C:\temp\file.txt is DEF456.
-    
+
     #>
 
     param (
@@ -944,7 +944,7 @@ function Test-FileSignature {
         This example tests the signature of the file "C:\Path\To\File.exe" against the expected thumbprint "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0".
 
     #>
-    
+
     param(
         [Parameter(Mandatory = $true, Position = 0)]
         [string] $Path,
@@ -957,7 +957,7 @@ function Test-FileSignature {
     if ($signature.Status -ne "Valid") {
         throw "Signature status is not valid. Status: $($signature.Status)"
     }
-    
+
     foreach ($thumbprint in $ExpectedThumbprint) {
         if ($signature.SignerCertificate.Thumbprint.Contains($thumbprint)) {
             Write-Output "Signature for $Path is valid"
@@ -992,8 +992,8 @@ function Update-Environment {
     )
 
     # Update PATH variable
-    $pathItems = $locations | ForEach-Object { 
-        (Get-Item $_).GetValue('PATH').Split(';') 
+    $pathItems = $locations | ForEach-Object {
+        (Get-Item $_).GetValue('PATH').Split(';')
     } | Select-Object -Unique
     $env:PATH = $pathItems -join ';'
 
@@ -1004,7 +1004,7 @@ function Update-Environment {
             $value = $key.GetValue($name)
             if (-not ($name -ieq 'PATH')) {
                 Set-Item -Path Env:$name -Value $value
-            } 
+            }
         }
     }
 }

--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -17,7 +17,7 @@ Function Install-VisualStudio {
 
     .PARAMETER RequiredComponents
         The list of required components. Required parameter.
-    
+
     .PARAMETER ExtraArgs
         The extra arguments to pass to the bootstrapper. Optional parameter.
     #>
@@ -85,10 +85,10 @@ Function Install-VisualStudio {
             }
 
             # Expand the zip file
-            Expand-Archive -Path "$env:TEMP\vslogs.zip" -DestinationPath "$env:TEMP\vslogs"
+            Expand-Archive -Path "$env:TEMP_DIR\vslogs.zip" -DestinationPath "$env:TEMP_DIR\vslogs"
 
             # Print logs
-            $vsLogsPath = "$env:TEMP\vslogs"
+            $vsLogsPath = "$env:TEMP_DIR\vslogs"
             $vsLogs = Get-ChildItem -Path $vsLogsPath -Recurse | Where-Object { -not $_.PSIsContainer } | Select-Object -ExpandProperty FullName
             foreach ($log in $vsLogs) {
                 Write-Host "============================"
@@ -96,7 +96,7 @@ Function Install-VisualStudio {
                 Write-Host "============================"
                 Get-Content -Path $log -ErrorAction Continue
             }
-            
+
             exit $exitCode
         }
     }

--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -201,7 +201,7 @@ Describe "Pipx" {
 }
 
 Describe "Kotlin" {
-    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-jvm")
+    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlinc-js", "kotlinc-jvm")
 
     It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
         "$toolName -version" | Should -ReturnZeroExitCode

--- a/images/windows/templates/windows-2019.pkr.hcl
+++ b/images/windows/templates/windows-2019.pkr.hcl
@@ -72,6 +72,11 @@ variable "imagedata_file" {
   default = "C:\\imagedata.json"
 }
 
+variable "temp_dir" {
+  type    = string
+  default = "D:\\temp"
+}
+
 variable "install_password" {
   type      = string
   default   = ""
@@ -190,7 +195,10 @@ build {
   sources = ["source.azure-arm.image"]
 
   provisioner "powershell" {
-    inline = ["New-Item -Path ${var.image_folder} -ItemType Directory -Force"]
+    inline = [
+      "New-Item -Path ${var.image_folder} -ItemType Directory -Force",
+      "New-Item -Path ${var.temp_dir} -ItemType Directory -Force"
+    ]
   }
 
   provisioner "file" {
@@ -253,7 +261,7 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_OS=${var.image_os}", "AGENT_TOOLSDIRECTORY=${var.agent_tools_directory}", "IMAGEDATA_FILE=${var.imagedata_file}", "IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_OS=${var.image_os}", "AGENT_TOOLSDIRECTORY=${var.agent_tools_directory}", "IMAGEDATA_FILE=${var.imagedata_file}", "IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     execution_policy = "unrestricted"
     scripts          = [
       "${path.root}/../scripts/build/Configure-WindowsDefender.ps1",
@@ -277,7 +285,7 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-VCRedist.ps1",
       "${path.root}/../scripts/build/Install-Docker.ps1",
@@ -297,7 +305,7 @@ build {
   provisioner "powershell" {
     elevated_password = "${var.install_password}"
     elevated_user     = "${var.install_user}"
-    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts           = [
       "${path.root}/../scripts/build/Install-VisualStudio.ps1",
       "${path.root}/../scripts/build/Install-KubernetesTools.ps1",
@@ -307,7 +315,7 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-Wix.ps1",
       "${path.root}/../scripts/build/Install-WDK.ps1",
@@ -323,7 +331,7 @@ build {
 
   provisioner "powershell" {
     execution_policy = "remotesigned"
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = ["${path.root}/../scripts/build/Install-ServiceFabricSDK.ps1"]
   }
 
@@ -336,7 +344,7 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-ActionsCache.ps1",
       "${path.root}/../scripts/build/Install-Ruby.ps1",
@@ -409,9 +417,10 @@ build {
 
   provisioner "powershell" {
     pause_before     = "2m0s"
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-WindowsUpdatesAfterReboot.ps1",
+      "${path.root}/../scripts/build/Invoke-Cleanup.ps1",
       "${path.root}/../scripts/tests/RunAll-Tests.ps1"
     ]
   }

--- a/images/windows/templates/windows-2022.pkr.hcl
+++ b/images/windows/templates/windows-2022.pkr.hcl
@@ -72,6 +72,11 @@ variable "imagedata_file" {
   default = "C:\\imagedata.json"
 }
 
+variable "temp_dir" {
+  type    = string
+  default = "D:\\temp"
+}
+
 variable "install_password" {
   type      = string
   default   = ""
@@ -190,7 +195,10 @@ build {
   sources = ["source.azure-arm.image"]
 
   provisioner "powershell" {
-    inline = ["New-Item -Path ${var.image_folder} -ItemType Directory -Force"]
+    inline = [
+      "New-Item -Path ${var.image_folder} -ItemType Directory -Force",
+      "New-Item -Path ${var.temp_dir} -ItemType Directory -Force"
+    ]
   }
 
   provisioner "file" {
@@ -242,7 +250,7 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_OS=${var.image_os}", "AGENT_TOOLSDIRECTORY=${var.agent_tools_directory}", "IMAGEDATA_FILE=${var.imagedata_file}", "IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_OS=${var.image_os}", "AGENT_TOOLSDIRECTORY=${var.agent_tools_directory}", "IMAGEDATA_FILE=${var.imagedata_file}", "IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     execution_policy = "unrestricted"
     scripts          = [
       "${path.root}/../scripts/build/Configure-WindowsDefender.ps1",
@@ -268,7 +276,7 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-Docker.ps1",
       "${path.root}/../scripts/build/Install-DockerWinCred.ps1",
@@ -287,7 +295,7 @@ build {
   provisioner "powershell" {
     elevated_password = "${var.install_password}"
     elevated_user     = "${var.install_user}"
-    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts           = [
       "${path.root}/../scripts/build/Install-VisualStudio.ps1",
       "${path.root}/../scripts/build/Install-KubernetesTools.ps1"
@@ -302,7 +310,7 @@ build {
 
   provisioner "powershell" {
     pause_before     = "2m0s"
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-Wix.ps1",
       "${path.root}/../scripts/build/Install-WDK.ps1",
@@ -318,7 +326,7 @@ build {
 
   provisioner "powershell" {
     execution_policy = "remotesigned"
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = ["${path.root}/../scripts/build/Install-ServiceFabricSDK.ps1"]
   }
 
@@ -331,7 +339,7 @@ build {
   }
 
   provisioner "powershell" {
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-ActionsCache.ps1",
       "${path.root}/../scripts/build/Install-Ruby.ps1",
@@ -385,7 +393,7 @@ build {
   provisioner "powershell" {
     elevated_password = "${var.install_password}"
     elevated_user     = "${var.install_user}"
-    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars  = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts           = [
       "${path.root}/../scripts/build/Install-WindowsUpdates.ps1",
       "${path.root}/../scripts/build/Configure-DynamicPort.ps1",
@@ -404,9 +412,10 @@ build {
 
   provisioner "powershell" {
     pause_before     = "2m0s"
-    environment_vars = ["IMAGE_FOLDER=${var.image_folder}"]
+    environment_vars = ["IMAGE_FOLDER=${var.image_folder}", "TEMP_DIR=${var.temp_dir}"]
     scripts          = [
       "${path.root}/../scripts/build/Install-WindowsUpdatesAfterReboot.ps1",
+      "${path.root}/../scripts/build/Invoke-Cleanup.ps1",
       "${path.root}/../scripts/tests/RunAll-Tests.ps1"
     ]
   }


### PR DESCRIPTION
# Description
This PR changes the temporary files directory from `C:\Users\<user>\AppData\Local\Temp`  to `D:\temp`, where `D:` drive is an temporary disk propagated with selected VM size. 
Also, all cleanup actions have been moved from `Configure-System.ps1` script to `Invoke-Cleanup.ps1`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
