### PR TITLE
[macOS] Add actions/runner cache

### DIFF
--- a/images/macos/scripts/build/install-runner-package.sh
+++ b/images/macos/scripts/build/install-runner-package.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e -o pipefail
+################################################################################
+##  File:  install-runner-package.sh
+##  Desc:  Download and Install runner package
+################################################################################
+
+# Source the helpers for use with the script
+source ~/utils/utils.sh
+
+AGENT_PATH="/opt/runner-cache"
+arch=$(get_arch)
+download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-osx-'"$arch"'-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest")
+archive_name="${download_url##*/}"
+archive_path=$(download_with_retry "$download_url")
+
+if [[ ! -d $AGENT_PATH ]]; then
+    sudo mkdir -p -m 775 $AGENT_PATH
+    sudo chown $USER:admin $AGENT_PATH
+fi
+
+sudo mv "$archive_path" "$AGENT_PATH/$archive_name"

--- a/images/macos/scripts/tests/RunnerCache.Tests.ps1
+++ b/images/macos/scripts/tests/RunnerCache.Tests.ps1
@@ -1,0 +1,7 @@
+Describe "RunnerCache" {
+    Context "runner cache directory not empty" {
+        It "<RunnerCachePath> not empty" -TestCases @{ RunnerCachePath = "/opt/runner-cache" } {
+            (Get-ChildItem -Path "$RunnerCachePath/*.tar.gz" -Recurse).Count | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -236,6 +236,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-llvm.sh",
       "${path.root}/../scripts/build/install-swiftlint.sh",
       "${path.root}/../scripts/build/install-openjdk.sh",

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -237,6 +237,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-llvm.sh",
       "${path.root}/../scripts/build/install-openjdk.sh",
       "${path.root}/../scripts/build/install-aws-tools.sh",

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -235,6 +235,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-llvm.sh",
       "${path.root}/../scripts/build/install-swiftlint.sh",
       "${path.root}/../scripts/build/install-openjdk.sh",

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -236,6 +236,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-llvm.sh",
       "${path.root}/../scripts/build/install-openjdk.sh",
       "${path.root}/../scripts/build/install-aws-tools.sh",

--- a/images/macos/templates/macOS-15.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.anka.pkr.hcl
@@ -233,6 +233,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-llvm.sh",
       "${path.root}/../scripts/build/install-swiftlint.sh",
       "${path.root}/../scripts/build/install-openjdk.sh",

--- a/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
@@ -235,6 +235,7 @@ build {
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-llvm.sh",
       "${path.root}/../scripts/build/install-openjdk.sh",
       "${path.root}/../scripts/build/install-aws-tools.sh",


### PR DESCRIPTION
# Description

The edits are aimed at synchronising the MacOS image with Windows and Ubuntu-based images. I am adding a cached version of the Actions agent.

#### Related issue:

[#6860](https://github.com/actions/runner-images-internal/issues/6860)

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
