### PR TITLE
[windows] Update Visual Studio Software Report

### DIFF
--- a/images/windows/scripts/docs-gen/SoftwareReport.VisualStudio.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.VisualStudio.psm1
@@ -43,18 +43,24 @@ function Get-VisualStudioExtensions {
     )
 
     # WDK
-    $wdkVersion = Get-WDKVersion
+    if (-not (Test-IsWin25)) {
+        $wdkVersion = Get-WDKVersion
+        $wdkPackages = @(
+            @{Package = 'Windows Driver Kit'; Version = $wdkVersion }
+        )
+    }
+
+    # WDK extension
     $wdkExtensionVersion = Get-VSExtensionVersion -packageName 'Microsoft.Windows.DriverKit'
-    $wdkPackages = @(
-        @{Package = 'Windows Driver Kit'; Version = $wdkVersion }
+    $wdkExtensions = @(
         @{Package = 'Windows Driver Kit Visual Studio Extension'; Version = $wdkExtensionVersion }
     )
 
     $extensions = @(
         $vsixs
-        $ssdtPackages
         $sdkPackages
         $wdkPackages
+        $wdkExtensions
     )
 
     $extensions | Foreach-Object {


### PR DESCRIPTION
# Description
This PR contains following Visual Studio related software report adjustments for windows images:
1. `Windows Driver Kit` is not installed standalone on windows-2025, so removed from the report.
2. `$ssdtPackages` is an orphaned variable, so removed from the report.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
