### PR TITLE
[Ubuntu 20 & Ubuntu 22] Adding Dotnet latest version 9.0

### DIFF
--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -269,11 +269,13 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-8.0"
+            "dotnet-sdk-8.0",
+            "dotnet-sdk-9.0"
         ],
         "versions": [
             "6.0",
-            "8.0"
+            "8.0",
+            "9.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -268,11 +268,13 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-8.0"
+            "dotnet-sdk-8.0",
+            "dotnet-sdk-9.0"
         ],
         "versions": [
             "6.0",
-            "8.0"
+            "8.0",
+            "9.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }


### PR DESCRIPTION
# Description
This PR adding latest Dotnet version 9.0 in Ubuntu-20 and Ubuntu-22.


#### Related issue:
https://github.com/actions/runner-images/issues/10964
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
