### PR TITLE
[Windows] Update Get-GithubReleasesByVersion function sorting

### DIFF
--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -589,8 +589,17 @@ function Get-GithubReleasesByVersion {
         )
     }
 
-    # Sort releases by version
-    $releases = $releases | Sort-Object -Descending { [version] $_.version }
+    # Sort releases by version, then by tag name parts if version is the same
+    $releases = $releases | Sort-Object -Descending {
+        [version] $_.version
+    }, {
+        $cleanTagName = $_.tag_name -replace '^v', ''
+        $parts = $cleanTagName -split '[.\-]'
+        $parsedParts = $parts | ForEach-Object {
+            if ($_ -match '^\d+$') { [int]$_ } else { $_ }
+        }
+        $parsedParts
+    }
 
     # Select releases matching version
     if ($Version -eq "latest") {


### PR DESCRIPTION
# Description

Sorting by semantic version in PowerShell does not always give predictable results in more complex cases. 😞  Example: "v2.47.0.windows.2"
At the same time not all the repos use `latest` tag for the current release in production, so we need to sort using more complex logic. 🤷‍♂️ 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
