### PR TITLE
[macos] Update Android Emulator to 35.4.9 on macOS-15 and macOS-15-arm

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -29,12 +29,14 @@
         }
     },
     "android": {
-        "cmdline-tools": "commandlinetools-mac-12266719_latest.zip",
+        "cmdline-tools": "commandlinetools-mac-8092744_latest.zip",
         "sdk-tools": "sdk-tools-darwin-4333796.zip",
         "platform_min_version": "34",
         "build_tools_min_version": "35.0.0",
         "extras": [
-            "android;m2repository", "google;m2repository", "google;google_play_services"
+            "android;m2repository",
+            "google;m2repository",
+            "google;google_play_services"
         ],
         "addons": [],
         "additional_tools": [


### PR DESCRIPTION
## Description 
- Updated the Android Emulator to version 35.4.9 on both macos-15 and macos-15-arm.
- Awaiting VM rollout for the changes to take effect.



#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
