### PR TITLE
[macOS] Pin Cmake to 3.31.6 due to a backward compatibility issue in 4.0

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -24,6 +24,15 @@ for package in $common_packages; do
             brew install "$kotlin_rb_path"
             ;;
 
+        cmake)
+            # Pin cmake bottle to 3.31.6 due to a backward compatibility issue with the latest version
+            # https://github.com/actions/runner-images/issues/11926
+            cmake_commit="b4e46db74e74a8c1650b38b1da222284ce1ec5ce"
+            cmake_rb_link="https://raw.githubusercontent.com/Homebrew/homebrew-core/$cmake_commit/Formula/c/cmake.rb"
+            cmake_rb_path=$(download_with_retry "$cmake_rb_link")
+            brew install "$cmake_rb_path"
+            ;;
+
         tcl-tk@8)
             brew_smart_install "$package"
             if is_VenturaX64 || is_SonomaX64; then


### PR DESCRIPTION
# Description

Users report major degradation in the new version, which prevents many projects from compiling using it. Temporarily pinning the latest stable version until the circumstances are clarified.

#### Related issue:

- https://github.com/actions/runner-images/issues/11926

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
