### PR TITLE
[macOS] Updated xcode to 16.3 Release Candidate 2 to macOS15 images.

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,10 +4,11 @@
         "x64": {
             "versions": [
                 {
-                    "link": "16.3_Release_Candidate", 
+                    "link": "16.3_Release_Candidate_2", 
                     "version": "16.3_Release_Candidate+16E137", 
+                    "version": "16.3.0-Release.Candidate.2+16E140",
                     "symlinks": ["16.3"],
-                    "sha256": "d23af7e6fc2f79b8b88483ddf0b469294d675beb035bcde97c44e156b5bfb350",
+                    "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [
                         { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "18.4"] },
                         { "watchOS": ["11.0", "11.1", "11.2", "11.4"] },
@@ -44,10 +45,10 @@
         "arm64":{
             "versions": [
                 {
-                    "link": "16.3_Release_Candidate", 
-                    "version": "16.3_Release_Candidate+16E137", 
+                    "link": "16.3_Release_Candidate_2", 
+                    "version": "16.3.0-Release.Candidate.2+16E140", 
                     "symlinks": ["16.3"],
-                    "sha256": "d23af7e6fc2f79b8b88483ddf0b469294d675beb035bcde97c44e156b5bfb350",
+                    "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [
                         { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "18.4"] },
                         { "watchOS": ["11.0", "11.1", "11.2", "11.4"] },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -5,7 +5,6 @@
             "versions": [
                 {
                     "link": "16.3_Release_Candidate_2", 
-                    "version": "16.3_Release_Candidate+16E137", 
                     "version": "16.3.0-Release.Candidate.2+16E140",
                     "symlinks": ["16.3"],
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",


### PR DESCRIPTION
# Description
Updated xcode to 16.3 Release Candidate 2 to macOS15 images.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
