### PR TITLE
[Ubuntu] Updated the Kotlin pester test and Power shell version for Ubuntu24.04.

### DIFF
--- a/images/ubuntu/scripts/build/install-powershell.sh
+++ b/images/ubuntu/scripts/build/install-powershell.sh
@@ -11,11 +11,5 @@ source $HELPER_SCRIPTS/os.sh
 pwsh_version=$(get_toolset_value .pwsh.version)
 
 # Install Powershell
-if is_ubuntu24; then
-    dependency_path=$(download_with_retry "http://mirrors.kernel.org/ubuntu/pool/main/i/icu/libicu72_72.1-3ubuntu2_amd64.deb")
-    sudo dpkg -i "$dependency_path"
-    package_path=$(download_with_retry "https://github.com/PowerShell/PowerShell/releases/download/v7.4.2/powershell-lts_7.4.2-1.deb_amd64.deb")
-    sudo dpkg -i "$package_path"
-else
+
     apt-get install powershell=$pwsh_version*
-fi

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -407,7 +407,7 @@ Describe "Kotlin" {
         "kotlinc-jvm -version" | Should -ReturnZeroExitCode
     }
 
-    It "kotlin-dce-js" {
-        "kotlin-dce-js -version" | Should -ReturnZeroExitCode
+    It "kotlinc-js" {
+        "kotlinc-js -version" | Should -ReturnZeroExitCode
     }
 }


### PR DESCRIPTION
This PR fix the Kotlin pester test issue and Power shell version issue.

#### Related issue:
https://github.com/actions/runner-images/issues/11058
https://github.com/actions/runner-images/issues/11055

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
