### PR TITLE
[Windows] Update Kotlin pester test

### DIFF
--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -201,7 +201,7 @@ Describe "Pipx" {
 }
 
 Describe "Kotlin" {
-    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlin-dce-js", "kotlinc-jvm")
+    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlinc-js", "kotlinc-jvm")
 
     It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
         "$toolName -version" | Should -ReturnZeroExitCode


### PR DESCRIPTION
# Description
Quick fix to update the Kotlin pester test for Windows.
In the latest release of Kotlin was removed deprecated JS `DCE` class, so `kotlin-dce-js.bat` was also removed. Instead, `kotlinc-js` was added to the test.
 
References:
- [Delete the org.jetbrains.kotlin.cli.js.dce.K2JSDce class](https://github.com/JetBrains/kotlin/releases/tag/v2.1.0)
- https://youtrack.jetbrains.com/issue/KT-70231

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
