### PR TITLE
[Windows] Add WSL2 to Windows-2022 image

### DIFF
--- a/images/windows/scripts/build/Configure-System.ps1
+++ b/images/windows/scripts/build/Configure-System.ps1
@@ -93,11 +93,11 @@ $servicesToDisable = @(
     'wuauserv'
     'DiagTrack'
     'dmwappushservice'
-    $(if(-not (Test-IsWin25)){'PcaSvc'})
+    $(if(-not (Test-IsWin22 -or Test-IsWin25)){'PcaSvc'})
     'SysMain'
     'gupdate'
     'gupdatem'
-    $(if(-not (Test-IsWin25)){'StorSvc'})
+    $(if(-not (Test-IsWin22 -or Test-IsWin25)){'StorSvc'})
 ) | Get-Service -ErrorAction SilentlyContinue
 Stop-Service $servicesToDisable
 $servicesToDisable.WaitForStatus('Stopped', "00:01:00")

--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -21,7 +21,7 @@ Import-Module (Join-Path $PSScriptRoot "SoftwareReport.VisualStudio.psm1") -Disa
 $softwareReport = [SoftwareReport]::new($(Build-OSInfoSection))
 $optionalFeatures = $softwareReport.Root.AddHeader("Windows features")
 $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (WSLv1):", "Enabled")
-if (Test-IsWin25) {
+if (Test-IsWin22 -or Test-IsWin25) {
     $optionalFeatures.AddToolVersion("Windows Subsystem for Linux (Default, WSLv2):", $(Get-WSL2Version))
 }
 $installedSoftware = $softwareReport.Root.AddHeader("Installed Software")

--- a/images/windows/templates/windows-2022.pkr.hcl
+++ b/images/windows/templates/windows-2022.pkr.hcl
@@ -247,6 +247,7 @@ build {
       "${path.root}/../scripts/build/Configure-WindowsDefender.ps1",
       "${path.root}/../scripts/build/Configure-PowerShell.ps1",
       "${path.root}/../scripts/build/Install-PowerShellModules.ps1",
+      "${path.root}/../scripts/build/Install-WSL2.ps1",
       "${path.root}/../scripts/build/Install-WindowsFeatures.ps1",
       "${path.root}/../scripts/build/Install-Chocolatey.ps1",
       "${path.root}/../scripts/build/Configure-BaseImage.ps1",


### PR DESCRIPTION
# Description

Windows 2025 runners already have WSL2 installed. This PR just updates the conditions to include it on Windows 2022 runners as well.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/actions/runner-images/issues/10563#issuecomment-2612617374

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
