### PR TITLE
Update Ruby version to 3.3 on macOS 13 and 14 images

### DIFF
--- a/images/macos/macos-13-Readme.md
+++ b/images/macos/macos-13-Readme.md
@@ -28,7 +28,7 @@
 - Perl 5.40.0
 - PHP 8.4.2
 - Python3 3.13.1
-- Ruby 3.0.7p220
+- Ruby 3.3.6
 
 ### Package Management
 - Bundler 2.5.23
@@ -126,7 +126,6 @@
 - 3.10.14 [PyPy 7.3.17]
 
 #### Ruby
-- 3.0.7
 - 3.1.6
 - 3.2.6
 - 3.3.6

--- a/images/macos/macos-13-Readme.md
+++ b/images/macos/macos-13-Readme.md
@@ -194,14 +194,14 @@
 | Simulator - iOS 16.4                                    | iphonesimulator16.4                           | 14.3.1        |
 | Simulator - iOS 17.0                                    | iphonesimulator17.0                           | 15.0.1        |
 | Simulator - iOS 17.2                                    | iphonesimulator17.2                           | 15.1, 15.2    |
-| tvOS 16.1                                               | appletvos16.1                                 | 14.1, 14.2    |
-| tvOS 16.4                                               | appletvos16.4                                 | 14.3.1        |
-| tvOS 17.0                                               | appletvos17.0                                 | 15.0.1        |
-| tvOS 17.2                                               | appletvos17.2                                 | 15.1, 15.2    |
-| Simulator - tvOS 16.1                                   | appletvsimulator16.1                          | 14.1, 14.2    |
-| Simulator - tvOS 16.4                                   | appletvsimulator16.4                          | 14.3.1        |
-| Simulator - tvOS 17.0                                   | appletvsimulator17.0                          | 15.0.1        |
-| Simulator - tvOS 17.2                                   | appletvsimulator17.2                          | 15.1, 15.2    |
+| tvOS 16.1                                                | appletvos16.1                                  | 14.1, 14.2    |
+| tvOS 16.4                                                | appletvos16.4                                  | 14.3.1        |
+| tvOS 17.0                                                | appletvos17.0                                  | 15.0.1        |
+| tvOS 17.2                                                | appletvos17.2                                  | 15.1, 15.2    |
+| Simulator - tvOS 16.1                                    | appletvsimulator16.1                           | 14.1, 14.2    |
+| Simulator - tvOS 16.4                                    | appletvsimulator16.4                           | 14.3.1        |
+| Simulator - tvOS 17.0                                    | appletvsimulator17.0                           | 15.0.1        |
+| Simulator - tvOS 17.2                                    | appletvsimulator17.2                           | 15.1, 15.2    |
 | watchOS 9.1                                             | watchos9.1                                    | 14.1, 14.2    |
 | watchOS 9.4                                             | watchos9.4                                    | 14.3.1        |
 | watchOS 10.0                                            | watchos10.0                                   | 15.0.1        |

--- a/images/macos/macos-14-Readme.md
+++ b/images/macos/macos-14-Readme.md
@@ -28,7 +28,7 @@
 - Perl 5.40.0
 - PHP 8.4.2
 - Python3 3.13.1
-- Ruby 3.0.7p220
+- Ruby 3.3.6
 
 ### Package Management
 - Bundler 2.5.23
@@ -118,7 +118,6 @@
 ### Cached Tools
 
 #### Ruby
-- 3.0.7
 - 3.1.6
 - 3.2.6
 - 3.3.6


### PR DESCRIPTION
Related to #11345

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actions/runner-images/pull/11351?shareId=c105a468-85ca-4d04-a53e-6fbb960f9a85).