### PR TITLE
Possible Temp fix: Pin old git version

### DIFF
--- a/images/ubuntu/scripts/build/install-git.sh
+++ b/images/ubuntu/scripts/build/install-git.sh
@@ -7,12 +7,20 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-GIT_REPO="ppa:git-core/ppa"
+# Temporary fix for git version 2.48 breaking change impacting checkout action
+# Note: The PPA has removed the 2.47.1 version, even in superseeded packages for Noble and others
+#       the fallback here is to use the 2.47.1 version from the PPA for an earlier version of Ubuntu
+wget -O git.deb https://launchpad.net/~git-core/+archive/ubuntu/ppa/+files/git_2.47.1-0ppa1~ubuntu16.04.1_amd64.deb
+wget -O git-man.deb https://launchpad.net/~git-core/+archive/ubuntu/ppa/+files/git-man_2.47.1-0ppa1~ubuntu16.04.1_all.deb 
 
-## Install git
-add-apt-repository $GIT_REPO -y
-apt-get update
-apt-get install git
+apt-get install -y ./git.deb ./git-man.deb
+
+# GIT_REPO="ppa:git-core/ppa"
+
+# ## Install git
+# add-apt-repository $GIT_REPO -y
+# apt-get update
+# apt-get install git=1:2.47.1-*
 
 # Git version 2.35.2 introduces security fix that breaks action\checkout https://github.com/actions/checkout/issues/760
 cat <<EOF >> /etc/gitconfig
@@ -24,10 +32,10 @@ EOF
 apt-get install git-ftp
 
 # Remove source repo's
-add-apt-repository --remove $GIT_REPO
+# add-apt-repository --remove $GIT_REPO
 
 # Document apt source repo's
-echo "git-core $GIT_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
+# echo "git-core $GIT_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
 
 # Add well-known SSH host keys to known_hosts
 ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /etc/ssh/ssh_known_hosts


### PR DESCRIPTION
Potential workaround for 2.48 git causing issue with checkout action.

Wip. 

Git 2.47.1 deb dependencies `dpkg -I git` 

```
 Version: 1:2.47.1-0ppa1~ubuntu16.04.1
 Architecture: amd64
 Maintainer: Jonathan Nieder <jrnieder@gmail.com>
 Installed-Size: 46811
 Depends: libc6 (>= 2.16), libcurl3-gnutls (>= 7.16.2), libexpat1 (>= 2.0.1), libpcre2-8-0, zlib1g (>= 1:1.2.2), perl, liberror-perl, git-man (>> 1:2.47.1), git-man (<< 1:2.47.1-.)
 Recommends: ca-certificates, patch, less, ssh-client
 Suggests: gettext-base, git-daemon-run | git-daemon-sysvinit, git-doc, git-email, git-gui, gitk, gitweb, git-cvs, git-mediawiki, git-svn
 Breaks: bash-completion (<< 1:1.90-1), cogito (<= 0.18.2+), dgit (<< 5.1~), git-buildpackage (<< 0.6.5), git-el (<< 1:2.32.0~rc2-1~), gitosis (<< 0.2+20090917-7), gitpkg (<< 0.15), guilt (<< 0.33), openssh-client (<< 1:6.8), stgit (<< 0.15), stgit-contrib (<< 0.15)
 Provides: git-completion, git-core
 Section: vcs
 Priority: optional
 Multi-Arch: foreign
```

# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
