### PR TITLE
[macOS] Update Xcode runtimes installer helper and toolset format

### DIFF
--- a/images/macos/scripts/build/Install-Xcode.ps1
+++ b/images/macos/scripts/build/Install-Xcode.ps1
@@ -33,7 +33,7 @@ Write-Host "Configuring Xcode versions..."
 $xcodeVersions | ForEach-Object {
     Write-Host "Configuring Xcode $($_.link) ..."
     Invoke-XcodeRunFirstLaunch -Version $_.link
-    Install-AdditionalSimulatorRuntimes -Version $_.link -Runtimes $_.install_runtimes
+    Install-AdditionalSimulatorRuntimes -Version $_.link -Arch $arch -Runtimes $_.install_runtimes
 }
 
 Invoke-XcodeRunFirstLaunch -Version $defaultXcode

--- a/images/macos/scripts/helpers/Xcode.Installer.psm1
+++ b/images/macos/scripts/helpers/Xcode.Installer.psm1
@@ -175,33 +175,84 @@ function Install-AdditionalSimulatorRuntimes {
         [Parameter(Mandatory)]
         [string] $Version,
         [Parameter(Mandatory)]
-        [array] $Runtimes
+        [string] $Arch,
+        [Parameter(Mandatory)]
+        [object] $Runtimes
     )
 
     Write-Host "Installing Simulator Runtimes for Xcode $Version ..."
     $xcodebuildPath = Get-XcodeToolPath -Version $Version -ToolName 'xcodebuild'
-    $validRuntimes = @("iOS", "watchOS", "tvOS", "visionOS")
-    # Install all runtimes / skip all runtimes installation
-    if ($Runtimes.Count -eq 1) {
-        if ($Runtimes[0] -eq "true") {
-            Write-Host "Installing all runtimes for Xcode $Version ..."
-            Invoke-ValidateCommand "sudo $xcodebuildPath -downloadAllPlatforms" | Out-Null
-            return
-        } elseif ($Runtimes[0] -eq "false") {
-            Write-Host "Skipping runtimes installation for Xcode $Version ..."
-            return
-        }
+    $validRuntimes = @("iOS", "watchOS", "tvOS")
+
+    # visionOS is only available on arm64
+    if ($Arch -eq "arm64") {
+        $validRuntimes += "visionOS"
     }
 
-    # Validate and install specified runtimes
-    $invalidRuntimes = $Runtimes | Where-Object { $_ -notmatch "^($( $validRuntimes -join '|' ))(\s.*|$)" }
-    if ($invalidRuntimes) {
-        throw "Error: Invalid runtimes detected: $($invalidRuntimes -join ', '). Valid values are: $validRuntimes."
+    # Install all runtimes / skip runtimes
+    if ($Runtimes -eq "default") {
+        Write-Host "Installing all runtimes for Xcode $Version ..."
+        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadAllPlatforms" | Out-Null
+        return
+    } elseif ($Runtimes -eq "none") {
+        Write-Host "Skipping runtimes installation for Xcode $Version ..."
+        return
     }
-    
-    foreach ($runtime in $Runtimes) {
-        Write-Host "Installing runtime $runtime ..."
-        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $runtime" | Out-Null
+
+    # Convert $Runtimes to hashtable
+    if ($Runtimes -is [System.Object[]]) {
+        $convertedRuntimes = @{}
+
+        foreach ($entry in $Runtimes) {
+            if ($entry -is [PSCustomObject]) {
+                $entry = $entry | ConvertTo-Json -Compress | ConvertFrom-Json -AsHashtable
+            }
+            
+            # Copy all keys and values from the entry to the converted runtimes
+            foreach ($key in $entry.Keys) {
+                if ($convertedRuntimes.ContainsKey($key)) {
+                    $convertedRuntimes[$key] += $entry[$key]
+                } else {
+                    $convertedRuntimes[$key] = $entry[$key]
+                }
+            }
+        }
+        $Runtimes = $convertedRuntimes
+    }
+
+    # Validate runtimes format
+    if ($Runtimes -isnot [System.Collections.Hashtable]) {
+        throw "Invalid runtime format for Xcode $(Version): Expected hashtable, got [$($Runtimes.GetType())]"
+    }
+
+    # Install runtimes for specified platforms
+    foreach ($platform in $validRuntimes) {        
+        if (-not $Runtimes.ContainsKey($platform)) {
+            Write-Host "No runtimes specified for $platform in the toolset for Xcode $Version, please check the toolset."
+            return
+        }
+        foreach ($platformVersion in $Runtimes[$platform]) {
+            switch ($platformVersion) {
+                "skip" {
+                    Write-Host "Skipping $platform runtimes installation for Xcode $Version ..."
+                    continue
+                }
+                "default" {
+                    Write-Host "Installing default $platform runtime for Xcode $Version ..."
+                    Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $platform" | Out-Null
+                    continue
+                }
+                default {
+                    # Version might be a semver or a build number
+                    if (($platformVersion -match "^\d{1,2}\.\d(\.\d)?$") -or ($platformVersion -match "^[a-zA-Z0-9]{6,8}$")) {
+                        Write-Host "Installing $platform $platformVersion runtime for Xcode $Version ..."
+                        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $platform -buildVersion $platformVersion" | Out-Null
+                        continue
+                    }
+                    throw "$platformVersion is not a valid value for $platform version. Valid values are 'latest' or 'skip' or a semver from 0.0 to 99.9.(9)."
+                }
+            }
+        }
     }
 }
 

--- a/images/macos/toolsets/Readme.md
+++ b/images/macos/toolsets/Readme.md
@@ -6,9 +6,19 @@
   - `link` property points to the place where Xcode will be located on image. `/Applications/Xcode_<link>.app`  
   - `version` points to Xcode version that will be downloaded and installed
   - `symlinks` describes the list of aliases where symlinks will be created to
-  - `install_runtimes` is an array or boolean function to control over the related simulator runtimes, set of possible values: [ `iOS`, `watchOS`, `visionOS`, `tvOS` ], use `true` if you want to install all runtimes, use `false` if you want to skip runtimes installation
   - `sha256` used to check integrity of the Xcode installer file
-- `default` - version of Xcode to set as default (should be metched with any `link` in `versions` property)
+  - `install_runtimes` – controls the installation of simulator runtimes:
+    - `default` – installs all default runtimes.
+    - `none` – skips runtime installation.
+    - **Hashtable** – allows manual selection:
+      - Mandatory keys: `[ "iOS", "watchOS", "tvOS" ]`, plus `visionOS` for arm64 images.
+      - Values [array of string]:  
+        - `"default"` – installs the default runtime.  
+        - `"skip"` – skips installation.  
+        - Specific version numbers, e.g., `"18.2"`, `"2.2"`, `"18.3.1"`.
+        - Apple release version, e.g., `"22E5216h"`, `"17A577"`.
+
+- `default` - version of Xcode to set as default (should be matched with any `link` in `versions` property)
     **Example:** `"11.2"`  
 
 **Note:**
@@ -22,10 +32,36 @@
 
 **Example:**
 
+String format:
+
 ```json
 "versions": [
-    { "link": "16_beta_4", "version": "16.0.0-Beta.4+16A5211f", "symlinks": ["16.0"], "install_runtimes": "false", "sha256": "4270cd8021b2f7f512ce91bfc4423b25bccab36cdab21834709d798c8daade72"},
-    { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"}
+    { "link": "16_beta_4", "version": "16.0.0-Beta.4+16A5211f", "symlinks": ["16.0"], "install_runtimes": "none", "sha256": "4270cd8021b2f7f512ce91bfc4423b25bccab36cdab21834709d798c8daade72"},
+    { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "default", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"}
+]
+```
+
+Block format:
+
+```json
+"versions": [
+    {
+        "link": "16.2",
+        "version": "16.2+16C5032a",
+        "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
+        "install_runtimes": [
+          { "iOS": ["18.0", "18.1", "18.2"] },
+          { "watchOS": "default" },
+          { "tvOS": "default" },
+          { "visionOS": "2.2" }
+        ]
+    },
+    {
+        "link": "16.1",
+        "version": "16.1+16B40",
+        "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
+        "install_runtimes": "default"
+    }
 ]
 ```
 

--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,22 +3,22 @@
         "default": "15.2",
         "x64": {
             "versions": [
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "true", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "true", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
-                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "true", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
-                { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "true", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
-                { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "true", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
+                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
+                { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
+                { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
                 ]
         },
         "arm64":{
             "versions": [
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "true", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "true", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
-                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "true", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
-                { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "true", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
-                { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "true", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
+                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
+                { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
+                { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
             ]
         }
     },

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -3,24 +3,105 @@
         "default": "15.4",
         "x64": {
             "versions": [
-                { "link": "16.2", "version": "16.2+16C5032a", "install_runtimes": ["iOS -buildVersion 18.2", "watchOS", "tvOS"], "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de"},
-                { "link": "16.1", "version": "16.1+16B40", "install_runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
-                { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
-                { "link": "15.3", "version": "15.3.0+15E204a", "install_runtimes": "true", "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234"},
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "true", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "true", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"}
+                {
+                    "link": "16.2",
+                    "version": "16.2+16C5032a",
+                    "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
+                    "install_runtimes": [
+                        { "iOS": "18.2" },
+                        { "watchOS": "default" },
+                        { "tvOS": "default" }
+                    ]
+                },
+                {
+                    "link": "16.1",
+                    "version": "16.1+16B40",
+                    "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.4",
+                    "version": "15.4.0+15F31d",
+                    "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.3",
+                    "version": "15.3.0+15E204a",
+                    "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.2",
+                    "version": "15.2.0+15C500b",
+                    "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.1",
+                    "version": "15.1.0+15C65",
+                    "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.0.1",
+                    "version": "15.0.1+15A507",
+                    "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8",
+                    "symlinks": ["15.0"],
+                    "install_runtimes": "default"
+                }
             ]
         },
         "arm64":{
             "versions": [
-                { "link": "16.2", "version": "16.2+16C5032a", "install_runtimes": ["iOS -buildVersion 18.2", "watchOS", "tvOS"], "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de"},
-                { "link": "16.1", "version": "16.1+16B40", "install_runtimes": ["iOS", "watchOS", "tvOS"], "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
-                { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"},
-                { "link": "15.3", "version": "15.3.0+15E204a", "install_runtimes": "true", "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234"},
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "true", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "true", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "true", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"}
+                {
+                    "link": "16.2",
+                    "version": "16.2+16C5032a",
+                    "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
+                    "install_runtimes": [
+                        { "iOS": "18.2" },
+                        { "watchOS": "default" },
+                        { "tvOS": "default" },
+                        { "visionOS": "2.2" }
+                    ]
+                },
+                {
+                    "link": "16.1",
+                    "version": "16.1+16B40",
+                    "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.4",
+                    "version": "15.4.0+15F31d",
+                    "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.3",
+                    "version": "15.3.0+15E204a",
+                    "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.2",
+                    "version": "15.2.0+15C500b",
+                    "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.1",
+                    "version": "15.1.0+15C65",
+                    "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05",
+                    "install_runtimes": "default"
+                },
+                {
+                    "link": "15.0.1",
+                    "version": "15.0.1+15A507",
+                    "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8",
+                    "symlinks": ["15.0"],
+                    "install_runtimes": "default"
+                }
             ]
         }
     },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,40 +4,82 @@
         "x64": {
             "versions": [
                 {
-                "link": "16.3_beta_3", "version": "16.3.0-Beta.3+16E5129f", "symlinks": ["16.3"],  
-                    "install_runtimes":
-                    [
-                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5232a",
-                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5244a",
-                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5250a"
-                    ],
-                    "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
+                    "link": "16.3_beta_3", 
+                    "version": "16.3.0-Beta.3+16E5129f", 
+                    "symlinks": ["16.3"],
+                    "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348",
+                    "install_runtimes": [
+                        { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "22E5232a"] },
+                        { "watchOS": ["11.0", "11.1", "11.2", "22T5244a"] },
+                        { "tvOS": ["18.0", "18.1", "18.2", "22L5250a"] }
+                    ]
                 },
-                { "link": "16.2", "version": "16.2+16C5032a", "install_runtimes": "false", "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de"},
-                { "link": "16.1", "version": "16.1+16B40", "install_runtimes": "false", "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
-                { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "install_runtimes": "false", "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"},
-                { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"}
+                {
+                    "link": "16.2",
+                    "version": "16.2+16C5032a",
+                    "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
+                    "install_runtimes": "none"
+                },
+                {
+                    "link": "16.1",
+                    "version": "16.1+16B40",
+                    "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
+                    "install_runtimes": "none"
+                },
+                {
+                    "link": "16",
+                    "version": "16.0.0+16A242d",
+                    "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3",
+                    "symlinks": ["16.0"],
+                    "install_runtimes": "none"
+                },
+                {
+                    "link": "15.4",
+                    "version": "15.4.0+15F31d",
+                    "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
+                    "install_runtimes": "default"
+                }
             ]
         },
         "arm64":{
             "versions": [
                 {
-                    "link": "16.3_beta_3",
-                    "version": "16.3.0-Beta.3+16E5129f",
-                    "symlinks": ["16.3"], 
-                    "install_runtimes":
-                    [
-                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5232a",
-                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5244a",
-                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5250a",
-                        "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5215f"
-                    ],
-                    "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
+                    "link": "16.3_beta_3", 
+                    "version": "16.3.0-Beta.3+16E5129f", 
+                    "symlinks": ["16.3"],
+                    "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348",
+                    "install_runtimes": [
+                        { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "22E5232a"] },
+                        { "watchOS": ["11.0", "11.1", "11.2", "22T5244a"] },
+                        { "tvOS": ["18.0", "18.1", "18.2", "22L5250a"] },
+                        { "visionOS": ["2.0", "2.1", "2.2", "2.3", "22O5215f"] }
+                    ]
                 },
-                { "link": "16.2", "version": "16.2+16C5032a", "install_runtimes": "false", "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de"},
-                { "link": "16.1", "version": "16.1+16B40", "install_runtimes": "false", "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
-                { "link": "16", "version": "16.0.0+16A242d", "symlinks": ["16.0"], "install_runtimes": "false", "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3"},
-                { "link": "15.4", "version": "15.4.0+15F31d", "install_runtimes": "true", "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a"}
+                {
+                    "link": "16.2",
+                    "version": "16.2+16C5032a",
+                    "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
+                    "install_runtimes": "none"
+                },
+                {
+                    "link": "16.1",
+                    "version": "16.1+16B40",
+                    "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
+                    "install_runtimes": "none"
+                },
+                {
+                    "link": "16",
+                    "version": "16.0.0+16A242d",
+                    "sha256": "4a26c3d102a55c7222fb145e0ee1503249c9c26c6e02dc64d783c8810b37b1e3",
+                    "symlinks": ["16.0"],
+                    "install_runtimes": "none"
+                },
+                {
+                    "link": "15.4",
+                    "version": "15.4.0+15F31d",
+                    "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
+                    "install_runtimes": "default"
+                }
             ]
         }
     },    


### PR DESCRIPTION
# Description

Modification of the Xcode runtime installer function. Added the ability to install multiple versions for one platform, improved the mechanism for working with the toolset, added validation of options. Additionally, the formatting of the toolset section has been updated to be more readable, and the documentation has been updated accordingly. The set of runtimes remains unchanged.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
