### PR TITLE
[Windows] Updated to PHP version 8.4.

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -458,7 +458,7 @@
         "version": "3.10"
     },
     "php": {
-        "version": "8.3"
+        "version": "8.4"
     },
     "llvm": {
         "version": "18"

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -371,7 +371,7 @@
         "version": "18"
     },
     "php": {
-        "version": "8.3"
+        "version": "8.4"
     },
     "postgresql": {
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9",

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -308,7 +308,7 @@
         "version": "19"
     },
     "php": {
-        "version": "8.3"
+        "version": "8.4"
     },
     "postgresql": {
         "version": "17",


### PR DESCRIPTION

This PR will update the latest version of PHP 8.4* to the windows 2019, 2022 and 2025.

#### Related issue:
https://github.com/actions/runner-images/issues/11187

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
