### PR TITLE
[macOS] Updated xcode to 16.3 beta 3  for macOS15 macOS15arm

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -7,9 +7,9 @@
                 "link": "16.3_beta_3", "version": "16.3.0-Beta.3+16E5129f", "symlinks": ["16.3"],  
                     "install_runtimes":
                     [
-                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5216h",
-                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5212l",
-                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5218l"
+                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5231a",
+                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5243a",
+                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5249a"
                     ],
                     "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
                 },
@@ -27,10 +27,10 @@
                     "symlinks": ["16.3"], 
                     "install_runtimes":
                     [
-                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5216h",
-                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5212l",
-                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5218l",
-                        "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5215f"
+                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5231a",
+                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5243a",
+                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5249a",
+                        "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5230a"
                     ],
                     "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
                 },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -7,9 +7,9 @@
                 "link": "16.3_beta_3", "version": "16.3.0-Beta.3+16E5129f", "symlinks": ["16.3"],  
                     "install_runtimes":
                     [
-                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5231a",
-                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5243a",
-                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5249a"
+                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5232a",
+                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5244a",
+                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5250a"
                     ],
                     "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
                 },
@@ -27,10 +27,10 @@
                     "symlinks": ["16.3"], 
                     "install_runtimes":
                     [
-                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5231a",
-                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5243a",
-                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5249a",
-                        "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5230a"
+                        "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5232a",
+                        "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5244a",
+                        "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5250a",
+                        "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5231a"
                     ],
                     "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
                 },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -30,7 +30,7 @@
                         "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5232a",
                         "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5244a",
                         "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5250a",
-                        "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5231a"
+                        "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5215f"
                     ],
                     "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
                 },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,14 +4,14 @@
         "x64": {
             "versions": [
                 {
-                "link": "16.3_beta_2", "version": "16.3.0-Beta.2+16E5121h", "symlinks": ["16.3"], 
+                "link": "16.3_beta_3", "version": "16.3.0-Beta.3+16E5129f", "symlinks": ["16.3"],  
                     "install_runtimes":
                     [
                         "iOS -buildVersion 18.0", "iOS -buildVersion 18.1", "iOS -buildVersion 18.2", "iOS -buildVersion 18.3.1", "iOS -buildVersion 22E5216h",
                         "watchOS -buildVersion 11.0", "watchOS -buildVersion 11.1", "watchOS -buildVersion 11.2", "watchOS -buildVersion 22T5212l",
                         "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5218l"
                     ],
-                    "sha256": "f4bb80c2e93d3561ecbabc82d1a92c830d831c96afc48944baa8116e3fd0013d"
+                    "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
                 },
                 { "link": "16.2", "version": "16.2+16C5032a", "install_runtimes": "false", "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de"},
                 { "link": "16.1", "version": "16.1+16B40", "install_runtimes": "false", "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},
@@ -22,8 +22,8 @@
         "arm64":{
             "versions": [
                 {
-                    "link": "16.3_beta_2",
-                    "version": "16.3.0-Beta.2+16E5121h",
+                    "link": "16.3_beta_3",
+                    "version": "16.3.0-Beta.3+16E5129f",
                     "symlinks": ["16.3"], 
                     "install_runtimes":
                     [
@@ -32,7 +32,7 @@
                         "tvOS -buildVersion 18.0", "tvOS -buildVersion 18.1", "tvOS -buildVersion 18.2", "tvOS -buildVersion 22L5218l",
                         "visionOS -buildVersion 2.0", "visionOS -buildVersion 2.1",  "visionOS -buildVersion 2.2", "visionOS -buildVersion 2.3", "visionOS -buildVersion 22O5215f"
                     ],
-                    "sha256": "f4bb80c2e93d3561ecbabc82d1a92c830d831c96afc48944baa8116e3fd0013d"
+                    "sha256": "5f709f7b418005c7c735d6f62076feb8fd9095f874f3d7c2d58a039ce9531348"
                 },
                 { "link": "16.2", "version": "16.2+16C5032a", "install_runtimes": "false", "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de"},
                 { "link": "16.1", "version": "16.1+16B40", "install_runtimes": "false", "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720"},


### PR DESCRIPTION
# Description
Updated xcode to 16.3 beta 3  for macOS15 and  macOS15arm
<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
