### PR TITLE
Update Maven to 3.9.*

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -72,7 +72,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.9.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -69,7 +69,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.9.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -65,7 +65,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.8.8"
+        "maven": "3.9.9"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
Fixes #11093

Update Maven version to 3.9.9 in Ubuntu toolsets.

* Change `maven` version to `3.9.9` in `images/ubuntu/toolsets/toolset-2004.json`.
* Change `maven` version to `3.9.9` in `images/ubuntu/toolsets/toolset-2204.json`.
* Change `maven` version to `3.9.9` in `images/ubuntu/toolsets/toolset-2404.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actions/runner-images/issues/11093?shareId=XXXX-XXXX-XXXX-XXXX).