### PR TITLE
[Windows] Change file encoding to utf8 with no BOM

### DIFF
--- a/images/windows/scripts/build/Configure-ImageDataFile.ps1
+++ b/images/windows/scripts/build/Configure-ImageDataFile.ps1
@@ -44,4 +44,6 @@ $json = @"
 ]
 "@
 
-$json | Out-File -FilePath $imageDataFile
+
+$Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+[System.IO.File]::WriteAllLines($imageDataFile, @($json), $Utf8NoBomEncoding)

--- a/images/windows/scripts/build/Configure-ImageDataFile.ps1
+++ b/images/windows/scripts/build/Configure-ImageDataFile.ps1
@@ -44,6 +44,5 @@ $json = @"
 ]
 "@
 
-
 $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
-[System.IO.File]::WriteAllLines($imageDataFile, @($json), $Utf8NoBomEncoding)
+[System.IO.File]::WriteAllText($imageDataFile, $json, $Utf8NoBomEncoding)


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

This PR is to change the encoding of ImageDatafile to use UTF-8 without BOM.
Some system is facing issues in reading the content of this file.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
