### PR TITLE
Add trigger to run Windows 2025 CI

### DIFF
--- a/.github/workflows/windows2025.yml
+++ b/.github/workflows/windows2025.yml
@@ -1,0 +1,20 @@
+name: Trigger Windows25 CI
+run-name: Windows2025 - ${{ github.event.pull_request.title }}
+
+on:
+  pull_request_target:
+    types: labeled
+    paths:
+    - 'images/windows/**'
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  Windows_2022:
+    if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2025'
+    uses: ./.github/workflows/trigger-ubuntu-win-build.yml
+    with:
+      image_type: 'windows2025'
+    secrets: inherit


### PR DESCRIPTION
# Description
Add trigger to run Windows 2025 CI

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
