### PR TITLE
[windows] Fix .Net 8 SDK installation

### DIFF
--- a/images/windows/scripts/build/Install-DotnetSDK.ps1
+++ b/images/windows/scripts/build/Install-DotnetSDK.ps1
@@ -95,6 +95,15 @@ $dotnetToolset = (Get-ToolsetContent).dotnet
 # Download installation script.
 $installScriptPath = Invoke-DownloadWithRetry -Url "https://dot.net/v1/dotnet-install.ps1"
 
+# Visual Studio 2022 pre-creates sdk-manifests/8.0.100 folder, causing dotnet-install to skip manifests creation
+# https://github.com/actions/runner-images/issues/11402
+if (Test-IsWin22 -or Test-IsWin25) {
+    $sdkManifestPath = "C:\Program Files\dotnet\sdk-manifests\8.0.100"
+    if (Test-Path $sdkManifestPath) {
+        Move-Item -Path $sdkManifestPath -Destination $env:TEMP_DIR -ErrorAction Stop
+    }
+}
+
 # Install and warm up dotnet
 foreach ($dotnetVersion in $dotnetToolset.versions) {
     $sdkVersionsToInstall = Get-SDKVersionsToInstall -DotnetVersion $dotnetVersion
@@ -102,6 +111,17 @@ foreach ($dotnetVersion in $dotnetToolset.versions) {
         Install-DotnetSDK -InstallScriptPath $installScriptPath -SDKVersion $sdkVersion -DotnetVersion $dotnetVersion
         if ($dotnetToolset.warmup) {
             Invoke-DotnetWarmup -SDKVersion $sdkVersion
+        }
+    }
+}
+
+# Replace manifests inside sdk-manifests/8.0.100 folder with ones from Visual Studio
+# https://github.com/actions/runner-images/issues/11402
+if (Test-IsWin22 -or Test-IsWin25) {
+    if (Test-Path "${env:TEMP_DIR}\8.0.100") {
+        Get-ChildItem -Path "${env:TEMP_DIR}\8.0.100" | ForEach-Object {
+            Remove-Item -Path "$sdkManifestPath\$($_.BaseName)" -Recurse -Force | Out-Null
+            Move-Item -Path $_.FullName -Destination $sdkManifestPath -Force -ErrorAction Stop
         }
     }
 }


### PR DESCRIPTION
# Description
Visual Studio 2022 installation contains `Microsoft.NetCore.Component.SDK` component, which creates `C:\Program Files\dotnet\sdk-manifests\8.0.100` folder with `microsoft.net.sdk.aspire 8.2.2` workload manifest.
Later during any dotnet/sdk 8.0 installation using [dotnet-install](https://dot.net/v1/dotnet-install.ps1) script, `8.0.100` folder's existence prevents manifest files from being copied. This causes [issues](https://github.com/dotnet/sdk/issues/45931) with `dotnet` cli command
This PR introduces following workaround logic on `windows-2022` and `windows-2025` images:
1. Manifests created by Visual Studio are copied to the temporary location for the duration of `dotnet-sdk` install
2. Visual Studio related manifests are copied back to the original location after `dotnet-sdk` install

#### Related issue: https://github.com/actions/runner-images/issues/11402

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
