### PR TITLE
[Windows] Pin the git version to 2.47.1

### DIFF
--- a/images/windows/scripts/build/Install-Git.ps1
+++ b/images/windows/scripts/build/Install-Git.ps1
@@ -8,12 +8,12 @@
 
 $downloadUrl = Resolve-GithubReleaseAssetUrl `
     -Repo "git-for-windows/git" `
-    -Version "latest" `
+    -Version "2.47.1" `
     -UrlMatchPattern "Git-*-64-bit.exe"
 
 $externalHash = Get-ChecksumFromGithubRelease `
     -Repo "git-for-windows/git" `
-    -Version "latest" `
+    -Version "2.47.1" `
     -FileName (Split-Path $downloadUrl -Leaf) `
     -HashType "SHA256"
 


### PR DESCRIPTION
# Description
This PR will pin the git version to 2.47.1 on Windows.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
