### PR TITLE
[macOS] update git version to 2.48.1

### DIFF
--- a/images/macos/scripts/build/install-git.sh
+++ b/images/macos/scripts/build/install-git.sh
@@ -7,14 +7,7 @@
 source ~/utils/utils.sh
 
 echo "Installing Git..."
-#brew_smart_install "git"
-
-COMMIT=aecf26f53d0d1d15d42f658ae2db243f87746af6
-FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/g/git.rb"
-FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/g/git.rb"
-mkdir -p "$(dirname $FORMULA_PATH)"
-curl -fsSL $FORMULA_URL -o $FORMULA_PATH
-HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install git
+brew_smart_install "git"
 
 git config --global --add safe.directory "*"
 


### PR DESCRIPTION
# Description
update git version to 2.48.1 to all macOS images.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
