### PR TITLE
[macOS] Update Runner installer script to use API PAT

### DIFF
--- a/images/macos/scripts/build/install-runner-package.sh
+++ b/images/macos/scripts/build/install-runner-package.sh
@@ -9,7 +9,7 @@ source ~/utils/utils.sh
 
 AGENT_PATH="/opt/runner-cache"
 arch=$(get_arch)
-download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-osx-'"$arch"'-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest")
+download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-osx-'"$arch"'-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest" "$API_PAT")
 archive_name="${download_url##*/}"
 archive_path=$(download_with_retry "$download_url")
 


### PR DESCRIPTION
# Description

Without using PAT, the method quickly exhausts access attempts due to unauthorised access limits.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
