### PR TITLE
[Ubuntu] Update default CodeQL major version to v3

### DIFF
--- a/images/ubuntu/scripts/build/install-codeql-bundle.sh
+++ b/images/ubuntu/scripts/build/install-codeql-bundle.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Retrieve the CLI version of the latest CodeQL bundle.
-base_url="$(curl -fsSL https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json)"
+base_url="$(curl -fsSL https://raw.githubusercontent.com/github/codeql-action/v3/src/defaults.json)"
 bundle_version="$(echo "$base_url" | jq -r '.cliVersion')"
 bundle_tag_name="codeql-bundle-v$bundle_version"
 


### PR DESCRIPTION
# Description

Bug fix — the default version of the CodeQL version was using the `https://raw.githubusercontent.com/github/codeql-action/v2/src/defaults.json` file to retrieve the latest CLI version, but we have deprecated v2 of the CodeQL Action and the file no longer populates the latest CLI versions. This change updates to v3.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/actions/runner-images/issues/11891 and other similar customer issues.

## Check list
- [x] Related issue / work item is attached
- [N/A] Tests are written (if applicable)
- [N/A] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
