### PR TITLE
Update run-runner-image.sh

### DIFF
--- a/.devcontainer/Clangfile.json
+++ b/.devcontainer/Clangfile.json
@@ -1,0 +1,35 @@
+{
+  "version": "2025",
+  "clang_versions": {
+    "default": "18.0.0",
+    "supported": ["14.0.0", "16.0.0", "18.0.0"]
+  },
+  "toolchain": {
+    "compiler": "clang++",
+    "options": {
+      "optimization": "-O2",
+      "warnings": "-Wall",
+      "standard": "c++20"
+    }
+  },
+  "tasks": [
+    {
+      "name": "Build Project",
+      "command": "clang++ -O2 -Wall -std=c++20 main.cpp -o main"
+    },
+    {
+      "name": "Run Tests",
+      "command": "./test_suite --run"
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "libstdc++",
+      "version": ">=12.0"
+    },
+    {
+      "name": "glibc",
+      "version": ">=2.31"
+    }
+  ]
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,20 +1,16 @@
-# Use the base image for C++ development
-FROM mcr.microsoft.com/devcontainers/cpp:1-debian-12
+# Use base images for C++ development
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04 AS ubuntu-base
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022 AS windows-base
 
-# Set the CMake version to reinstall if needed
+# Ubuntu Environment Setup
+FROM ubuntu-base AS ubuntu-setup
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
-
-# Copy the script to reinstall CMake from source
 COPY ./reinstall-cmake.sh /tmp/
-
-# Reinstall CMake if a specific version is provided
 RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
         chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
     fi \
-    && rm -f /tmp/reinstall-cmake.sh
-
-# Install additional system packages for debugging
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && rm -f /tmp/reinstall-cmake.sh \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
        python3-pip \
        nodejs \
@@ -24,6 +20,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
        valgrind \
        lsof \
        git \
+       clang-18 \
+       libstdc++-12-dev \
+       glibc-source \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Python setup
@@ -33,15 +32,39 @@ RUN python3 -m pip install --upgrade pip
 RUN npm install -g yarn
 
 # Install vcpkg if not already present
+ENV VCPKG_INSTALLATION_ROOT=/vcpkg
 RUN git clone https://github.com/microsoft/vcpkg.git $VCPKG_INSTALLATION_ROOT \
     && cd $VCPKG_INSTALLATION_ROOT \
     && ./bootstrap-vcpkg.sh
 
 # Copy project files into the container
 COPY . /workspace
-
-# Set the working directory in the container
 WORKDIR /workspace
-
-# Default command to launch a debugging shell
 CMD ["bash"]
+
+# Windows Environment Setup
+FROM windows-base AS windows-setup
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
+    choco install -y \
+    msys2 \
+    cmake \
+    clang \
+    python \
+    nodejs \
+    git \
+    jdk17 \
+    visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+
+# Setup environment variables
+ENV PATH="${PATH};C:\msys64\usr\bin;C:\Program Files\Git\cmd"
+
+# Install vcpkg for Windows
+RUN git clone https://github.com/microsoft/vcpkg.git C:\vcpkg \
+    && cd C:\vcpkg \
+    && .\bootstrap-vcpkg.bat
+
+# Copy project files into the container
+COPY . C:\workspace
+WORKDIR C:\workspace
+CMD ["powershell"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,47 @@
+# Use the base image for C++ development
+FROM mcr.microsoft.com/devcontainers/cpp:1-debian-12
+
+# Set the CMake version to reinstall if needed
+ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
+
+# Copy the script to reinstall CMake from source
+COPY ./reinstall-cmake.sh /tmp/
+
+# Reinstall CMake if a specific version is provided
+RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
+        chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
+    fi \
+    && rm -f /tmp/reinstall-cmake.sh
+
+# Install additional system packages for debugging
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+       python3-pip \
+       nodejs \
+       npm \
+       openjdk-17-jdk \
+       gdb \
+       valgrind \
+       lsof \
+       git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Python setup
+RUN python3 -m pip install --upgrade pip
+
+# Node.js setup
+RUN npm install -g yarn
+
+# Install vcpkg if not already present
+RUN git clone https://github.com/microsoft/vcpkg.git $VCPKG_INSTALLATION_ROOT \
+    && cd $VCPKG_INSTALLATION_ROOT \
+    && ./bootstrap-vcpkg.sh
+
+# Copy project files into the container
+COPY . /workspace
+
+# Set the working directory in the container
+WORKDIR /workspace
+
+# Default command to launch a debugging shell
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "Internal Windows Server 2025",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".",
+		"args": {
+			"INSTALL_DEPENDENCIES": "true"
+		}
+	},
+	"features": {
+		"ghcr.io/elanhasson/devcontainer-features/dotnet-aspire-daily:1": {},
+		"ghcr.io/nikiforovall/devcontainer-features/dotnet-aspire:1": {},
+		"ghcr.io/nikiforovall/devcontainer-features/dotnet-csharpier:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cmake-tools",
+				"ms-dotnettools.csharp",
+				"ms-vscode.cpptools",
+				"ms-python.python",
+				"ms-vscode.powershell"
+			]
+		}
+	},
+	"forwardPorts": [55787],
+	"postCreateCommand": "gcc --version && cmake . && make && ./run_tests",
+	"remoteUser": "root",
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+	],
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+	"workspaceFolder": "/workspace/runner-images"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,8 +35,3 @@
   "workspaceFolder": "/workspace/runner-images",
   "initializeCommand": "PORT=$(shuf -i 55000-55999 -n 1) && echo $PORT"
 }
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-	],
-	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
-	"workspaceFolder": "/workspace/runner-images"
-}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,32 +1,40 @@
 {
-	"name": "Internal Windows Server 2025",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"context": ".",
-		"args": {
-			"INSTALL_DEPENDENCIES": "true"
-		}
-	},
-	"features": {
-		"ghcr.io/elanhasson/devcontainer-features/dotnet-aspire-daily:1": {},
-		"ghcr.io/nikiforovall/devcontainer-features/dotnet-aspire:1": {},
-		"ghcr.io/nikiforovall/devcontainer-features/dotnet-csharpier:1": {}
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"ms-vscode.cmake-tools",
-				"ms-dotnettools.csharp",
-				"ms-vscode.cpptools",
-				"ms-python.python",
-				"ms-vscode.powershell"
-			]
-		}
-	},
-	"forwardPorts": [55787],
-	"postCreateCommand": "gcc --version && cmake . && make && ./run_tests",
-	"remoteUser": "root",
-	"mounts": [
+  "name": "Multi-Platform CI/CD Development",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".",
+    "args": {
+      "INSTALL_DEPENDENCIES": "true",
+      "REINSTALL_CMAKE_VERSION_FROM_SOURCE": "none"
+    }
+  },
+  "features": {
+    "ghcr.io/elanhasson/devcontainer-features/dotnet-aspire-daily:1": {},
+    "ghcr.io/nikiforovall/devcontainer-features/dotnet-aspire:1": {},
+    "ghcr.io/nikiforovall/devcontainer-features/dotnet-csharpier:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-dotnettools.csharp",
+        "ms-vscode.cpptools",
+        "ms-python.python",
+        "ms-vscode.powershell",
+        "github.vscode-github-actions"
+      ]
+    }
+  },
+  "forwardPorts": [55787],
+  "postCreateCommand": "gcc --version && cmake . && make && ./run_tests",
+  "remoteUser": "root",
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace/runner-images",
+  "initializeCommand": "PORT=$(shuf -i 55000-55999 -n 1) && echo $PORT"
+}
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
 	],
 	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",

--- a/.devcontainer/internal.windows-2025.json
+++ b/.devcontainer/internal.windows-2025.json
@@ -1,0 +1,591 @@
+{
+  "NodeType": "HeaderNode",
+  "Title": "Windows Server 2025",
+  "Children": [
+    {
+      "NodeType": "ToolVersionNode",
+      "ToolName": "OS Version:",
+      "Version": "10.0.26100 Build 2605"
+    },
+    {
+      "NodeType": "ToolVersionNode",
+      "ToolName": "Image Version:",
+      "Version": "20241215.1.0"
+    },
+    {
+      "NodeType": "HeaderNode",
+      "Title": "Windows updates",
+      "Children": [
+        {
+          "NodeType": "ToolVersionNode",
+          "ToolName": "Update Title",
+          "Version": "Some Update",
+          "TimeCreated": "2024-12-30T12:34:56Z"
+        },
+        {
+          "NodeType": "ToolVersionNode",
+          "ToolName": "Another Update",
+          "Version": "Another Update Version",
+          "TimeCreated": "2024-12-30T12:34:56Z"
+        }
+      ]
+    },
+    {
+      "NodeType": "HeaderNode",
+      "Title": "Windows features",
+      "Children": {
+        "NodeType": "ToolVersionNode",
+        "ToolName": "Windows Subsystem for Linux (WSLv1):",
+        "Version": "Enabled"
+      }
+    },
+    {
+      "NodeType": "HeaderNode",
+      "Title": "Installed Software",
+      "Children": [
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Language and Runtime",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Bash",
+              "Version": "5.2.37(1)-release"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Go",
+              "Version": "1.23.4"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Julia",
+              "Version": "1.10.5"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Kotlin",
+              "Version": "2.1.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "LLVM",
+              "Version": "19.1.5"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Node",
+              "Version": "22.12.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Perl",
+              "Version": "5.40.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "PHP",
+              "Version": "8.3.14"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Python",
+              "Version": "3.9.13"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Ruby",
+              "Version": "3.3.6"
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Package Management",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Chocolatey",
+              "Version": "2.4.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Composer",
+              "Version": "2.8.4"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Helm",
+              "Version": "3.16.2"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Miniconda",
+              "Version": "24.9.2 (pre-installed on the image but not added to PATH)"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "NPM",
+              "Version": "10.9.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "NuGet",
+              "Version": "6.12.1.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "pip",
+              "Version": "24.3.1 (python 3.9)"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Pipx",
+              "Version": "1.7.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "RubyGems",
+              "Version": "3.5.22"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Vcpkg",
+              "Version": "(build from commit c26eabb23)"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Yarn",
+              "Version": "1.22.22"
+            },
+            {
+              "NodeType": "HeaderNode",
+              "Title": "Environment variables",
+              "Children": {
+                "NodeType": "TableNode",
+                "Headers": "Name|Value",
+                "Rows": [
+                  "VCPKG_INSTALLATION_ROOT|C:\\vcpkg",
+                  "CONDA|C:\\Miniconda"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Project Management",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Ant",
+              "Version": "1.10.14"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Gradle",
+              "Version": "8.11"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Maven",
+              "Version": "3.9.9"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "sbt",
+              "Version": "1.10.6"
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Tools",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "7zip",
+              "Version": "24.09"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "aria2",
+              "Version": "1.37.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "azcopy",
+              "Version": "10.27.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Bazel",
+              "Version": "8.0.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Bazelisk",
+              "Version": "1.25.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Bicep",
+              "Version": "0.32.4"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Cabal",
+              "Version": "3.12.1.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "CMake",
+              "Version": "3.31.2"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "CodeQL Action Bundle",
+              "Version": "2.20.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Docker",
+              "Version": "26.1.3"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Docker Compose v2",
+              "Version": "2.27.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Docker-wincred",
+              "Version": "0.8.2"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "ghc",
+              "Version": "9.10.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Git",
+              "Version": "2.47.1.windows.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Git LFS",
+              "Version": "3.6.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "ImageMagick",
+              "Version": "7.1.1-41"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "jq",
+              "Version": "1.7.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Kind",
+              "Version": "0.25.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Kubectl",
+              "Version": "1.32.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "gcc",
+              "Version": "14.2.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "gdb",
+              "Version": "14.2"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "GNU Binutils",
+              "Version": "2.42"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Newman",
+              "Version": "6.2.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "OpenSSL",
+              "Version": "3.4.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Packer",
+              "Version": "1.11.2"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Pulumi",
+              "Version": "3.143.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "R",
+              "Version": "4.4.2"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Service Fabric SDK",
+              "Version": "10.1.2493.9590"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Stack",
+              "Version": "3.1.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Swig",
+              "Version": "4.1.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "VSWhere",
+              "Version": "3.1.7"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "WinAppDriver",
+              "Version": "1.2.2009.02003"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "WiX Toolset",
+              "Version": "3.14.1.8722"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "yamllint",
+              "Version": "1.35.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "zstd",
+              "Version": "1.5.6"
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "CLI Tools",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "AWS CLI",
+              "Version": "2.22.17"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "AWS SAM CLI",
+              "Version": "1.132.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "AWS Session Manager CLI",
+              "Version": "1.2.694.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Azure CLI",
+              "Version": "2.67.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Azure DevOps CLI extension",
+              "Version": "1.0.1"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "GitHub CLI",
+              "Version": "2.63.2"
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Rust Tools",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Cargo",
+              "Version": "1.83.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Rust",
+              "Version": "1.83.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Rustdoc",
+              "Version": "1.83.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Rustup",
+              "Version": "1.27.1"
+            },
+            {
+              "NodeType": "HeaderNode",
+              "Title": "Packages",
+              "Children": [
+                {
+                  "NodeType": "ToolVersionNode",
+                  "ToolName": "Clippy",
+                  "Version": "0.1.83"
+                },
+                {
+                  "NodeType": "ToolVersionNode",
+                  "ToolName": "Rustfmt",
+                  "Version": "1.8.0"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Browsers and Drivers",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Google Chrome",
+              "Version": "131.0.6778.140"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Chrome Driver",
+              "Version": "131.0.6778.108"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Microsoft Edge",
+              "Version": "131.0.2903.99"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Microsoft Edge Driver",
+              "Version": "131.0.2903.99"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Mozilla Firefox",
+              "Version": "133.0.3"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Gecko Driver",
+              "Version": "0.35.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "IE Driver",
+              "Version": "4.14.0.0"
+            },
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Selenium server",
+              "Version": "4.27.0"
+            },
+            {
+              "NodeType": "HeaderNode",
+              "Title": "Environment variables",
+              "Children": {
+                "NodeType": "TableNode",
+                "Headers": "Name|Value",
+                "Rows": [
+                  "CHROMEWEBDRIVER|C:\\SeleniumWebDrivers\\ChromeDriver",
+                  "EDGEWEBDRIVER|C:\\SeleniumWebDrivers\\EdgeDriver",
+                  "GECKOWEBDRIVER|C:\\SeleniumWebDrivers\\GeckoDriver",
+                  "SELENIUM_JAR_PATH|C:\\selenium\\selenium-server.jar"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Java",
+          "Children": {
+            "NodeType": "TableNode",
+            "Headers": "Version|Environment Variable",
+            "Rows": [
+              "8.0.432+6|JAVA_HOME_8_X64",
+              "11.0.25+9|JAVA_HOME_11_X64",
+              "17.0.13+11 (default)|JAVA_HOME_17_X64",
+              "21.0.5+11.0|JAVA_HOME_21_X64"
+            ]
+          }
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Shells",
+          "Children": {
+            "NodeType": "TableNode",
+            "Headers": "Name|Target",
+            "Rows": [
+              "gitbash.exe|C:\\Program Files\\Git\\bin\\bash.exe",
+              "msys2bash.cmd|C:\\msys64\\usr\\bin\\bash.exe",
+              "wslbash.exe|C:\\Windows\\System32\\bash.exe"
+            ]
+          }
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "MSYS2",
+          "Children": [
+            {
+              "NodeType": "ToolVersionNode",
+              "ToolName": "Pacman",
+              "Version": "6.1.0"
+            },
+            {
+              "NodeType": "HeaderNode",
+              "Title": "Notes",
+              "Children": {
+                "NodeType": "NoteNode",
+                "Content": "Location: C:\\msys64\n\nNote: MSYS2 is pre-installed on image but not added to PATH."
+              }
+            }
+          ]
+        },
+        {
+          "NodeType": "HeaderNode",
+          "Title": "Cached Tools",
+          "Children": [
+            {
+              "NodeType": "ToolVersionsListNode",
+              "ToolName": "Go",
+              "Versions": [
+                "1.21.13",
+                "1.22.10",
+                "1.23.4"
+              ],
+              "MajorVersionRegex": "^\\d+\\.\\d+",
+              "ListType": "List"
+            },
+            {
+              "NodeType": "ToolVersionsListNode",
+              "ToolName": "Node.js",
+              "Versions": [
+                "18.20.5",
+                "20.18.1",
+                "22.12.0"
+              ],
+              "MajorVersionRegex": "^\\d+",
+              "ListType": "List"
+            },

--- a/.devcontainer/internal.windows-2025.json
+++ b/.devcontainer/internal.windows-2025.json
@@ -573,6 +573,7 @@
               "Versions": [
                 "1.21.13",
                 "1.22.10",
+                "1.23.10",
                 "1.23.4"
               ],
               "MajorVersionRegex": "^\\d+\\.\\d+",
@@ -589,3 +590,22 @@
               "MajorVersionRegex": "^\\d+",
               "ListType": "List"
             },
+
+            },
+            {
+              "NodeType": "ToolVersionsListNode",
+              "ToolName": "Node.js",
+              "Versions": [
+                "18.20.5",
+                "20.18.1",
+                "22.12.0"
+              ],
+              "MajorVersionRegex": "^\\d+",
+              "ListType": "List"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+

--- a/.devcontainer/nternal.ubuntu.24.04.json
+++ b/.devcontainer/nternal.ubuntu.24.04.json
@@ -1,0 +1,37 @@
+{
+  "os": {
+    "name": "Ubuntu",
+    "version": "24.04",
+    "base_image": "ubuntu:24.04"
+  },
+  "packages": {
+    "preinstalled": [
+      "clang-18",
+      "python3.12",
+      "nodejs-20",
+      "libsdl2-dev",
+      "astyle",
+      "ccache"
+    ],
+    "removed": [
+      "terraform",
+      "mono"
+    ]
+  },
+  "toolchains": [
+    {
+      "name": "clang",
+      "version": "18.0.0",
+      "path": "/usr/bin/clang"
+    },
+    {
+      "name": "gcc",
+      "version": "14.0.0",
+      "path": "/usr/bin/gcc"
+    }
+  ],
+  "compatibility": {
+    "preferred_lts": "22.04",
+    "notes": "Transitioning to 24.04 image. Recommended to update dependencies."
+  }
+}

--- a/.devcontainer/run-runner-image.sh
+++ b/.devcontainer/run-runner-image.sh
@@ -1,35 +1,79 @@
 #!/bin/bash
 
-# Script to build and run the Runner Image for Windows Server 2025 debugging
+# Script to build and run Runner Images for Ubuntu 24.04 and Windows Server 2025 debugging
+# with Clang setup
 
 # Variables
-IMAGE_NAME="runner-images-windows-2025"
+UBUNTU_IMAGE_NAME="runner-images-ubuntu-24.04"
+WINDOWS_IMAGE_NAME="runner-images-windows-2025"
 CONTAINER_NAME="runner-images-container"
-DOCKERFILE_PATH="./Dockerfile"  # Adjust if Dockerfile is in a different location
+UBUNTU_DOCKERFILE_PATH="./Dockerfile.ubuntu"  # Adjust if Dockerfile for Ubuntu is in a different location
+WINDOWS_DOCKERFILE_PATH="./Dockerfile.windows"  # Adjust if Dockerfile for Windows is in a different location
 CONTEXT_DIR="."                # Adjust if the context is a different directory
 WORKSPACE_DIR="$(pwd)"         # Current directory as the workspace
+UBUNTU_CLANGFILE_PATH="clangfile.ubuntu.json"
+WINDOWS_CLANGFILE_PATH="clangfile.windows.json"
+LOG_FILE="runner-images-build.log"
 
 # Functions
-function build_image() {
-    echo "Building Docker image: ${IMAGE_NAME}..."
-    docker build -t ${IMAGE_NAME} -f ${DOCKERFILE_PATH} ${CONTEXT_DIR}
+
+# Cleanup Function
+cleanup() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] Cleaning up any existing container with the same name..."
+    if docker rm -f ${CONTAINER_NAME} 2>/dev/null; then
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] Container ${CONTAINER_NAME} successfully removed."
+    else
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] No container named ${CONTAINER_NAME} found or removal failed."
+    fi
 }
 
-function run_container() {
-    echo "Running Docker container: ${CONTAINER_NAME}..."
+# Build Image Function
+build_image() {
+    local image_name="$1"
+    local dockerfile_path="$2"
+    local clangfile_path="$3"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] Building Docker image: ${image_name}..."
+    if docker build -t ${image_name} -f ${dockerfile_path} --build-arg CLANGFILE=${clangfile_path} ${CONTEXT_DIR} | tee -a ${LOG_FILE}; then
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] Docker image ${image_name} built successfully."
+    else
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] ERROR: Docker image build for ${image_name} failed. Check ${LOG_FILE} for details."
+        exit 1
+    fi
+}
+
+# Run Container Function
+run_container() {
+    local image_name="$1"
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] Running Docker container: ${CONTAINER_NAME} for ${image_name}..."
     docker run -it --rm \
         --name ${CONTAINER_NAME} \
         --mount type=bind,source=${WORKSPACE_DIR},target=/workspace \
         --network none \  # Ensures no network access for isolation
-        ${IMAGE_NAME}
+        ${image_name}
+    if [ $? -eq 0 ]; then
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] Container ${CONTAINER_NAME} for ${image_name} ran successfully."
+    else
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] ERROR: Failed to run container ${CONTAINER_NAME} for ${image_name}."
+        exit 1
+    fi
 }
 
-function cleanup() {
-    echo "Cleaning up any existing container with the same name..."
-    docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
-}
+# Main Execution Workflow
+echo "[$(date +'%Y-%m-%d %H:%M:%S')] Starting Runner Image Setup for Ubuntu 24.04 and Windows Server 2025 with Clang configurations..."
 
-# Main execution
+# Clean up any previous runs
 cleanup
-build_image
-run_container
+
+# Build the Ubuntu Docker image with Clang configuration
+build_image ${UBUNTU_IMAGE_NAME} ${UBUNTU_DOCKERFILE_PATH} ${UBUNTU_CLANGFILE_PATH}
+
+# Run the Ubuntu container
+run_container ${UBUNTU_IMAGE_NAME}
+
+# Build the Windows Docker image with Clang configuration
+build_image ${WINDOWS_IMAGE_NAME} ${WINDOWS_DOCKERFILE_PATH} ${WINDOWS_CLANGFILE_PATH}
+
+# Run the Windows container
+run_container ${WINDOWS_IMAGE_NAME}
+
+echo "[$(date +'%Y-%m-%d %H:%M:%S')] Runner Image Setup for both Ubuntu 24.04 and Windows Server 2025 with Clang configurations completed."

--- a/.devcontainer/run-runner-image.sh
+++ b/.devcontainer/run-runner-image.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Script to build and run the Runner Image for Windows Server 2025 debugging
+
+# Variables
+IMAGE_NAME="runner-images-windows-2025"
+CONTAINER_NAME="runner-images-container"
+DOCKERFILE_PATH="./Dockerfile"  # Adjust if Dockerfile is in a different location
+CONTEXT_DIR="."                # Adjust if the context is a different directory
+WORKSPACE_DIR="$(pwd)"         # Current directory as the workspace
+
+# Functions
+function build_image() {
+    echo "Building Docker image: ${IMAGE_NAME}..."
+    docker build -t ${IMAGE_NAME} -f ${DOCKERFILE_PATH} ${CONTEXT_DIR}
+}
+
+function run_container() {
+    echo "Running Docker container: ${CONTAINER_NAME}..."
+    docker run -it --rm \
+        --name ${CONTAINER_NAME} \
+        --mount type=bind,source=${WORKSPACE_DIR},target=/workspace \
+        --network none \  # Ensures no network access for isolation
+        ${IMAGE_NAME}
+}
+
+function cleanup() {
+    echo "Cleaning up any existing container with the same name..."
+    docker rm -f ${CONTAINER_NAME} 2>/dev/null || true
+}
+
+# Main execution
+cleanup
+build_image
+run_container


### PR DESCRIPTION
Updates the ISO to create both WIndows 2025 toolkit devcontainer and also ISO for ubunutu 24.04 2025 toolkit, and makes .devcontainer the root file directory for the update. 

Sorry Mac users, you're on your own until Tim Cook decides to  come in and help out.

# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
