### PR TITLE
[Ubuntu] Add Installation of google-cloud-errors Gem for Ubuntu 20

### DIFF
--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -13,6 +13,9 @@ apt-get install ruby-full
 # temporary fix for fastlane installation https://github.com/sporkmonger/addressable/issues/541
 if is_ubuntu20; then
     gem install public_suffix -v 5.1.1
+    
+    # Install google-cloud-errors gem pinned to version 1.4.0
+    gem install google-cloud-errors -v 1.4.0
 fi
 
 # Install ruby gems from toolset

--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -14,7 +14,7 @@ apt-get install ruby-full
 if is_ubuntu20; then
     gem install public_suffix -v 5.1.1
     
-    # temporary Install google-cloud-errors gem pinned to version 1.4.0
+    # Install google-cloud-errors gem pinned to version 1.4.0
     gem install google-cloud-errors -v 1.4.0
 fi
 

--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -14,7 +14,7 @@ apt-get install ruby-full
 if is_ubuntu20; then
     gem install public_suffix -v 5.1.1
     
-    # Install google-cloud-errors gem pinned to version 1.4.0
+    # temporary Install google-cloud-errors gem pinned to version 1.4.0
     gem install google-cloud-errors -v 1.4.0
 fi
 


### PR DESCRIPTION
# Description
This PR will includes the installation of the google-cloud-errors gem (version 1.4.0) for Ubuntu 20 environments. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
