### PR TITLE
[Windows] Fix Visual studio signature, Az Powershell module failures and Pin the Zstd version 

### DIFF
--- a/images/windows/scripts/build/Install-Zstd.ps1
+++ b/images/windows/scripts/build/Install-Zstd.ps1
@@ -2,10 +2,10 @@
 ##  File:  Install-Zstd.ps1
 ##  Desc:  Install zstd
 ################################################################################
-
+# Temporarily pin the version
 $downloadUrl = Resolve-GithubReleaseAssetUrl `
     -Repo "facebook/zstd" `
-    -Version "latest" `
+    -Version "1.5.6" `
     -UrlMatchPattern "zstd-*-win64.zip"
 $zstdArchivePath = Invoke-DownloadWithRetry $downloadUrl
 $zstdName = [IO.Path]::GetFileNameWithoutExtension($zstdArchivePath)

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -115,7 +115,7 @@
         {
             "name": "az",
             "versions": [
-                "12.1.0"
+                "12.4.0"
             ],
             "zip_versions": [
 
@@ -179,7 +179,7 @@
         "subversion" : "17",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": "8F985BE8FD256085C90A95D3C74580511A1DB975",
+        "signature": "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D",
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",


### PR DESCRIPTION
# Description
 This PR will fix the visual studio signature failure , Pin the Zstd version to 1.5.6 and update the Az Powershell module to the newer version . 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
