### PR TITLE
[windows] Pin the cmake version to 3.31.6

### DIFF
--- a/images/windows/scripts/build/Install-ChocolateyPackages.ps1
+++ b/images/windows/scripts/build/Install-ChocolateyPackages.ps1
@@ -6,7 +6,7 @@
 $commonPackages = (Get-ToolsetContent).choco.common_packages
 
 foreach ($package in $commonPackages) {
-    Install-ChocoPackage $package.name -Version $package.version -ArgumentList $package.args
+    Install-ChocoPackage $package.name $package.version -ArgumentList $package.args
 }
 
 Invoke-PesterTests -TestFile "ChocoPackages"

--- a/images/windows/scripts/build/Install-ChocolateyPackages.ps1
+++ b/images/windows/scripts/build/Install-ChocolateyPackages.ps1
@@ -6,7 +6,7 @@
 $commonPackages = (Get-ToolsetContent).choco.common_packages
 
 foreach ($package in $commonPackages) {
-    Install-ChocoPackage $package.name -ArgumentList "--version $package.version $package.args"
+    Install-ChocoPackage $package.name -Version $package.version -ArgumentList $package.args
 }
 
 Invoke-PesterTests -TestFile "ChocoPackages"

--- a/images/windows/scripts/build/Install-ChocolateyPackages.ps1
+++ b/images/windows/scripts/build/Install-ChocolateyPackages.ps1
@@ -6,7 +6,7 @@
 $commonPackages = (Get-ToolsetContent).choco.common_packages
 
 foreach ($package in $commonPackages) {
-    Install-ChocoPackage $package.name $package.version -ArgumentList $package.args
+    Install-ChocoPackage $package.name -Version $package.version -ArgumentList $package.args
 }
 
 Invoke-PesterTests -TestFile "ChocoPackages"

--- a/images/windows/scripts/build/Install-ChocolateyPackages.ps1
+++ b/images/windows/scripts/build/Install-ChocolateyPackages.ps1
@@ -6,7 +6,7 @@
 $commonPackages = (Get-ToolsetContent).choco.common_packages
 
 foreach ($package in $commonPackages) {
-    Install-ChocoPackage $package.name -ArgumentList $package.args
+    Install-ChocoPackage $package.name -ArgumentList "--version $package.version $package.args"
 }
 
 Invoke-PesterTests -TestFile "ChocoPackages"

--- a/images/windows/scripts/helpers/ChocoHelpers.ps1
+++ b/images/windows/scripts/helpers/ChocoHelpers.ps1
@@ -16,8 +16,11 @@ function Install-ChocoPackage {
     .PARAMETER RetryCount
         The number of times to retry the installation if it fails. Default is 5.
 
+    .PARAMETER Version
+        The version of the package to install.
+
     .EXAMPLE
-        Install-ChocoPackage -PackageName "git" -RetryCount 3
+        Install-ChocoPackage -PackageName "git" -Version "2.39.2" -RetryCount 3
     #>
 
     [CmdletBinding()]
@@ -25,6 +28,7 @@ function Install-ChocoPackage {
         [Parameter(Mandatory)]
         [string] $PackageName,
         [string[]] $ArgumentList,
+        [string] $Version,
         [int] $RetryCount = 5
     )
 
@@ -32,8 +36,11 @@ function Install-ChocoPackage {
         $count = 1
         while ($true) {
             Write-Host "Running [#$count]: choco install $packageName -y $argumentList"
-            choco install $packageName -y @argumentList --no-progress --require-checksums
-
+            if ($Version) {
+                choco install $packageName --version $Version -y @ArgumentList --no-progress --require-checksums
+            } else {
+                choco install $packageName -y @ArgumentList --no-progress --require-checksums
+            }
             $pkg = choco list --localonly $packageName --exact --all --limitoutput
             if ($pkg) {
                 Write-Host "Package installed: $pkg"

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -416,6 +416,7 @@
             },
             {
                 "name": "cmake.install",
+                "version": "3.31.6",
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
             },
             { "name": "imagemagick" },

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -337,6 +337,7 @@
             },
             {
                 "name": "cmake.install",
+                "version": "3.31.6",
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
             },
             { "name": "imagemagick" },

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -292,6 +292,7 @@
             },
             {
                 "name": "cmake.install",
+                "version": "3.31.6",
                 "args": [ "--installargs", "ADD_CMAKE_TO_PATH=\"System\"" ]
             },
             {


### PR DESCRIPTION
# Description
This PR will pin the cmake version to 3.31.6 on windows image to resolve compatibility issues . 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
