### PR TITLE
[macOS] Remove `sudo` from simulators installer script

### DIFF
--- a/images/macos/scripts/helpers/Xcode.Installer.psm1
+++ b/images/macos/scripts/helpers/Xcode.Installer.psm1
@@ -192,7 +192,7 @@ function Install-AdditionalSimulatorRuntimes {
     # Install all runtimes / skip runtimes
     if ($Runtimes -eq "default") {
         Write-Host "Installing all runtimes for Xcode $Version ..."
-        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadAllPlatforms" | Out-Null
+        Invoke-ValidateCommand "$xcodebuildPath -downloadAllPlatforms" | Out-Null
         return
     } elseif ($Runtimes -eq "none") {
         Write-Host "Skipping runtimes installation for Xcode $Version ..."
@@ -239,14 +239,14 @@ function Install-AdditionalSimulatorRuntimes {
                 }
                 "default" {
                     Write-Host "Installing default $platform runtime for Xcode $Version ..."
-                    Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $platform" | Out-Null
+                    Invoke-ValidateCommand "$xcodebuildPath -downloadPlatform $platform" | Out-Null
                     continue
                 }
                 default {
                     # Version might be a semver or a build number
                     if (($platformVersion -match "^\d{1,2}\.\d(\.\d)?$") -or ($platformVersion -match "^[a-zA-Z0-9]{6,8}$")) {
                         Write-Host "Installing $platform $platformVersion runtime for Xcode $Version ..."
-                        Invoke-ValidateCommand "sudo $xcodebuildPath -downloadPlatform $platform -buildVersion $platformVersion" | Out-Null
+                        Invoke-ValidateCommand "$xcodebuildPath -downloadPlatform $platform -buildVersion $platformVersion" | Out-Null
                         continue
                     }
                     throw "$platformVersion is not a valid value for $platform version. Valid values are 'latest' or 'skip' or a semver from 0.0 to 99.9.(9)."


### PR DESCRIPTION
# Description

We don't really need sudo there. It might have negative impact.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
