### PR TITLE
[Windows] Updated the EdgeDriver, vcRedis signature and Openssl version to 3.4.1 in Windows 25

### DIFF
--- a/images/windows/scripts/build/Install-EdgeDriver.ps1
+++ b/images/windows/scripts/build/Install-EdgeDriver.ps1
@@ -27,7 +27,7 @@ Write-Host "Expand Microsoft Edge WebDriver archive..."
 Expand-7ZipArchive -Path $archivePath -DestinationPath $edgeDriverPath
 
 #Validate the EdgeDriver signature
-$signatureThumbprint = "7920AC8FB05E0FFFE21E8FF4B4F03093BA6AC16E"
+$signatureThumbprint = "0BD8C56733FDCC06F8CB919FF5A200E39B1ACF71"
 Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedThumbprint $signatureThumbprint
 
 Write-Host "Setting the environment variables..."

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -467,7 +467,7 @@
     "postgresql": {
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9",
         "version": "14",
-        "vcRedistSignature": "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D",
+        "vcRedistSignature": "8F985BE8FD256085C90A95D3C74580511A1DB975",
         "installVcRedist": true
     },
     "kotlin": {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -383,7 +383,7 @@
     "postgresql": {
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9",
         "version": "14",
-        "vcRedistSignature": "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D",
+        "vcRedistSignature": "8F985BE8FD256085C90A95D3C74580511A1DB975",
         "installVcRedist": true
     },
     "kotlin": {

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -324,7 +324,7 @@
         "version": "latest"
     },
     "openssl": {
-        "version": "3.4.0",
+        "version": "3.4.1",
         "pinnedDetails": {
             "link": "https://github.com/actions/runner-images-internal/pull/6702",
             "reason": "Meaningful reason must be added at next update.",


### PR DESCRIPTION
This PR will update the Edge-Driver  , vcRedis Signature for Windows 2019 and 2022 images and Openssl version 3.4.1 is updated in Windows-2025 image.

#### Related [issue:] [11586](https://github.com/actions/runner-images/issues/11586)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
