### PR TITLE
[Windows] Accept by default "Send Diagnostic data to Microsoft" consent for windows-2025 image

### DIFF
--- a/images/windows/scripts/build/Configure-User.ps1
+++ b/images/windows/scripts/build/Configure-User.ps1
@@ -41,6 +41,14 @@ if (-not (Test-IsWin25)) {
         throw "Failed to copy HKCU\Software\TortoiseSVN to HKLM\DEFAULT\Software\TortoiseSVN"
     }
 }
+# Accept by default "Send Diagnostic data to Microsoft" consent.
+if (Test-IsWin25) {
+    $registryKeyPath = 'HKLM:\DEFAULT\SOFTWARE\Microsoft\Windows\CurrentVersion\Privacy'
+    New-ItemProperty -Path $registryKeyPath -Name PrivacyConsentPresentationVersion -PropertyType DWORD -Value 3 | Out-Null
+    New-ItemProperty -Path $registryKeyPath -Name PrivacyConsentSettingsValidMask -PropertyType DWORD -Value 4 | Out-Null
+    New-ItemProperty -Path $registryKeyPath -Name PrivacyConsentSettingsVersion -PropertyType DWORD -Value 5 | Out-Null
+}
+
 Dismount-RegistryHive "HKLM\DEFAULT"
 
 # Remove the "installer" (var.install_user) user profile for Windows 2025 image


### PR DESCRIPTION
# Description
This change is tweak registry to accept by default "Send Diagnostic data to Microsoft" consent for windows-2025 image.

Example:
![image](https://github.com/user-attachments/assets/80aac630-9df0-496c-894d-96ee7d22c37f)




#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
