### PR TITLE
[Ubuntu 20 and 22] Removing .Net version 7.0 

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -269,12 +269,10 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0",
             "dotnet-sdk-8.0"
         ],
         "versions": [
             "6.0",
-            "7.0",
             "8.0"
         ],
         "tools": [

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -268,12 +268,10 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0",
             "dotnet-sdk-8.0"
         ],
         "versions": [
             "6.0",
-            "7.0",
             "8.0"
         ],
         "tools": [


### PR DESCRIPTION
# Description
This PR will remove the .Net version 7.0 


#### Related issue:
Related Announcement: https://github.com/actions/runner-images/issues/10894
## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
