### PR TITLE
[macOS] Disable rarely used services, use optimised configs

### DIFF
--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -6,8 +6,32 @@
 
 source ~/utils/utils.sh
 
+# Set solid color wallpaper
+osascript -e 'tell application "Finder" to set desktop picture to POSIX file "/System/Library/Desktop Pictures/Solid Colors/Black.png"'
+
 # Close all finder windows because they can interfere with UI tests
 close_finder_window
+
+# Disable Handoff and Continuity
+defaults write com.apple.coreservices.useractivityd ActivityReceivingEnabled -bool false
+defaults write com.apple.coreservices.useractivityd ActivityAdvertisingAllowed -bool false
+
+# Disable graphic effects in System
+defaults write com.apple.universalaccess reduceMotion -bool true
+defaults write com.apple.universalaccess reduceTransparency -bool true
+
+# Disable analytics daemon (requires SIP to be disabled)
+sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.SubmitDiagInfo.plist
+
+# Disable notification center agent
+launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist
+
+# Disable Time Machine and it's daemon
+sudo tmutil disable
+sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.backupd.plist
+
+# Disable Apple Push Notification Service daemon
+sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.apsd.plist
 
 # Remove Parallels Desktop
 # https://github.com/actions/runner-images/issues/6105
@@ -32,11 +56,18 @@ yarn cache clean
 # Clean up temporary directories
 sudo rm -rf ~/utils /tmp/*
 
-# Erase all indexes and wait until the rebuilding process ends,
-# for now there is no way to get status of indexing process, it takes around 3 minutes to accomplish
-sudo mdutil -E /
-sudo log stream | grep -q -E 'mds.*Released.*BackgroundTask' || true
-echo "Indexing completed"
+if is_Ventura; then
+    # Erase all indexes and wait until the rebuilding process ends,
+    # for now there is no way to get status of indexing process, it takes around 3 minutes to accomplish
+    sudo mdutil -E /
+    sudo log stream | grep -q -E 'mds.*Released.*BackgroundTask' || true
+    echo "Indexing completed"
+else
+    # Disable spotlight and MDS
+    sudo mdutil -a -i off
+    sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
+    sudo mdutil -a -s | grep "Indexing enabled." && echo "Indexing is still enabled" && exit 1 || true
+fi
 
 # delete symlink for tests running
 sudo rm -f /usr/local/bin/invoke_tests

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -284,6 +284,9 @@ build {
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    scripts         = ["${path.root}/../scripts/build/configure-hostname.sh"]
+    scripts         = [
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
+    ]
   }
 }

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -283,6 +283,9 @@ build {
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    scripts         = ["${path.root}/../scripts/build/configure-hostname.sh"]
+    scripts         = [
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
+    ]
   }
 }

--- a/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
@@ -282,6 +282,9 @@ build {
 
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
-    scripts         = ["${path.root}/../scripts/build/configure-hostname.sh"]
+    scripts         = [
+      "${path.root}/../scripts/build/configure-hostname.sh",
+      "${path.root}/../scripts/build/configure-system.sh"
+    ]
   }
 }


### PR DESCRIPTION
# Description

- Set solid color wallpaper
- Disable Handoff and Continuity
- Disable some graphic effects in System
- Disable analytics daemon
- Disable notification center agent
- Disable Time Machine and it's daemon
- Disable Apple Push Notification Service daemon
- Disable MDS and Spotlight (macOS-14 and higher)

Apply script to arm64 based machines.

#### Related issue:
- [#6865](https://github.com/actions/runner-images-internal/issues/6865)
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
