### PR TITLE
[Windows] Updating Docker-Engine version to 27

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -363,8 +363,8 @@
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019"
         ],
         "components": {
-            "docker": "26.1.3",
-            "compose": "2.27.1"
+            "docker": "27.5.1",
+            "compose": "2.32.2"
         }
     },
     "pipx": [

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -287,8 +287,8 @@
             "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
         ],
         "components": {
-            "docker": "26.1.3",
-            "compose": "2.27.1"
+            "docker": "27.5.1",
+            "compose": "2.32.2"
         }
     },
     "pipx": [

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -228,8 +228,8 @@
     "docker": {
         "images": [],
         "components": {
-            "docker": "26.1.3",
-            "compose": "2.27.1"
+            "docker": "27.5.1",
+            "compose": "2.32.2"
         }
     },
     "pipx": [


### PR DESCRIPTION
This PR updates the docker engine version to 27 and compose to 2.32.2

#### Related issue: [11104](https://github.com/actions/runner-images/issues/11104)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
