### PR TITLE
Update Docker Engine to Version 28.*

### DIFF
--- a/images/ubuntu/scripts/tests/Docker.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Docker.Tests.ps1
@@ -1,0 +1,41 @@
+Describe "Docker" {
+    It "docker is installed" {
+        "docker --version" | Should -ReturnZeroExitCode
+    }
+
+    It "docker service is up" {
+        "docker images" | Should -ReturnZeroExitCode
+    }
+
+    It "docker symlink" {
+        "C:\Windows\SysWOW64\docker.exe ps" | Should -ReturnZeroExitCode
+    }
+
+    It "docker version 28.* is installed" {
+        $dockerVersion = (docker --version).Split(" ")[2]
+        $dockerVersion | Should -Match "^28\."
+    }
+}
+
+Describe "DockerCompose" {
+    It "docker compose v2" {
+        "docker compose version" | Should -ReturnZeroExitCode
+    }
+
+}
+
+Describe "DockerWinCred" {
+    It "docker-wincred" {
+        "docker-credential-wincred version" | Should -ReturnZeroExitCode
+    }
+}
+
+Describe "DockerImages" -Skip:(Test-IsWin25) {
+    Context "docker images" {
+        $testCases = (Get-ToolsetContent).docker.images | ForEach-Object { @{ ImageName = $_ } }
+
+        It "<ImageName>" -TestCases $testCases {
+            docker images "$ImageName" --format "{{.Repository}}" | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/images/ubuntu/toolsets/toolset-2004.json
+++ b/images/ubuntu/toolsets/toolset-2004.json
@@ -237,11 +237,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "26.1.3"
+                "version": "28.*"
             },
             {
                 "package": "docker-ce",
-                "version": "26.1.3"
+                "version": "28.*"
             }
         ],
         "plugins": [
@@ -252,7 +252,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.27.1",
+                "version": "2.28.0",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -236,11 +236,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "26.1.3"
+                "version": "28.*"
             },
             {
                 "package": "docker-ce",
-                "version": "26.1.3"
+                "version": "28.*"
             }
         ],
         "plugins": [
@@ -251,7 +251,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.27.1",
+                "version": "2.28.0",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -195,11 +195,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "26.1.3"
+                "version": "28.*"
             },
             {
                 "package": "docker-ce",
-                "version": "26.1.3"
+                "version": "28.*"
             }
         ],
         "plugins": [
@@ -210,7 +210,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.27.1",
+                "version": "2.28.0",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
Fixes #11766

Update Docker Engine to Version 28.* in Ubuntu OS images.

* **Update toolset files**
  - Update `images/ubuntu/toolsets/toolset-2004.json` to list Docker Engine Version 28.*, Docker CE CLI Version 28.*, and Docker Compose Version 2.28.0.
  - Update `images/ubuntu/toolsets/toolset-2204.json` to list Docker Engine Version 28.*, Docker CE CLI Version 28.*, and Docker Compose Version 2.28.0.
  - Update `images/ubuntu/toolsets/toolset-2404.json` to list Docker Engine Version 28.*, Docker CE CLI Version 28.*, and Docker Compose Version 2.28.0.

* **Add tests for Docker Engine Version 28.***
  - Add `images/ubuntu/scripts/tests/Docker.Tests.ps1` to include tests for Docker Engine Version 28.*.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actions/runner-images/pull/11897?shareId=cd4e038e-49c1-41be-91c4-7036907bb2e9).