### PR TITLE
New possibility 

### DIFF
--- a/images/ubuntu/scripts/tests/Databases.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Databases.Tests.ps1
@@ -22,6 +22,12 @@ Describe "PostgreSQL" {
         # Server version
         (pg_config --version).split()[-1] | Should -BeLike "$toolsetVersion*"
     }
+
+    It "PostgreSQL Service with specified version" {
+        "sudo systemctl start postgresql.service -v 17" | Should -ReturnZeroExitCode
+        "pg_isready" | Should -OutputTextMatchingRegex "/var/run/postgresql:5432 - accepting connections"
+        "sudo systemctl stop postgresql" | Should -ReturnZeroExitCode
+    }
 }
 
 Describe "MySQL" {


### PR DESCRIPTION
Fixes #11531

Add a test for PostgreSQL service with specified version in `Databases.Tests.ps1`.

* Add a new test case to start PostgreSQL service with version 17.
* Validate that PostgreSQL service is accepting connections.
* Stop the PostgreSQL service after the test.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actions/runner-images/pull/11734?shareId=16412cb9-c1c2-4223-9046-122b34af4e3b).