### PR TITLE
[macOS] Update default CodeQL major version to v3

### DIFF
--- a/images/macos/scripts/build/install-codeql-bundle.sh
+++ b/images/macos/scripts/build/install-codeql-bundle.sh
@@ -7,7 +7,7 @@
 source ~/utils/utils.sh
 
 # Retrieve the CLI version of the latest CodeQL bundle.
-defaults_json_path=$(download_with_retry https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json)
+defaults_json_path=$(download_with_retry https://raw.githubusercontent.com/github/codeql-action/v3/src/defaults.json)
 bundle_version=$(jq -r '.cliVersion' $defaults_json_path)
 bundle_tag_name="codeql-bundle-v$bundle_version"
 


### PR DESCRIPTION
# Description

Bug fix — the default version of the CodeQL version was using the `https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json` file to retrieve the latest CLI version, but we have deprecated v2 of the CodeQL Action and the file no longer populates the latest CLI versions. This change updates to v3.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/actions/runner-images/issues/11891 and other similar customer issues.

## Check list
- [x] Related issue / work item is attached
- [N/A] Tests are written (if applicable)
- [N/A] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
