### PR TITLE
Remove authentication method from "cleanup" script

### DIFF
--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -1,7 +1,7 @@
 param(
     [String] [Parameter (Mandatory=$true)] $TemplatePath,
     [String] [Parameter (Mandatory=$true)] $ClientId,
-    [String] [Parameter (Mandatory=$true)] $ClientSecret,
+    [String] [Parameter (Mandatory=$false)] $ClientSecret,
     [String] [Parameter (Mandatory=$true)] $Location,
     [String] [Parameter (Mandatory=$true)] $ImageName,
     [String] [Parameter (Mandatory=$true)] $ImageResourceGroupName,
@@ -13,7 +13,7 @@ param(
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkRG,
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkSubnet,
     [String] [Parameter (Mandatory=$false)] $AllowedInboundIpAddresses = "[]",
-    [hashtable] [Parameter (Mandatory=$False)] $Tags = @{}
+    [hashtable] [Parameter (Mandatory=$false)] $Tags = @{}
 )
 
 if (-not (Test-Path $TemplatePath))

--- a/images.CI/linux-and-win/cleanup.ps1
+++ b/images.CI/linux-and-win/cleanup.ps1
@@ -1,13 +1,6 @@
 param(
-    [Parameter (Mandatory=$true)] [string] $TempResourceGroupName,
-    [Parameter (Mandatory=$true)] [string] $SubscriptionId,
-    [Parameter (Mandatory=$true)] [string] $ClientId,
-    [Parameter (Mandatory=$true)] [string] $ClientSecret,
-    [Parameter (Mandatory=$true)] [string] $TenantId
+    [Parameter (Mandatory=$true)] [string] $TempResourceGroupName
 )
-
-az login --service-principal --username $ClientId --password=$ClientSecret --tenant $TenantId | Out-Null
-az account set --subscription $SubscriptionId | Out-Null
 
 $groupExist = az group exists --name $TempResourceGroupName
 if ($groupExist -eq "true") {


### PR DESCRIPTION
# Description
This PR removes unnecessary authentication methods from the "cleanup" script, since the image generation workflow uses OIDC authentication.
Also, this PR make the `ClientSecret` parameter optional for the `build-image.ps1` script.

#### Related issue:
https://github.com/actions/runner-images-internal/issues/6776

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
