### PR TITLE
Add instructions for cloning the repository using GitHub CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,11 @@ We are in the process of preparing the macOS CI to accept contributions. Until t
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
 - [GitHub Help](https://help.github.com)
+
+## Cloning the Repository
+
+To clone this repository using GitHub CLI, use the following command:
+
+```sh
+gh repo clone actions/runner-images
+```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Software and Image Support](#software-and-image-support)
 - [How to Interact with the Repo](#how-to-interact-with-the-repo)
 - [FAQs](#faqs)
+- [Cloning the Repository](#cloning-the-repository)
 
 ## About
 
@@ -214,3 +215,11 @@ Please create an issue and get an approval from us to add this tool to the image
 We strongly encourage customers to build their own images using the main branch.
 This repository contains multiple branches and releases that serve as document milestones to reflect what software is installed in the images at certain point of time. Current builds are not idempotent and if one tries to build a runner image using the specific tag it is not guaranteed that the build will succeed.
 </details>
+
+## Cloning the Repository
+
+To clone this repository using GitHub CLI, use the following command:
+
+```sh
+gh repo clone actions/runner-images
+```


### PR DESCRIPTION
Add instructions for cloning the repository using GitHub CLI.

* **README.md**
  - Add a new section "Cloning the Repository" with instructions and the command `gh repo clone actions/runner-images`.
  - Update the table of contents to include the new section.

* **CONTRIBUTING.md**
  - Add a new section "Cloning the Repository" with instructions and the command `gh repo clone actions/runner-images`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actions/runner-images/pull/11491?shareId=14799a99-6b1a-4dcc-83db-0ae01712a24f).