### PR TITLE
[Ubuntu] Pinning Kotlin previous version 2.1.10

### DIFF
--- a/images/ubuntu/scripts/build/install-kotlin.sh
+++ b/images/ubuntu/scripts/build/install-kotlin.sh
@@ -9,7 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 KOTLIN_ROOT="/usr/share"
-download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"kotlin-compiler\") and endswith(\".zip\")" "latest")
+download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"kotlin-compiler\") and endswith(\".zip\")" "2.1.10")
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - Kotlin


### PR DESCRIPTION
# Description
This PR will resolve the Kotlin test failure on v2.1.20 by pinning the previous version 2.1.10.
#### Related issue:
https://github.com/actions/runner-images/issues/11844
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
