### PR TITLE
[macOS]Update Xcode to 16.3 release to macOS15 images.

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -6,7 +6,6 @@
                 {
                     "link": "16.3", 
                     "version": "16.3+16E140",
-                    "symlinks": ["16.3"],
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [
                         { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "18.4"] },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -5,7 +5,7 @@
             "versions": [
                 {
                     "link": "16.3", 
-                    "version": "16.3+16E140",
+                    "version": "16.3.0+16E140",
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [
                         { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "18.4"] },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,8 +4,8 @@
         "x64": {
             "versions": [
                 {
-                    "link": "16.3_Release_Candidate_2", 
-                    "version": "16.3.0-Release.Candidate.2+16E140",
+                    "link": "16.3", 
+                    "version": "16.3+16E140",
                     "symlinks": ["16.3"],
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [
@@ -44,8 +44,8 @@
         "arm64":{
             "versions": [
                 {
-                    "link": "16.3_Release_Candidate_2", 
-                    "version": "16.3.0-Release.Candidate.2+16E140", 
+                    "link": "16.3", 
+                    "version": "16.3+16E140", 
                     "symlinks": ["16.3"],
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -5,7 +5,7 @@
             "versions": [
                 {
                     "link": "16.3", 
-                    "version": "16.3.0+16E140",
+                    "version": "16.3+16E140",
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [
                         { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "18.4"] },
@@ -44,8 +44,7 @@
             "versions": [
                 {
                     "link": "16.3", 
-                    "version": "16.3+16E140", 
-                    "symlinks": ["16.3"],
+                    "version": "16.3+16E140",
                     "sha256": "c593177b73e45f31e1cf7ced131760d8aa8e1532f5bbf8ba11a4ded01da14fbb",
                     "install_runtimes": [
                         { "iOS": ["18.0", "18.1", "18.2", "18.3.1", "18.4"] },


### PR DESCRIPTION
# Description
Update Xcode to 16.3 release to macOS 15 images.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
