### PR TITLE
[macOS] Disable rustup self-updating

### DIFF
--- a/images/macos/scripts/build/install-rust.sh
+++ b/images/macos/scripts/build/install-rust.sh
@@ -15,6 +15,15 @@ rustup-init -y --no-modify-path --default-toolchain=stable --profile=minimal
 echo "Initialize environment variables..."
 CARGO_HOME=$HOME/.cargo
 
+echo "Disable rustup self-updating"
+# This is undesirable because:
+# - We will keep rustup updated (just like any other dependency).
+# - rustup does not need to be the latest and greatest.
+# - Self-updating in CI will introduce longer build times for no benefit.
+# - ... which becomes important because self-updating happens in various
+#   places, including `rustup toolchain install`.
+rustup set auto-self-update disable
+
 echo "Install common tools..."
 rustup component add rustfmt clippy
 


### PR DESCRIPTION
# Description
1. Disable rustup self-updating.
[issue-11714](https://github.com/actions/runner-images/issues/11714)

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
