### PR TITLE
Implement az-cli warmup on ubuntu

### DIFF
--- a/images/ubuntu/scripts/build/cleanup.sh
+++ b/images/ubuntu/scripts/build/cleanup.sh
@@ -19,6 +19,13 @@ if command -v journalctl; then
     journalctl --vacuum-time=1s
 fi
 
+# remove redundant folders from azcli
+if [[ -z "${AZURE_CONFIG_DIR}" ]]; then
+    rm -rf $AZURE_CONFIG_DIR/logs
+    rm -rf $AZURE_CONFIG_DIR/commands
+    rm -rf $AZURE_CONFIG_DIR/telemetry
+fi
+
 # delete all .gz and rotated file
 find /var/log -type f -regex ".*\.gz$" -delete
 find /var/log -type f -regex ".*\.[0-9]$" -delete

--- a/images/ubuntu/scripts/build/install-azure-cli.sh
+++ b/images/ubuntu/scripts/build/install-azure-cli.sh
@@ -4,12 +4,40 @@
 ##  Desc:  Install Azure CLI (az)
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/etc-environment.sh
+
+# AZURE_CONFIG_DIR shell variable defines where the CLI configuration file for managing behavior are stored
+# https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file
+# This path SHOULD be different from the installation directory /opt/az/
+export AZURE_CONFIG_DIR="/opt/az-config"
+mkdir -p $AZURE_CONFIG_DIR
+set_etc_environment_variable "AZURE_CONFIG_DIR" "${AZURE_CONFIG_DIR}"
+
+# AZURE_EXTENSION_DIR shell variable defines where modules are installed
+# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
+# This path SHOULD be different from the installation directory /opt/az/
+export AZURE_EXTENSION_DIR="/opt/az-extension"
+mkdir -p $AZURE_EXTENSION_DIR
+set_etc_environment_variable "AZURE_EXTENSION_DIR" "${AZURE_EXTENSION_DIR}"
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 echo "azure-cli https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt" >> $HELPER_SCRIPTS/apt-sources.txt
 
-rm -f /etc/apt/sources.list.d/azure-cli.list
-rm -f /etc/apt/sources.list.d/azure-cli.list.save
+# Remove Azure CLI repository (instructions taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#uninstall-azure-cli)
+rm -f /etc/apt/sources.list.d/azure-cli.sources
+
+echo "Warmup 'az'"
+az --help > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Command 'az --help' failed"
+    exit 1
+fi
+
+# Hand over the ownership of the directories and files to the non-root user
+chown -R "$SUDO_USER:$SUDO_USER" $AZURE_CONFIG_DIR
+chown -R "$SUDO_USER:$SUDO_USER" $AZURE_EXTENSION_DIR
 
 invoke_tests "CLI.Tools" "Azure CLI"

--- a/images/ubuntu/scripts/build/install-azure-devops-cli.sh
+++ b/images/ubuntu/scripts/build/install-azure-devops-cli.sh
@@ -4,14 +4,6 @@
 ##  Desc:  Install Azure DevOps CLI (az devops)
 ################################################################################
 
-# Source the helpers for use with the script
-source $HELPER_SCRIPTS/etc-environment.sh
-
-# AZURE_EXTENSION_DIR shell variable defines where modules are installed
-# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
-export AZURE_EXTENSION_DIR=/opt/az/azcliextensions
-set_etc_environment_variable "AZURE_EXTENSION_DIR" "${AZURE_EXTENSION_DIR}"
-
 # install azure devops Cli extension
 az extension add -n azure-devops
 


### PR DESCRIPTION
# Description
This PR fixes #10110.

- Config + cli-extensions directory is placed in /opt but not in installation dir at /opt/az/ as this is bad practice.
- Removed cli-extensions directory setup from devops extension as this setting belongs in az-cli setup
- Added cleanup for telemetry / logs in config directory

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

#10110

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
