### PR TITLE
[windows-2025] Fix .Net 8 SDK installation

### DIFF
--- a/images/windows/scripts/build/Install-DotnetSDK.ps1
+++ b/images/windows/scripts/build/Install-DotnetSDK.ps1
@@ -97,7 +97,7 @@ $installScriptPath = Invoke-DownloadWithRetry -Url "https://dot.net/v1/dotnet-in
 
 # Visual Studio 2022 pre-creates sdk-manifests/8.0.100 folder, causing dotnet-install to skip manifests creation
 # https://github.com/actions/runner-images/issues/11402
-if (Test-IsWin22 -or Test-IsWin25) {
+if ((Test-IsWin22) -or (Test-IsWin25)) {
     $sdkManifestPath = "C:\Program Files\dotnet\sdk-manifests\8.0.100"
     if (Test-Path $sdkManifestPath) {
         Move-Item -Path $sdkManifestPath -Destination $env:TEMP_DIR -ErrorAction Stop
@@ -117,7 +117,7 @@ foreach ($dotnetVersion in $dotnetToolset.versions) {
 
 # Replace manifests inside sdk-manifests/8.0.100 folder with ones from Visual Studio
 # https://github.com/actions/runner-images/issues/11402
-if (Test-IsWin22 -or Test-IsWin25) {
+if ((Test-IsWin22) -or (Test-IsWin25)) {
     if (Test-Path "${env:TEMP_DIR}\8.0.100") {
         Get-ChildItem -Path "${env:TEMP_DIR}\8.0.100" | ForEach-Object {
             Remove-Item -Path "$sdkManifestPath\$($_.BaseName)" -Recurse -Force | Out-Null


### PR DESCRIPTION
# Description
This PR fixes condition handling in `Install-DotnetSDK.ps1` script in case of `windows-2025`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
