### PR TITLE
Add instructions for cloning the repository using gh command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,11 @@ We are in the process of preparing the macOS CI to accept contributions. Until t
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
 - [GitHub Help](https://help.github.com)
+
+## Cloning the Repository
+
+To clone the repository using the `gh` command, run the following command:
+
+```sh
+gh repo clone actions/runner-images
+```

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ In general, these are the guidelines we follow when deciding what to pre-install
 - **Issues**: To file a bug report, or request tools to be added/updated, please [open an issue using the appropriate template](https://github.com/actions/runner-images/issues/new/choose)
 - **Discussions**: If you want to share your thoughts about image configuration, installed software, or bring a new idea, please create a new topic in a [discussion](https://github.com/actions/runner-images/discussions) for a corresponding category. Before making a new discussion please make sure no similar topics were created earlier.
 - For general questions about using the runner images or writing your Actions workflow, please open requests in the [GitHub Actions Community Forum](https://github.community/c/github-actions/41).
+- **Cloning the Repository**: To clone the repository using the `gh` command, run the following command:
+  ```sh
+  gh repo clone actions/runner-images
+  ```
 
 ## FAQs
 


### PR DESCRIPTION
Add instructions for cloning the repository using the `gh` command.

* **README.md**:
  - Add a new section "Cloning the Repository" with instructions on how to clone the repository using the `gh` command.

* **CONTRIBUTING.md**:
  - Add a new section "Cloning the Repository" with instructions on how to clone the repository using the `gh` command before making contributions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actions/runner-images/pull/11544?shareId=2bee4e4c-12d9-4a86-b9f3-2ca146641e93).