### PR TITLE
[Windows] Pin sbt version to 1.10.10

### DIFF
--- a/images/windows/scripts/build/Install-Sbt.ps1
+++ b/images/windows/scripts/build/Install-Sbt.ps1
@@ -5,7 +5,9 @@
 
 # Install the latest version of sbt.
 # See https://chocolatey.org/packages/sbt
-Install-ChocoPackage sbt
+# The version is pinned due to issue with sbt latest version
+# See https://github.com/sbt/sbt/issues/8077
+Install-ChocoPackage sbt -ArgumentList "--version", "1.10.10
 
 $env:SBT_HOME="${env:ProgramFiles(x86)}\sbt"
 

--- a/images/windows/scripts/build/Install-Sbt.ps1
+++ b/images/windows/scripts/build/Install-Sbt.ps1
@@ -7,7 +7,7 @@
 # See https://chocolatey.org/packages/sbt
 # The version is pinned due to issue with sbt latest version
 # See https://github.com/sbt/sbt/issues/8077
-Install-ChocoPackage sbt -ArgumentList "--version", "1.10.10
+Install-ChocoPackage sbt -ArgumentList "--version", "1.10.10"
 
 $env:SBT_HOME="${env:ProgramFiles(x86)}\sbt"
 


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
Pinning the version of SBT to 1.10.10 to ensure that the build process is generates correct version.
Will remove the pin version when [this issue](https://github.com/sbt/sbt/issues/8077) is resolved

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
