### PR TITLE
[Windows] Update maven version to 3.9 

### DIFF
--- a/images/windows/scripts/build/Install-JavaTools.ps1
+++ b/images/windows/scripts/build/Install-JavaTools.ps1
@@ -110,7 +110,6 @@ foreach ($jdkVersionToInstall in $jdkVersionsToInstall) {
 # Install Java tools
 # Force chocolatey to ignore dependencies on Ant and Maven or else they will download the Oracle JDK
 Install-ChocoPackage ant -ArgumentList "--ignore-dependencies"
-# Maven 3.9.x has multiple compatibilities problems
 $toolsetMavenVersion = (Get-ToolsetContent).maven.version
 $versionToInstall = Resolve-ChocoPackageVersion -PackageName "maven" -TargetVersion $toolsetMavenVersion
 

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -449,7 +449,7 @@
         "default": "18.*"
     },
     "maven": {
-        "version": "3.8"
+        "version": "3.9"
     },
     "mysql": {
         "version": "5.7",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -359,7 +359,7 @@
         "default": "18.*"
     },
     "maven": {
-        "version": "3.8"
+        "version": "3.9"
     },
     "mysql": {
         "version": "8.0",


### PR DESCRIPTION
This PR updates the maven version to 3.9 in Windows 2019 and 2022 images , Windows 2025 has already been updated to 3.9.



#### Related issue: [10715](https://github.com/actions/runner-images/issues/10715)
#### Related Announcement: [11093](https://github.com/actions/runner-images/issues/11093)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
