### PR TITLE
[Windows] Remove Windows\Installer\* folder cleanup for windows 2025 image

### DIFF
--- a/images/windows/scripts/build/Invoke-Cleanup.ps1
+++ b/images/windows/scripts/build/Invoke-Cleanup.ps1
@@ -15,7 +15,6 @@ Write-Host "Clean up various directories"
     "$env:SystemRoot\logs",
     "$env:SystemRoot\winsxs\manifestcache",
     "$env:SystemRoot\Temp",
-    $(if(Test-IsWin25){"$env:SystemRoot\Installer\*"}),
     "$env:SystemDrive\Users\$env:INSTALL_USER\AppData\Local\Temp",
     "$env:TEMP",
     "$env:AZURE_CONFIG_DIR\logs",
@@ -52,6 +51,8 @@ if ($LASTEXITCODE -ne 0) {
 
 if (Test-IsWin25) {
     $directoriesToCompact = @(
+        "C:\Program Files (x86)\Android",
+        "C:\Program Files\dotnet",
         "$env:SystemRoot\assembly",
         "$env:SystemRoot\WinSxS"
     )


### PR DESCRIPTION
# Description
Remove `C:\Windows\Installer\*` folder cleanup for windows 2025 image

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
