### PR TITLE
[ubuntu] Add documentation on .NET core changes for 2404

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `-latest` migration process is gradual and happens over 1-2 months in order 
 | Go        | 3 latest minor versions |
 | Python <br/> Ruby | 5 most popular `major.minor` versions |
 | PyPy      | 3 most popular `major.minor` versions |
-| .NET Core | 2 latest LTS versions and 1 latest version. For each feature version only latest patch is installed |
+| .NET Core | 2 latest LTS versions and 1 latest version. For each feature version only latest patch is installed. Note for [Ubuntu images see details.](./docs/dotnet-ubuntu.md) |
 | GCC <br/> GNU Fortran <br/> Clang <br/> GNU C++ | 3 latest major versions |
 | Android NDK | 1 latest non-LTS, 2 latest LTS versions |
 | Xcode     | - only one major version of Xcode will be supported per macOS version <br/> - all minor versions of the supported major version will be available <br/> - beta and RC versions will be provided "as-is" in the latest available macOS image only no matter of beta/GA status of the image <br/> - when a new patch version is released, the previous patch version will be replaced |

--- a/docs/dotnet-ubuntu.md
+++ b/docs/dotnet-ubuntu.md
@@ -6,7 +6,7 @@ This document gives an overview of these change and the impact this has on the `
 
 ## .NET Core for Ubuntu 2004 and 2204
 
-2004 and 2024 use the [Microsoft Package repository](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet8&pivots=os-linux-ubuntu-2004) to install .NET deb files built and published by the .NET team.
+2004 and 2204 use the [Microsoft Package repository](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet8&pivots=os-linux-ubuntu-2004) to install .NET deb files built and published by the .NET team.
 
 ## .NET Core Versions from Ubuntu 2404
 

--- a/docs/dotnet-ubuntu.md
+++ b/docs/dotnet-ubuntu.md
@@ -4,7 +4,7 @@
 
 This document gives an overview of these change and the impact this has on the `runner-images`.
 
-## .NET Core for Ubuntu 2004 and 2024
+## .NET Core for Ubuntu 2004 and 2204
 
 2004 and 2024 use the [Microsoft Package repository](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet8&pivots=os-linux-ubuntu-2004) to install .NET deb files built and published by the .NET team.
 

--- a/docs/dotnet-ubuntu.md
+++ b/docs/dotnet-ubuntu.md
@@ -1,0 +1,34 @@
+# Ubuntu .NET Core Versions
+
+.NET has changed the recommended install methods for Ubuntu from 2404.
+
+This document gives an overview of these change and the impact this has on the `runner-images`.
+
+## .NET Core for Ubuntu 2004 and 2024
+
+2004 and 2024 use the [Microsoft Package repository](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet8&pivots=os-linux-ubuntu-2004) to install .NET deb files built and published by the .NET team.
+
+## .NET Core Versions from Ubuntu 2404
+
+The .NET Core team have worked with Canonical and Ubuntu now provides its own .NET packages.
+
+These are the recommended install path and, as-such what is installed on the image.
+
+> The release of Ubuntu 24.04 is just around the corner. Canonical-produced .NET 6, 7, and 8 packages will be available on day one, for "Noble Numbat". Microsoft will not be publishing .NET packages to the 24.04 feed at packages.microsoft.com.
+
+You can read the [full announcement from .NET team here](https://github.com/dotnet/core/discussions/9258). We'll briefly summarize how this change may impact users of the image.
+
+### [`Feature Bands`](https://learn.microsoft.com/dotnet/core/porting/versioning-sdk-msbuild-vs)
+
+Going forward only the `1xx` feature band will be present in the image as Ubuntu only build and publish this band.
+
+> Most distros, including Ubuntu, stick to the .1xx feature band for the lifetime of a major .NET version. They make this choice because .1xx is (effectively) the "compatibility band". Higher bands can have breaking changes.
+> This means there will no longer be packages available for .2xx and later feature bands. Such packages have been exclusively available from Microsoft. If users see an incompatibility between .1xx and higher feature bands, we ask that you please report it in the dotnet/sdk repo. [link: dotnet/core discussion](https://github.com/dotnet/core/discussions/9258)
+
+If you need a higher feature band for your Actions the recommendation is to use the [`setup-dotnet`](https://github.com/actions/setup-dotnet) action to install the desired version.
+
+### .NET MAUI
+
+.NET MAUI is [not included](https://github.com/dotnet/core/discussions/9258#discussioncomment-9548857) in the Ubuntu .NET package. There is work [ongoing to fix.](https://github.com/dotnet/core/discussions/9258#discussioncomment-9548857)
+
+You should be able to resolve this by using the [`setup-dotnet`](https://github.com/actions/setup-dotnet) action to install the desired version.


### PR DESCRIPTION
# Description

This adds a short document detailing the changes .NET Core team have made related to Ubuntu.

It provides a brief overview of the implications and how to resolve issues caused by this change.

Docs only.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
