### PR TITLE
[Ubuntu] Update maven version to 3.9.9

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -72,7 +72,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.9.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -69,7 +69,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.9.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -65,7 +65,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.9.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
This PR updates the maven version to 3.9 in Ubuntu 20,22,24 images.

Related issue: https://github.com/actions/runner-images/issues/10715
Related Announcement: https://github.com/actions/runner-images/issues/11093

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
