### PR TITLE
[windows] Don't fail Windows Update test if an update failed but later succeeded

### DIFF
--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -462,6 +462,7 @@ function Get-WindowsUpdateStates {
         [PSCustomObject]@{
             State = $state
             Title = $title
+            TimeCreated = $event.TimeCreated
         }
     }
 }

--- a/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
+++ b/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
@@ -66,10 +66,10 @@ Describe "Windows Updates" {
         "$env:windir\WindowsUpdateDone.txt" | Should -Exist
     }
 
-    $testCases = Get-WindowsUpdateStates | Sort-Object Title | ForEach-Object {
+    $testCases = Get-WindowsUpdateStates | Sort-Object TimeCreated | Group-Object Title | ForEach-Object {
         @{
-            Title = $_.Title
-            State = $_.State
+            Title = $_.Group[-1].Title
+            State = $_.Group[-1].State
         }
     }
 


### PR DESCRIPTION
# Description
Bug fix

I've been trying to build the Windows Server 2025 image this month, and eight of nine attempts to build have failed due to Windows Update failures (the ninth was a fluke failure during VS installation). I kept the OS disk and debugged into it, and the issue was that the "Windows Malicious Software Removal Tool x64 - v5.130 (KB890830)" update was failing due to the machine being rebooted. It appears the install was starting around the time `Install-PowerShellCore.ps1` was running. On a hunch, I tried updating the PS installer to set `ENABLE_MU=0`/`USE_MU=0` but the failures didn't go away.

Broken Test Output (note duplicate entries for MSRT):
```yaml
azure-arm.image: Describing Windows Updates
azure-arm.image:   [+] WindowsUpdateDone.txt should exist 5ms (2ms|3ms)
azure-arm.image:   [+] 2024-11 Cumulative Update for .NET Framework 3.5 and 4.8.1 for Microsoft server operating system version 24H2 for x64 (KB5045934) 57ms (56ms|1ms)
azure-arm.image:   [+] Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.421.1098.0) - Current Channel (Broad) 4ms (2ms|2ms)
azure-arm.image:   [+] Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.421.1101.0) - Current Channel (Broad) 2ms (1ms|1ms)
azure-arm.image:   [+] Security Update for Microsoft OLE DB Driver for SQL Server (KB5040711) 2ms (1ms|1ms)
azure-arm.image:   [+] Update for Microsoft Defender Antivirus antimalware platform - KB4052623 (Version 4.18.24090.11) - Current Channel (Broad) 2ms (1ms|1ms)
azure-arm.image:   [-] Windows Malicious Software Removal Tool x64 - v5.130 (KB890830) 175ms (173ms|2ms)
azure-arm.image:    Expected collection 'Installed' to contain 'Failed', but it was not found.
azure-arm.image:    at $State | Should -BeIn $expect, C:\image\tests\WindowsFeatures.Tests.ps1:76
azure-arm.image:    at <ScriptBlock>, C:\image\tests\WindowsFeatures.Tests.ps1:76
azure-arm.image:   [+] Windows Malicious Software Removal Tool x64 - v5.130 (KB890830) 3ms (2ms|1ms)
```

To address this, I've updated the WU logic to ignore an earlier failure for a given update if it is followed by a successful attempt.

I don't know if there is a larger issue here...should WU be running in the background at this point? I only encountered this issue on the WS2025 image, and have also been building WS2022 and WS2019 a bunch without issue, so maybe something's still off with the new image?

#### Related issue:
I haven't created one, but can if you'd like me to.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated