### PR TITLE
[Windows] Install "strawberryperl" right after "cmake" in windows-2025 image

### DIFF
--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -274,10 +274,6 @@
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
             { "name": "packer" },
-            {
-                "name": "strawberryperl" ,
-                "args": [ "--version", "5.40.0.1" ]
-            },
             { "name": "pulumi" },
             { "name": "swig" },
             { "name": "vswhere" },
@@ -288,6 +284,10 @@
             {
                 "name": "cmake.install",
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
+            },
+            {
+                "name": "strawberryperl" ,
+                "args": [ "--version", "5.40.0.1" ]
             },
             { "name": "imagemagick" }
         ]


### PR DESCRIPTION
# Description
This pull request moves `Strawberry Perl` down in the list of packages that are installed via chocolatey.

The updated version of `Strawberry Perl` comes with `CMake` with an older version than the one we install directly from chocolatey. To keep the correct version of `CMake`, we need to move `Strawberry Perl` down.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
