### PR TITLE
[Windows] Fix SBT version issue and Pinning Kotlin version

### DIFF
--- a/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -166,15 +166,7 @@ function Get-GradleVersion {
 }
 
 function Get-SbtVersion {
-    try {
-        $version = sbt --script-version
-        if ($version) {
-            return $version
-        }
-        Write-Host "Failed to retrieve SBT version." -ForegroundColor Red
-    } catch {
-        Write-Host "Error: SBT command not found or the version flag may be deprecated." -ForegroundColor Red
-    }
+    sbt --script-version
 }
 
 function Get-DotnetSdks {

--- a/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -166,7 +166,15 @@ function Get-GradleVersion {
 }
 
 function Get-SbtVersion {
-    (sbt -version) -match "sbt runner" | Get-StringPart -Part 3
+    try {
+        $version = sbt --script-version
+        if ($version) {
+            return $version
+        }
+        Write-Host "Failed to retrieve SBT version." -ForegroundColor Red
+    } catch {
+        Write-Host "Error: SBT command not found or the version flag may be deprecated." -ForegroundColor Red
+    }
 }
 
 function Get-DotnetSdks {

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -452,7 +452,12 @@
         "installVcRedist": true
     },
     "kotlin": {
-        "version": "latest"
+        "version": "2.1.10",
+        "pinnedDetails": {
+            "link": "https://youtrack.jetbrains.com/issues/KT?preview=KT-76169",
+            "reason": "this was pinned due to a new version 2.1.20 released has an issue with kotlinc-js -version` and kapt -version",
+            "review-at": "2025-03-31"
+        }
     },
     "openssl": {
         "version": "1.1.1",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -373,7 +373,12 @@
         "installVcRedist": true
     },
     "kotlin": {
-        "version": "latest"
+        "version": "2.1.10",
+        "pinnedDetails": {
+            "link": "https://youtrack.jetbrains.com/issues/KT?preview=KT-76169",
+            "reason": "this was pinned due to a new version 2.1.20 released has an issue with kotlinc-js -version` and kapt -version",
+            "review-at": "2025-03-31"
+        }
     },
     "openssl": {
         "version": "1.1.1",

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -327,7 +327,12 @@
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
     },
     "kotlin": {
-        "version": "latest"
+        "version": "2.1.10",
+        "pinnedDetails": {
+            "link": "https://youtrack.jetbrains.com/issues/KT?preview=KT-76169",
+            "reason": "this was pinned due to a new version 2.1.20 released has an issue with kotlinc-js -version` and kapt -version",
+            "review-at": "2025-03-31"
+        }
     },
     "openssl": {
         "version": "3.4.1",


### PR DESCRIPTION
# Description
This PR will resolve SBT version mismatch issue and Kotlin test failure on v2.1.20 by pinning the previous version 2.1.10 in the Windows image

#### Related issue:
https://github.com/actions/runner-images/issues/11844

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
