### PR TITLE
[windows] Add Android SDK and Tools 34 to windows-2025

### DIFF
--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -86,8 +86,8 @@
     "android": {
         "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-12266719_latest.zip",
         "hash": "F9088C04A44F1F37A8A3A228A7663E11AE9445FA07529C96CEF38ACB985A88F3",
-        "platform_min_version": "35",
-        "build_tools_min_version": "35.0.0",
+        "platform_min_version": "34",
+        "build_tools_min_version": "34.0.0",
         "extras": [
             "android;m2repository",
             "google;m2repository",


### PR DESCRIPTION
# Description
This PR adds Android 34 SDK and Tools to `windows-2025`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
