### PR TITLE
[Ubuntu-24] Add libsqlite3-dev package to ubuntu 24

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -127,6 +127,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libsqlite3-dev",
             "locales",
             "mercurial",
             "openssh-client",


### PR DESCRIPTION
# Description
This PR will add the `libsqlite3-dev` package to the Ubuntu 24 image .

#### Related issue:
https://github.com/actions/runner-images/issues/11279


## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
