### PR TITLE
[Actions] Remove Ruby check for CodeQL test as not used

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python', 'ruby' ]
+        language: [ 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
# Description

After applying https://github.com/actions/runner-images/pull/11473, we no longer use Ruby in our sources. Required for unlock: https://github.com/actions/runner-images/pull/11473

#### Related issue:

https://github.com/actions/runner-images/pull/11473

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
