### PR TITLE
Updated SBT version regex to support >= 1.10.11

### DIFF
--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -207,7 +207,7 @@ function Get-MavenVersion {
 
 function Get-SbtVersion {
     $result = Get-CommandResult "sbt -version"
-    $result.Output -match "sbt script version: (?<version>\d+\.\d+\.\d+)" | Out-Null
+    $result.Output -match "sbt (script|runner) version: (?<version>\d+\.\d+\.\d+)" | Out-Null
     return $Matches.version
 }
 

--- a/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -166,7 +166,7 @@ function Get-GradleVersion {
 }
 
 function Get-SbtVersion {
-    (sbt -version) -match "sbt script" | Get-StringPart -Part 3
+    (sbt -version) -match "sbt (script|runner)" | Get-StringPart -Part 3
 }
 
 function Get-DotnetSdks {


### PR DESCRIPTION
# Description

In version 1.10.11 the output of `sbt --version` was changed. It now outputs `sbt runner version: ...` instead of `sbt script version: ...`

See commit [89ff244](
https://github.com/sbt/sbt/pull/8066/commits/89ff2440ef1f90e4de8bd2511ba4138d8a080d84#diff-926bf07a92dd3aab0f5ad7b0af3238aa451bd7ea244aa1e5b32aa8b1077b6e27R678-R685)

![image](https://github.com/user-attachments/assets/e4c83c53-c97e-421e-8d45-3e41ce374424)

#### Related issue: 

#11813 

## Check list
- [x] Related issue / work item is attached
- [x] ~Tests are written (if applicable)~
- [x] ~Documentation is updated (if applicable)~
- [x] Changes are tested and related VM images are successfully generated 
   *Verified that the 22.04 image builds again*
