### PR TITLE
[macOS] Enable NOPASSWD `sudo` for `admin` group

### DIFF
--- a/images/macos/scripts/build/configure-machine.sh
+++ b/images/macos/scripts/build/configure-machine.sh
@@ -90,6 +90,12 @@ if [[ ! "$(automationmodetool)" =~ "DOES NOT REQUIRE" ]]; then
     exit 1
 fi
 
+# Fix sudoers file permissions
+sudo chmod 440 /etc/sudoers.d/*
+
+# Add NOPASSWD for the current user to sudoers
+sudo sed -i '' 's/%admin		ALL = (ALL) ALL/%admin		ALL = (ALL) NOPASSWD: ALL/g' /etc/sudoers
+
 # Create symlink for tests running
 if [[ ! -d "/usr/local/bin" ]];then
     sudo mkdir -p -m 775 /usr/local/bin

--- a/images/macos/scripts/tests/Common.Tests.ps1
+++ b/images/macos/scripts/tests/Common.Tests.ps1
@@ -87,3 +87,12 @@ Describe "Unxip" {
         "unxip --version" | Should -ReturnZeroExitCode
     }
 }
+
+Describe "Sudoers" {
+    It "Sudo Cache" {
+        "sudo -v" | Should -ReturnZeroExitCode
+    }
+    It "Sudoers files" {
+        "sudo visudo -c" | Should -ReturnZeroExitCode
+    }
+}


### PR DESCRIPTION
# Description

This PR enables passwordless sudo for users in the admin group, and also fixes the permissions of the sudoers daemon files (they turned out to be corrupted).
Plus a couple of tests are added to check the validity of the above parameters.

#### Related issue:

- https://github.com/actions/runner-images/issues/10484

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
