### PR TITLE
[macOS] Add Android SDK 34 to macOS-15 images

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -31,7 +31,7 @@
     "android": {
         "cmdline-tools": "commandlinetools-mac-12266719_latest.zip",
         "sdk-tools": "sdk-tools-darwin-4333796.zip",
-        "platform_min_version": "35",
+        "platform_min_version": "34",
         "build_tools_min_version": "35.0.0",
         "extras": [
             "android;m2repository", "google;m2repository", "google;google_play_services"


### PR DESCRIPTION
# Description

The platform is too used to not be added.

#### Related issue:
- https://github.com/actions/runner-images/issues/10814

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
