### PR TITLE
Remove deprecated parameters from GenerateResourcesAndImage helper

### DIFF
--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -75,7 +75,7 @@ In any case, you will need these software installed:
 ## Manual image generation
 
 This repository includes a script that assists in generating images in Azure.
-All you need is an Azure subscription and a build agent configured as described above.
+All you need is an Azure subscription, a resource group in that subscription and a build agent configured as described above.
 We suggest starting with building the UbuntuMinimal image because it includes only basic software and builds in less than 30 minutes.
 
 All the commands below should be executed in PowerShell.
@@ -96,7 +96,8 @@ Import-Module .\helpers\GenerateResourcesAndImage.ps1
 Finally, run the `GenerateResourcesAndImage` function, setting the mandatory arguments: image type and where to build and store the resulting managed image:
 
 - `SubscriptionId` - your Azure Subscription ID;
-- `ResourceGroupName` - the name of the resource group that will be created within your subscription (e.g., "imagegen-test");
+- `ResourceGroupName` - the name of the resource group that will store the resulting artifact (e.g., "imagegen-test").
+    The resource group must already exist in your Azure subscription;
 - `AzureLocation` - the location where resources will be created (e.g., "East US");
 - `ImageType` - the type of image to build (we suggest choosing "UbuntuMinimal" here; other valid options are "Windows2019", "Windows2022", "Windows2025", "Ubuntu2004", "Ubuntu2204", "Ubuntu2404").
 
@@ -195,9 +196,10 @@ you can use Packer directly. To do this, you will need:
 - a resource group created in your Azure subscription where the managed image will be stored;
 - a string to be used as a password for the user used to install software (Windows only).
 
-Then, you can invoke Packer in your CI/CD pipeline using the following command:
+Then, you can invoke Packer in your CI/CD pipeline using the following commands:
 
 ```powershell
+packer plugins install github.com/hashicorp/azure 2.2.1
 packer build -var "subscription_id=$SubscriptionId" `
              -var "client_id=$ClientId" `
              -var "client_secret=$ClientSecret" `

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -103,12 +103,6 @@ Function GenerateResourcesAndImage {
         .PARAMETER RestrictToAgentIpAddress
             If set, access to the VM used by packer to generate the image is restricted to the public IP address this script is run from. 
             This parameter cannot be used in combination with the virtual_network_name packer parameter.
-        .PARAMETER Force
-            Delete the resource group if it exists without user confirmation.
-            This parameter is deprecated and will be removed in a future release.
-        .PARAMETER ReuseResourceGroup
-            Reuse the resource group if it exists without user confirmation.
-            This parameter is deprecated and will be removed in a future release.
         .PARAMETER OnError
             Specify how packer handles an error during image creation.
             Options:
@@ -150,23 +144,11 @@ Function GenerateResourcesAndImage {
         [Parameter(Mandatory = $False)]
         [switch] $RestrictToAgentIpAddress,
         [Parameter(Mandatory = $False)]
-        [switch] $Force,
-        [Parameter(Mandatory = $False)]
-        [switch] $ReuseResourceGroup,
-        [Parameter(Mandatory = $False)]
         [ValidateSet("abort", "ask", "cleanup", "run-cleanup-provisioner")]
         [string] $OnError = "ask",
         [Parameter(Mandatory = $False)]
         [hashtable] $Tags = @{}
     )
-
-    if ($Force -or $ReuseResourceGroup) {
-        Write-Warning "The `ReuseResourceGroup` and `Force` parameters are deprecated and will be removed in a future release. The resource group will be reused when it already exists and an error will be thrown when it doesn't. If you want to delete the resource group, please delete it manually."
-    }
-
-    if ($Force -and $ReuseResourceGroup) {
-        throw "Force and ReuseResourceGroup cannot be used together."
-    }
 
     Show-LatestCommit -ErrorAction SilentlyContinue
 
@@ -266,73 +248,8 @@ Function GenerateResourcesAndImage {
         if ($ResourceGroupExists) {
             Write-Verbose "Resource group '$ResourceGroupName' already exists."
         }
-
-        # Remove resource group if it exists and we are not reusing it
-        if ($ResourceGroupExists -and -not $ReuseResourceGroup) {
-            if ($Force) {
-                # Delete and recreate the resource group
-                Write-Host "Deleting resource group '$ResourceGroupName'..."
-                az group delete --name $ResourceGroupName --yes --output none
-                if ($LastExitCode -ne 0) {
-                    throw "Failed to delete resource group '$ResourceGroupName'."
-                }
-                Write-Host "Resource group '$ResourceGroupName' was deleted."
-                $ResourceGroupExists = $false
-            }
-            else {
-                # are we running in a non-interactive session?
-                # https://stackoverflow.com/questions/9738535/powershell-test-for-noninteractive-mode
-                if ([System.Console]::IsOutputRedirected -or ![Environment]::UserInteractive -or !!([Environment]::GetCommandLineArgs() | Where-Object { $_ -ilike '-noni*' })) {
-                    throw "Non-interactive mode, resource group '$ResourceGroupName' already exists, either specify -Force to delete it, or -ReuseResourceGroup to reuse."
-                }
-                else {
-                    # Resource group already exists, ask the user what to do
-                    $title = "Resource group '$ResourceGroupName' already exists"
-                    $message = "Do you want to delete the resource group and all resources in it?"
-
-                    $options = @(
-                        [System.Management.Automation.Host.ChoiceDescription]::new("&Yes", "Delete the resource group and all resources in it."),
-                        [System.Management.Automation.Host.ChoiceDescription]::new("&No", "Keep the resource group and continue."),
-                        [System.Management.Automation.Host.ChoiceDescription]::new("&Abort", "Abort execution.")
-                    )
-                    $result = $Host.UI.PromptForChoice($title, $message, $options, 0)
-                }
-
-                switch ($result) {
-                    0 {
-                        # Delete and recreate the resource group
-                        Write-Host "Deleting resource group '$ResourceGroupName'..."
-                        az group delete --name $ResourceGroupName --yes
-                        if ($LastExitCode -ne 0) {
-                            throw "Failed to delete resource group '$ResourceGroupName'."
-                        }
-                        Write-Host "Resource group '$ResourceGroupName' was deleted."
-                        $ResourceGroupExists = $false
-                    }
-                    1 {
-                        # Keep the resource group and continue
-                    }
-                    2 {
-                        # Stop the current action
-                        Write-Error "User stopped the action."
-                        exit 1
-                    }
-                }
-            }
-        }
-
-        # Create resource group
-        if (-not $ResourceGroupExists) {
-            Write-Host "Creating resource group '$ResourceGroupName' in location '$AzureLocation'..."
-            if ($TagsList) {
-                az group create --name $ResourceGroupName --location $AzureLocation --tags $TagsList --query id
-            }
-            else {
-                az group create --name $ResourceGroupName --location $AzureLocation --query id
-            }
-            if ($LastExitCode -ne 0) {
-                throw "Failed to create resource group '$ResourceGroupName'."
-            }
+        else {
+            throw "Resource group '$ResourceGroupName' does not exist."
         }
 
         # Create service principal

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -83,7 +83,7 @@ Function GenerateResourcesAndImage {
         .PARAMETER SubscriptionId
             The Azure subscription id where the Azure resources will be created.
         .PARAMETER ResourceGroupName
-            The name of the resource group to create the Azure resources in.
+            The name of the resource group to store the resulting artifact. Resource group must already exist.
         .PARAMETER ImageType
             The type of image to generate. Valid values are: Windows2019, Windows2022, Windows2025, Ubuntu2004, Ubuntu2204, Ubuntu2404, UbuntuMinimal.
         .PARAMETER ManagedImageName


### PR DESCRIPTION
# Description
This PR:
1. Removes `Force` and `ReuseResourceGroup` parameters from [GenerateResourcesAndImage](https://github.com/actions/runner-images/blob/main/helpers/GenerateResourcesAndImage.ps1) helper. The resource group to store final artifact will be reused when it already exists and an error will be thrown when it doesn't
2. Updates documentation to reflect the changes

#### Related issue: https://github.com/actions/runner-images/issues/11674, https://github.com/actions/runner-images-internal/issues/6842

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
