### PR TITLE
[Ubuntu] Removing mongo db from  toolset in Ubuntu 22.04 and 24.04

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -367,10 +367,7 @@
             "command": "yarn"
         }
     ],
-    "mongodb": {
-        "version": "5.0"
-    },
-    "postgresql": {
+     "postgresql": {
         "version": "14"
     },
     "pwsh": {

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -314,9 +314,6 @@
             "command": "yarn"
         }
     ],
-    "mongodb": {
-        "version": "7.0"
-    },
     "postgresql": {
         "version": "16"
     },


### PR DESCRIPTION
This PR removes the MongoDB from the toolset in Ubuntu 22.04 and 24.04.
`Mongo Db` is not part of Ubuntu 22.04 and 24.04

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
