### PR TITLE
[Ubuntu] Updating SBT version regex pattern.

### DIFF
--- a/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/ubuntu/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -207,7 +207,7 @@ function Get-MavenVersion {
 
 function Get-SbtVersion {
     $result = Get-CommandResult "sbt -version"
-    $result.Output -match "sbt script version: (?<version>\d+\.\d+\.\d+)" | Out-Null
+    $result.Output -match "sbt runner version: (?<version>\d+\.\d+\.\d+)" | Out-Null
     return $Matches.version
 }
 


### PR DESCRIPTION
# Description
The output of the sbt --version command has been updated to display the `sbt runner version` instead of the `sbt script version`, which will resolve the issue.

#### Related issue:
https://github.com/actions/runner-images/issues/11813
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
