### PR TITLE
Use all processors when installing zstd

### DIFF
--- a/images/ubuntu/scripts/build/install-zstd.sh
+++ b/images/ubuntu/scripts/build/install-zstd.sh
@@ -22,8 +22,8 @@ use_checksum_comparison "$archive_path" "$external_hash"
 apt-get install liblz4-dev
 tar xzf "$archive_path" -C /tmp
 
-make -C "/tmp/${release_name}/contrib/pzstd" all
-make -C "/tmp/${release_name}" zstd-release
+make -C "/tmp/${release_name}/contrib/pzstd" -j $(nproc) all
+make -C "/tmp/${release_name}" -j $(nproc) zstd-release
 
 for copyprocess in zstd zstdless zstdgrep; do
     cp "/tmp/${release_name}/programs/${copyprocess}" /usr/local/bin/


### PR DESCRIPTION
# Description
Speeds up my builds from 93s to 37s (four core) for the install-zstd.sh step

#### Related issue:
None

## Check list
- [n/a] Related issue / work item is attached
- [n/a] Tests are written (if applicable)
- [n/a] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
