### PR TITLE
Update Tags handling in build-image.ps1

### DIFF
--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -34,7 +34,7 @@ $SensitiveData = @(
     ':  ->'
 )
 
-$azure_tags = $Tags.GetEnumerator() | ForEach-Object { "{0}={1}" -f $_.Key, $_.Value } | Join-String -Separator ","
+$azure_tags = ($Tags.GetEnumerator() | ForEach-Object { "{0}={1}" -f $_.Key, $_.Value }) -join ","
 
 Write-Host "Show Packer Version"
 packer --version


### PR DESCRIPTION
# Description
`Join-String` cmdlt is not available in `powershell 5.*`. This PR replaces cmdlt with `-join` operator

#### Related issue: https://github.com/actions/runner-images/issues/11415

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
