### PR TITLE
fix:Pin kotlin version to 2.1.10

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -452,7 +452,7 @@
         "installVcRedist": true
     },
     "kotlin": {
-        "version": "latest"
+        "version": "2.1.10"
     },
     "openssl": {
         "version": "1.1.1",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -373,7 +373,7 @@
         "installVcRedist": true
     },
     "kotlin": {
-        "version": "latest"
+        "version": "2.1.10"
     },
     "openssl": {
         "version": "1.1.1",

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -327,7 +327,7 @@
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
     },
     "kotlin": {
-        "version": "latest"
+        "version": "2.1.10"
     },
     "openssl": {
         "version": "3.4.1",


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement? 
Bug Fix
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
As Kotlin version  `2.1.20` has an issue which is causing the Image generation of the runner images (Win) to fail.
This PR pins the kotlin version to `2.1.10` which was the latest working version.
An [issue is raised ](https://youtrack.jetbrains.com/issues/KT?preview=KT-76169) with Jetbrains about this issue.
Will again unpin the version once the issue is resolved.

This resolves #11844 



#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
