### PR TITLE
[macOS] Always use the latest major version of CodeQL Action

### DIFF
--- a/images/macos/scripts/build/install-codeql-bundle.sh
+++ b/images/macos/scripts/build/install-codeql-bundle.sh
@@ -7,7 +7,8 @@
 source ~/utils/utils.sh
 
 # Retrieve the latest major version of the CodeQL Action to use in the base URL for downloading the bundle.
-releases=$(curl -s "https://api.github.com/repos/github/codeql-action/releases")
+[ -n "$API_PAT" ] && authString=(-H "Authorization: token ${API_PAT}")
+releases=$(curl "${authString[@]}" -s "https://api.github.com/repos/github/codeql-action/releases")
 
 # Get the release tags starting with v[0-9] and sort them in descending order, then parse the first one to get the major version.
 codeql_action_latest_major_version=$(echo "$releases" |

--- a/images/macos/scripts/build/install-codeql-bundle.sh
+++ b/images/macos/scripts/build/install-codeql-bundle.sh
@@ -23,6 +23,7 @@ fi
 
 # Retrieve the CLI version of the latest CodeQL bundle.
 defaults_json_path=$(download_with_retry "https://raw.githubusercontent.com/github/codeql-action/$codeql_action_latest_major_version/src/defaults.json")
+bundle_version=$(jq -r '.cliVersion' "$defaults_json_path")
 bundle_tag_name="codeql-bundle-v$bundle_version"
 
 echo "Downloading CodeQL bundle $bundle_version..."
@@ -31,16 +32,16 @@ echo "Downloading CodeQL bundle $bundle_version..."
 archive_path=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle.tar.gz")
 
 codeql_toolcache_path=$AGENT_TOOLSDIRECTORY/CodeQL/$bundle_version/x64
-mkdir -p $codeql_toolcache_path
+mkdir -p "$codeql_toolcache_path" 
 
 echo "Unpacking the downloaded CodeQL bundle archive..."
-tar -xzf $archive_path -C $codeql_toolcache_path
+tar -xzf "$archive_path" -C "$codeql_toolcache_path"
 
 # Touch a file to indicate to the CodeQL Action that this bundle shipped with the toolcache. This is
 # to support overriding the CodeQL version specified in defaults.json on GitHub Enterprise.
-touch $codeql_toolcache_path/pinned-version
+touch "$codeql_toolcache_path/pinned-version"
 
 # Touch a file to indicate to the toolcache that setting up CodeQL is complete.
-touch $codeql_toolcache_path.complete
+touch "$codeql_toolcache_path.complete"
 
 invoke_tests "Common" "CodeQL Bundle"

--- a/images/macos/scripts/build/install-codeql-bundle.sh
+++ b/images/macos/scripts/build/install-codeql-bundle.sh
@@ -22,7 +22,7 @@ if [ -z "$codeql_action_latest_major_version" ]; then
 fi
 
 # Retrieve the CLI version of the latest CodeQL bundle.
-defaults_json_path=$(download_with_retry "https://raw.githubusercontent.com/github/codeql-action/$codeql_action_latest_major_version/src/defaults.json")
+defaults_json_path=$(download_with_retry "https://raw.githubusercontent.com/github/codeql-action/v$codeql_action_latest_major_version/src/defaults.json")
 bundle_version=$(jq -r '.cliVersion' "$defaults_json_path")
 bundle_tag_name="codeql-bundle-v$bundle_version"
 


### PR DESCRIPTION
Instead of hardcoding the CodeQL Action major version, we now always use the latest major version of CodeQL Action. 

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: Supersedes https://github.com/actions/runner-images/pull/11928.

## Check list
- [x] Related issue / work item is attached
- [N/A] Tests are written (if applicable)
- [N/A] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
