### PR TITLE
[Ubuntu] Disable apparmor user namespace restrictions

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -45,6 +45,9 @@ echo 'fs.inotify.max_user_instances=1280' | tee -a /etc/sysctl.conf
 # https://github.com/actions/runner-images/issues/9491
 echo 'vm.mmap_rnd_bits=28' | tee -a /etc/sysctl.conf
 
+# https://github.com/actions/runner-images/issues/10443
+echo 'kernel.apparmor_restrict_unprivileged_userns=0' | tee -a /etc/sysctl.conf
+
 # https://github.com/actions/runner-images/pull/7860
 netfilter_rule='/etc/udev/rules.d/50-netfilter.rules'
 rules_directory="$(dirname "${netfilter_rule}")"

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -6,3 +6,10 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
         $freeSpace | Should -BeGreaterOrEqual 17GB
     }
 }
+
+Describe "Check apparmor unprivileged userns restrictions" {
+    It "kernel.apparmor_restrict_unprivileged_userns == 0" {
+        $value = Get-Content /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+        $value | Should -BeEqual 0
+    }
+}


### PR DESCRIPTION
Fixes issue with tooling such as skopeo/buildah which uses unshare syscall that is restricted by default on Ubuntu 24.04

# Description

Fixes #10443 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
