### PR TITLE
[Ubuntu] Adding Dotnet latest version 9.0

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -270,12 +270,14 @@
         "aptPackages": [
             "dotnet-sdk-6.0",
             "dotnet-sdk-7.0",
-            "dotnet-sdk-8.0"
+            "dotnet-sdk-8.0",
+            "dotnet-sdk-9.0"
         ],
         "versions": [
             "6.0",
             "7.0",
-            "8.0"
+            "8.0",
+            "9.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -269,12 +269,14 @@
         "aptPackages": [
             "dotnet-sdk-6.0",
             "dotnet-sdk-7.0",
-            "dotnet-sdk-8.0"
+            "dotnet-sdk-8.0",
+            "dotnet-sdk-9.0"
         ],
         "versions": [
             "6.0",
             "7.0",
-            "8.0"
+            "8.0",
+            "9.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -223,10 +223,12 @@
     ],
     "dotnet": {
         "aptPackages": [
-            "dotnet-sdk-8.0"
+            "dotnet-sdk-8.0",
+            "dotnet-sdk-9.0"
         ],
         "versions": [
-            "8.0"
+            "8.0",
+            "9.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }


### PR DESCRIPTION
# Description
This PR adding latest Dotnet version 9.0 in Ubuntu 24.04, 22.04, and 20.04

Follow up to #10976 which brings similar functionality to Windows.

#### Related issue:

#10964

## Check list
- [x] Related issue / work item is attached
- ~~[ ] Tests are written (if applicable)~~
- ~~[ ] Documentation is updated (if applicable)~~
- [ ] Changes are tested and related VM images are successfully generated
