### PR TITLE
Revert "[windows] Fix WSL2 pester test"

### DIFF
--- a/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
+++ b/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Windows Updates" {
     }
 }
 
-Describe "WSL2" -Skip:((Test-IsWin19) -or (Test-IsWin22)) {
+Describe "WSL2" {
     It "WSL status should return zero exit code" {
         "wsl --status" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
Reverts actions/runner-images#11255

Logs show intentional skipping of tests, thus stopping the bot from running