### PR TITLE
[windows] Update Get-WindowsUpdateStates function

### DIFF
--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -454,8 +454,8 @@ function Get-WindowsUpdateStates {
             }
         }
 
-        # Skip update started event if it was already completed
-        if ( $state -eq "Running" -and $completedUpdates.ContainsKey($title) ) {
+        # Skip update events if it was already completed
+        if ( ($state -eq "Running" -or $state -eq "Failed") -and $completedUpdates.ContainsKey($title) ) {
             continue
         }
 

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -438,13 +438,15 @@ function Get-WindowsUpdateStates {
             19 {
                 $state = "Installed"
                 $title = $event.Properties[0].Value
-                $completedUpdates[$title] = ""
+                $completedUpdates[$title] = $state
                 break
             }
             20 {
                 $state = "Failed"
                 $title = $event.Properties[1].Value
-                $completedUpdates[$title] = ""
+                if (-not $completedUpdates.ContainsKey($title)) {
+                    $completedUpdates[$title] = $state
+                }
                 break
             }
             43 {
@@ -454,8 +456,13 @@ function Get-WindowsUpdateStates {
             }
         }
 
-        # Skip update events if it was already completed
-        if ( ($state -eq "Running" -or $state -eq "Failed") -and $completedUpdates.ContainsKey($title) ) {
+        # Skip Running update event if it was already completed
+        if ( ($state -eq "Running") -and $completedUpdates.ContainsKey($title) ) {
+            continue
+        }
+
+        # Skip Failed update event if it was already successfully installed
+        if ( ($state -eq "Failed") -and $completedUpdates[$title] -eq "Installed" ) {
             continue
         }
 


### PR DESCRIPTION
# Description
This PR updates the `Get-WindowsUpdateStates` function to skip the update failed event if the update has already been successfully installed

#### Related issue: https://github.com/actions/runner-images/pull/11253

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
