### PR TITLE
[Ubuntu] Enable podman.socket on Ubuntu 24.04

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -42,4 +42,8 @@ if is_ubuntu20; then
     echo "containers $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 fi
 
+if is_ubuntu24; then 
+ systemctl enable --now podman.socket
+fi
+
 invoke_tests "Tools" "Containers"


### PR DESCRIPTION
# Description
This PR will enable the podman.socket service on Ubuntu 24.04, as it is not enabled automatically by default in this version, unlike previous Ubuntu releases. 

#### Related issue:
https://github.com/actions/runner-images/issues/11366
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
