### PR TITLE
replace WebClient with Invoke-WebRequest

### DIFF
--- a/images/macos/scripts/helpers/Common.Helpers.psm1
+++ b/images/macos/scripts/helpers/Common.Helpers.psm1
@@ -84,7 +84,7 @@ function Invoke-DownloadWithRetry {
     for ($retries = 20; $retries -gt 0; $retries--) {
         try {
             $attemptStartTime = Get-Date
-            (New-Object System.Net.WebClient).DownloadFile($Url, $Path)
+            Invoke-WebRequest -Uri $Url -Outfile $Path
             $attemptSeconds = [math]::Round(($(Get-Date) - $attemptStartTime).TotalSeconds, 2)
             Write-Host "Package downloaded in $attemptSeconds seconds"
             break

--- a/images/ubuntu/scripts/helpers/Common.Helpers.psm1
+++ b/images/ubuntu/scripts/helpers/Common.Helpers.psm1
@@ -133,7 +133,7 @@ function Invoke-DownloadWithRetry {
     for ($retries = 20; $retries -gt 0; $retries--) {
         try {
             $attemptStartTime = Get-Date
-            (New-Object System.Net.WebClient).DownloadFile($Url, $DestinationPath)
+            Invoke-WebRequest -Uri $Url -Outfile $DestinationPath
             $attemptSeconds = [math]::Round(($(Get-Date) - $attemptStartTime).TotalSeconds, 2)
             Write-Host "Package downloaded in $attemptSeconds seconds"
             break

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -184,7 +184,7 @@ function Invoke-DownloadWithRetry {
     for ($retries = 20; $retries -gt 0; $retries--) {
         try {
             $attemptStartTime = Get-Date
-            (New-Object System.Net.WebClient).DownloadFile($Url, $Path)
+            Invoke-WebRequest -Uri $Url -Outfile $Path
             $attemptSeconds = [math]::Round(($(Get-Date) - $attemptStartTime).TotalSeconds, 2)
             Write-Host "Package downloaded in $attemptSeconds seconds"
             break


### PR DESCRIPTION
# Description
Lifecycle issue. Scripts were using the WebClient object, which is obsolete since last summer.
https://learn.microsoft.com/en-us/dotnet/api/system.net.webclient?view=net-9.0#remarks

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
