### PR TITLE
[macOS] Deprecate brew/bundle tap, pin Kotlin to 2.1.10

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -25,13 +25,11 @@ for package in $common_packages; do
             ;;
 
         tcl-tk@8)
+            brew_smart_install "$package"
             if is_VenturaX64 || is_SonomaX64; then
-                brew_smart_install "$package"
                 # Fix for https://github.com/actions/runner-images/issues/11074
                 ln -sf "$(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib" /usr/local/lib/libtcl8.6.dylib
                 ln -sf "$(brew --prefix tcl-tk@8)/lib/libtk8.6.dylib" /usr/local/lib/libtk8.6.dylib
-            else
-                brew_smart_install "$package"
             fi
             ;;
 

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -9,19 +9,37 @@ source ~/utils/utils.sh
 common_packages=$(get_toolset_value '.brew.common_packages[]')
 for package in $common_packages; do
     echo "Installing $package..."
-    if [[ $package == "packer" ]]; then
-        # Packer has been deprecated in Homebrew. Use tap to install Packer.
-        brew install hashicorp/tap/packer
-    else
-        if (is_VenturaX64 || is_SonomaX64) && [[ $package == "tcl-tk@8" ]]; then
+    case "$package" in
+        packer)
+            # Packer has been deprecated in Homebrew. Use tap to install Packer.
+            brew install hashicorp/tap/packer
+            ;;
+
+        kotlin)
+            # Pin kotlin bottle to 2.1.10 due to an issue with the latest version
+            # https://youtrack.jetbrains.com/issue/KT-76169/kotlinc-js-version-and-kapt-version-returning-non-zero-status-code-on-v2.1.20
+            kotlin_commit="442af88a2925f8c0e079eaf4fa62261133d2d7c4"
+            kotlin_rb_link="https://raw.githubusercontent.com/Homebrew/homebrew-core/$kotlin_commit/Formula/k/kotlin.rb"
+            kotlin_rb_path=$(download_with_retry "$kotlin_rb_link")
+            brew install "$kotlin_rb_path"
+            ;;
+
+        tcl-tk@8)
+            if is_VenturaX64 || is_SonomaX64; then
+                brew_smart_install "$package"
+                # Fix for https://github.com/actions/runner-images/issues/11074
+                ln -sf "$(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib" /usr/local/lib/libtcl8.6.dylib
+                ln -sf "$(brew --prefix tcl-tk@8)/lib/libtk8.6.dylib" /usr/local/lib/libtk8.6.dylib
+            else
+                brew_smart_install "$package"
+            fi
+            ;;
+
+        # Default behaviour for all other packages
+        *)
             brew_smart_install "$package"
-            # Fix for https://github.com/actions/runner-images/issues/11074
-            ln -sf $(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib /usr/local/lib/libtcl8.6.dylib
-            ln -sf $(brew --prefix tcl-tk@8)/lib/libtk8.6.dylib /usr/local/lib/libtk8.6.dylib
-        else
-            brew_smart_install "$package"
-        fi
-    fi
+            ;;
+    esac
 done
 
 cask_packages=$(get_toolset_value '.brew.cask_packages[]')

--- a/images/macos/scripts/build/install-homebrew.sh
+++ b/images/macos/scripts/build/install-homebrew.sh
@@ -38,6 +38,3 @@ brew_smart_install curl
 
 echo "Installing wget..."
 brew_smart_install "wget"
-
-# init brew bundle feature
-brew tap Homebrew/bundle


### PR DESCRIPTION
# Description

- Homebrew team deprecated bundle tap - deprecate it as available via `brew bundle` by default
- Kotlin 2.1.20 release blocks our tests - temporary pin previous release; issue [link](https://youtrack.jetbrains.com/issue/KT-76169/kotlinc-js-version-and-kapt-version-returning-non-zero-status-code-on-v2.1.20)
- Modify `install-common-utils.sh` to work with `case` instead of `if` blocks 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
