### PR TITLE
[Ubuntu] add Android SDK Platform-Tools

### DIFF
--- a/images/ubuntu/scripts/build/install-android-sdk.sh
+++ b/images/ubuntu/scripts/build/install-android-sdk.sh
@@ -110,6 +110,9 @@ available_build_tools=$(echo ${all_build_tools[@]//*rc[0-9]/})
 add_filtered_installation_components $minimum_platform_version "${available_platforms[@]}"
 add_filtered_installation_components $minimum_build_tool_version "${available_build_tools[@]}"
 
+# Add platform tools to the list of components to install
+components+=("platform-tools")
+
 # Install components
 echo "y" | $SDKMANAGER ${components[@]}
 

--- a/images/ubuntu/scripts/tests/Android.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Android.Tests.ps1
@@ -72,6 +72,7 @@ Describe "Android" {
         $platformsInstalled,
         $buildTools,
         $ndkFullVersions,
+        "platform-tools",
         ((Get-ToolsetContent).android.extra_list | ForEach-Object { "extras/${_}" }),
         ((Get-ToolsetContent).android.addon_list | ForEach-Object { "add-ons/${_}" }),
         ((Get-ToolsetContent).android.additional_tools | ForEach-Object { "${_}" })


### PR DESCRIPTION
# Description
This pull request adds the Android SDK Platform-Tools to the Ubuntu image.
The platform tools take up about 18 MB of disk space, but this should not be an obstacle to adding them.

#### Related issue:
https://github.com/actions/runner-images/issues/10495

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
