### PR TITLE
[Ubuntu] Add systemd-coredump

### DIFF
--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -6,16 +6,17 @@ Describe "Apt" {
 
     It "<toolName> is available" -TestCases $testCases {
         switch ($toolName) {
-            "acl"          { $toolName = "getfacl"; break }
-            "aria2"        { $toolName = "aria2c"; break }
-            "p7zip-full"   { $toolName = "p7zip"; break }
-            "subversion"   { $toolName = "svn"; break }
-            "sphinxsearch" { $toolName = "searchd"; break }
-            "binutils"     { $toolName = "strings"; break }
-            "coreutils"    { $toolName = "tr"; break }
-            "net-tools"    { $toolName = "netstat"; break }
-            "mercurial"    { $toolName = "hg"; break }
-            "findutils"    { $toolName = "find"; break }
+            "acl"               { $toolName = "getfacl"; break }
+            "aria2"             { $toolName = "aria2c"; break }
+            "p7zip-full"        { $toolName = "p7zip"; break }
+            "subversion"        { $toolName = "svn"; break }
+            "sphinxsearch"      { $toolName = "searchd"; break }
+            "binutils"          { $toolName = "strings"; break }
+            "coreutils"         { $toolName = "tr"; break }
+            "net-tools"         { $toolName = "netstat"; break }
+            "mercurial"         { $toolName = "hg"; break }
+            "findutils"         { $toolName = "find"; break }
+            "systemd-coredump"  { $toolName = "coredumpctl"; break }
         }
 
         (Get-Command -Name $toolName).CommandType | Should -BeExactly "Application"

--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -202,6 +202,7 @@
             "sshpass",
             "subversion",
             "sudo",
+            "systemd-coredump",
             "swig",
             "telnet",
             "time",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -201,6 +201,7 @@
             "sshpass",
             "subversion",
             "sudo",
+            "systemd-coredump",
             "swig",
             "telnet",
             "time",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -172,6 +172,7 @@
             "ssh",
             "sshpass",
             "sudo",
+            "systemd-coredump",
             "swig",
             "telnet",
             "time",


### PR DESCRIPTION
# Description
Add systemd-coredump utility to all Ubuntu images.

#### Related issue:
https://github.com/actions/runner-images/issues/10480

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
