### PR TITLE
[macOS] Enable index for macOS-14 and macOS-15

### DIFF
--- a/images/macos/scripts/build/configure-system.sh
+++ b/images/macos/scripts/build/configure-system.sh
@@ -56,18 +56,11 @@ yarn cache clean
 # Clean up temporary directories
 sudo rm -rf ~/utils /tmp/*
 
-if is_Ventura; then
-    # Erase all indexes and wait until the rebuilding process ends,
-    # for now there is no way to get status of indexing process, it takes around 3 minutes to accomplish
-    sudo mdutil -E /
-    sudo log stream | grep -q -E 'mds.*Released.*BackgroundTask' || true
-    echo "Indexing completed"
-else
-    # Disable spotlight and MDS
-    sudo mdutil -a -i off
-    sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
-    sudo mdutil -a -s | grep "Indexing enabled." && echo "Indexing is still enabled" && exit 1 || true
-fi
+# Erase all indexes and wait until the rebuilding process ends,
+# for now there is no way to get status of indexing process, it takes around 5 minutes to accomplish
+sudo mdutil -E /
+sudo log stream | grep -q -E 'mds.*Released.*BackgroundTask' || true
+echo "Indexing completed"
 
 # delete symlink for tests running
 sudo rm -f /usr/local/bin/invoke_tests


### PR DESCRIPTION
# Description

Turn back on indexing for macOS-14 and macOS-15.

#### Related issue:
- https://github.com/actions/runner-images/issues/11921

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
