### PR TITLE
[windows] Remove Windows\Installer\* folder cleanup

### DIFF
--- a/images/windows/scripts/build/Invoke-Cleanup.ps1
+++ b/images/windows/scripts/build/Invoke-Cleanup.ps1
@@ -15,7 +15,7 @@ Write-Host "Clean up various directories"
     "$env:SystemRoot\logs",
     "$env:SystemRoot\winsxs\manifestcache",
     "$env:SystemRoot\Temp",
-    "$env:SystemRoot\Installer\*",
+    $(if(Test-IsWin25){"$env:SystemRoot\Installer\*"}),
     "$env:SystemDrive\Users\$env:INSTALL_USER\AppData\Local\Temp",
     "$env:TEMP",
     "$env:AZURE_CONFIG_DIR\logs",


### PR DESCRIPTION
# Description
This PR removes `$env:SystemRoot\Installer\*` folder cleanup for Windows Server 2019 and 2022.

#### Related issue: https://github.com/actions/runner-images/issues/11119

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
