### PR TITLE
[macOS] Remove deprecated bundle tap

### DIFF
--- a/images/macos/scripts/build/install-homebrew.sh
+++ b/images/macos/scripts/build/install-homebrew.sh
@@ -38,6 +38,3 @@ brew_smart_install curl
 
 echo "Installing wget..."
 brew_smart_install "wget"
-
-# init brew bundle feature
-brew tap Homebrew/bundle


### PR DESCRIPTION
# Description

Tap for bundle was deprecated

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
