### PR TITLE
[Windows] Add WSL2 to Windows-2025 image

### DIFF
--- a/images/windows/scripts/build/Configure-System.ps1
+++ b/images/windows/scripts/build/Configure-System.ps1
@@ -93,11 +93,11 @@ $servicesToDisable = @(
     'wuauserv'
     'DiagTrack'
     'dmwappushservice'
-    'PcaSvc'
+    $(if(-not (Test-IsWin25)){'PcaSvc'})
     'SysMain'
     'gupdate'
     'gupdatem'
-    'StorSvc'
+    $(if(-not (Test-IsWin25)){'StorSvc'})
 ) | Get-Service -ErrorAction SilentlyContinue
 Stop-Service $servicesToDisable
 $servicesToDisable.WaitForStatus('Stopped', "00:01:00")

--- a/images/windows/scripts/build/Install-WSL2.ps1
+++ b/images/windows/scripts/build/Install-WSL2.ps1
@@ -1,0 +1,16 @@
+Write-Host "Install WSL2"
+
+$version = (Get-GithubReleasesByVersion -Repo "microsoft/WSL" -Version "latest").version
+$downloadUrl =  Resolve-GithubReleaseAssetUrl `
+    -Repo "microsoft/WSL" `
+    -Version $version `
+    -UrlMatchPattern "wsl.*.x64.msi"
+
+Install-Binary -Type MSI `
+    -Url $downloadUrl `
+    -ExpectedSHA256Sum "CD3F2A68A1A5836F6A1CC9965A7F5F54DB267CA221EAA87DF29345AB7957AEC4"
+
+Write-Host "Performing wsl --install --no-distribution"
+wsl.exe --install --no-distribution
+
+Invoke-PesterTests -TestFile "WindowsFeatures" -TestName "WSL2"

--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -20,11 +20,9 @@ Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -Disa
 # Software report
 $softwareReport = [SoftwareReport]::new($(Build-OSInfoSection))
 $optionalFeatures = $softwareReport.Root.AddHeader("Windows features")
- if (-not (Test-IsWin25)) {
-    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
-} else {
-    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
-    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv2):", $(Get-WSL2Version))
+$optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
+if (Test-IsWin25) {
+    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (Default, WSLv2):", $(Get-WSL2Version))
 }
 $installedSoftware = $softwareReport.Root.AddHeader("Installed Software")
 

--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -20,7 +20,12 @@ Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -Disa
 # Software report
 $softwareReport = [SoftwareReport]::new($(Build-OSInfoSection))
 $optionalFeatures = $softwareReport.Root.AddHeader("Windows features")
-$optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
+ if (-not (Test-IsWin25)) {
+    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
+} else {
+    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
+    $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv2):", $(Get-WSL2Version))
+}
 $installedSoftware = $softwareReport.Root.AddHeader("Installed Software")
 
 # Language and Runtime

--- a/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
@@ -318,3 +318,7 @@ function Get-ImageMagickVersion {
 function Get-MongoshVersion {
     return $(mongosh --version)
 }
+
+function Get-WSL2Version {
+    return $((Get-AppxPackage -Name "MicrosoftCorporationII.WindowsSubsystemForLinux").version)
+}

--- a/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
+++ b/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
@@ -82,3 +82,9 @@ Describe "Windows Updates" {
         $State | Should -BeIn $expect
     }
 }
+
+Describe "WSL2" {
+    It "WSL status should return zero exit code" {
+        "wsl --status" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/windows/templates/windows-2025.pkr.hcl
+++ b/images/windows/templates/windows-2025.pkr.hcl
@@ -243,7 +243,7 @@ build {
     inline = ["if (-not ((net localgroup Administrators) -contains '${var.install_user}')) { exit 1 }"]
   }
 
-  provisioner "powershell" {
+provisioner "powershell" {
     elevated_password = "${var.install_password}"
     elevated_user     = "${var.install_user}"
     inline            = ["bcdedit.exe /set TESTSIGNING ON"]
@@ -256,6 +256,7 @@ build {
       "${path.root}/../scripts/build/Configure-WindowsDefender.ps1",
       "${path.root}/../scripts/build/Configure-PowerShell.ps1",
       "${path.root}/../scripts/build/Install-PowerShellModules.ps1",
+      "${path.root}/../scripts/build/Install-WSL2.ps1",
       "${path.root}/../scripts/build/Install-WindowsFeatures.ps1",
       "${path.root}/../scripts/build/Install-Chocolatey.ps1",
       "${path.root}/../scripts/build/Configure-BaseImage.ps1",


### PR DESCRIPTION
# Description
This PR adds WSL v2 support to Windows-2025 image.
>[!! IMPORTANT] WSL v2 does not have a default distribution installed.

#### Related issue:
https://github.com/actions/runner-images/issues/10563
https://github.com/actions/runner-images/issues/11228

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
