### PR TITLE
[macOS] Update Kotlin to BasicTools.test file

### DIFF
--- a/images/macos/scripts/tests/BasicTools.Tests.ps1
+++ b/images/macos/scripts/tests/BasicTools.Tests.ps1
@@ -160,7 +160,7 @@ Describe "Homebrew" {
 }
 
 Describe "Kotlin" -Skip:($os.IsMonterey) {
-    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlinc-jvm", "kotlin-dce-js")
+    $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlinc-jvm", "kotlinc-js")
 
     It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
         "$toolName -version" | Should -ReturnZeroExitCode


### PR DESCRIPTION
# Description
Quick fix to update the Kotlin test for macOS
In the latest release of Kotlin was removed deprecated JS DCE class, so kotlin-dce-js.bat was also removed. Instead, kotlinc-js was added to the test.

References:

[Delete the org.jetbrains.kotlin.cli.js.dce.K2JSDce class](https://github.com/JetBrains/kotlin/releases/tag/v2.1.0)
https://youtrack.jetbrains.com/issue/KT-70231

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
