### PR TITLE
Update PostgreSQL version to 17 in Ubuntu 22.04 and 24.04 images

### DIFF
--- a/images/ubuntu/Ubuntu2204-Readme.md
+++ b/images/ubuntu/Ubuntu2204-Readme.md
@@ -187,7 +187,7 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 - sqlite3 3.37.2
 
 #### PostgreSQL
-- PostgreSQL 14.17
+- PostgreSQL 17
 ```
 User: postgres
 PostgreSQL service is disabled by default.
@@ -390,4 +390,3 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | xz-utils               | 5.2.5-2ubuntu1                      |
 | zip                    | 3.0-12build2                        |
 | zsync                  | 0.6.2-3ubuntu1                      |
-

--- a/images/ubuntu/Ubuntu2404-Readme.md
+++ b/images/ubuntu/Ubuntu2404-Readme.md
@@ -167,7 +167,7 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 - sqlite3 3.45.1
 
 #### PostgreSQL
-- PostgreSQL 16.8
+- PostgreSQL 17
 ```
 User: postgres
 PostgreSQL service is disabled by default.
@@ -323,4 +323,3 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | xz-utils               | 5.6.1+really5.4.5-1build0.1 |
 | zip                    | 3.0-13ubuntu0.2             |
 | zsync                  | 0.6.2-5build1               |
-

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -371,7 +371,7 @@
         "version": "5.0"
     },
     "postgresql": {
-        "version": "14"
+        "version": "17"
     },
     "pwsh": {
         "version": "7.4"

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -318,7 +318,7 @@
         "version": "7.0"
     },
     "postgresql": {
-        "version": "16"
+        "version": "17"
     },
     "pwsh": {
         "version": "7.4"


### PR DESCRIPTION
Fixes #11723

Update PostgreSQL version to 17 in Ubuntu 22.04 and 24.04 images.

* **Update toolset files:**
  - Change PostgreSQL version to 17 in `images/ubuntu/toolsets/toolset-2204.json`.
  - Change PostgreSQL version to 17 in `images/ubuntu/toolsets/toolset-2404.json`.

* **Update README files:**
  - Change PostgreSQL version to 17 in the "Databases" section of `images/ubuntu/Ubuntu2204-Readme.md`.
  - Change PostgreSQL version to 17 in the "Databases" section of `images/ubuntu/Ubuntu2404-Readme.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actions/runner-images/pull/11883?shareId=70dccf1a-b56f-4ee2-8a72-21d33f5f0b8a).