### PR TITLE
[Ubuntu] Disable man-db auto update

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -69,3 +69,7 @@ fi
 if is_ubuntu22; then
     sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
 fi
+
+#Disable man-db auto update
+echo "set man-db/auto-update false" | debconf-communicate
+dpkg-reconfigure man-db


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**Disable auto-update of man-db**

Every invocation to `apt-get update` updates the man-db database of the runner image which increases workload execution time.

Hence, this PR would disable the auto-update of man-db for Ubuntu images.

Please follow below links for the image-generation pipeline execution results with this change :

[Ubuntu20.04](https://github.com/actions/runner-images-ci/actions/runs/12264767669/job/34219375562)
[Ubuntu22.04](https://github.com/actions/runner-images-ci/actions/runs/12263076579/job/34213812241)
[Ubuntu24.04](https://github.com/actions/runner-images-ci/actions/runs/12263078589/job/34213819657)

#### Related issue:
https://github.com/actions/runner-images/issues/10977

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
