### PR TITLE
[windows] Fix WSL2 pester test

### DIFF
--- a/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
+++ b/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Windows Updates" {
     }
 }
 
-Describe "WSL2" {
+Describe "WSL2" -Skip:((Test-IsWin19) -or (Test-IsWin22)) {
     It "WSL status should return zero exit code" {
         "wsl --status" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
This PR skips the WSL2 pester test for `windows-2019` and `windows-2022`.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
