### PR TITLE
[Windows] Add Microsoft.Net.Component.4.7.2.SDK to Windows toolset 2022

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -187,6 +187,7 @@
             "Component.Unreal.Android",
             "Component.Xamarin",
             "Microsoft.Component.VC.Runtime.UCRTSDK",
+            "Microsoft.Net.Component.4.7.2.SDK",
             "Microsoft.Net.Component.4.7.TargetingPack",
             "Microsoft.Net.Component.4.7.2.TargetingPack",
             "Microsoft.Net.Component.4.8.1.SDK",


### PR DESCRIPTION
# Description
Add .NET 4.7.2 SDK to the windows-2022 image to maintain app development capability

#### Related issue:
https://github.com/actions/runner-images/issues/10942

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
