### PR TITLE
[windows-2025] Install mongosh for ALLUSERS and enable test

### DIFF
--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -49,8 +49,9 @@ if (Test-IsWin25) {
         -UrlMatchPattern "mongosh-*-x64.msi"
 
     Install-Binary -Type MSI `
-    -Url $mongoshDownloadUrl `
-    -ExpectedSignature 'A5BBE2A6DA1D2A6E057EF870267E6A91E4D56BAA'
+        -Url $mongoshDownloadUrl `
+        -ExtraInstallArgs @('ALLUSERS=1') `
+        -ExpectedSignature 'A5BBE2A6DA1D2A6E057EF870267E6A91E4D56BAA'
 }
 
 Invoke-PesterTests -TestFile "Databases" -TestName "MongoDB"

--- a/images/windows/scripts/tests/Databases.Tests.ps1
+++ b/images/windows/scripts/tests/Databases.Tests.ps1
@@ -30,8 +30,10 @@ Describe "MongoDB" {
         }
     }
 
-    Context "Shell" -Skip:(-not (Test-IsWin19) -or -not (Test-IsWin22)) {
-        "mongosh --version" | Should -Not -BeNullOrEmpty
+    Context "Shell" -Skip:(-not (Test-IsWin25)) {
+        It "mongosh" {
+            "mongosh --version" | Should -ReturnZeroExitCode
+        }
     }
 }
 


### PR DESCRIPTION
# Description
This PR:
1. Installs `mongosh` for ALLUSERS on windows-2025
2. Enables Pester Test

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
