### PR TITLE
check for both 160 and 170 dacfx installs

### DIFF
--- a/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
@@ -299,7 +299,15 @@ function Get-VisualCPPComponents {
 }
 
 function Get-DacFxVersion {
-    $dacfxversion = & "$env:ProgramFiles\Microsoft SQL Server\160\DAC\bin\sqlpackage.exe" /version
+    $sqlPackage160Path = Join-Path $env:ProgramFiles -ChildPath "Microsoft SQL Server\160\DAC\bin\sqlpackage.exe"
+    $sqlPackage170Path = Join-Path $env:ProgramFiles -ChildPath "Microsoft SQL Server\170\DAC\bin\sqlpackage.exe"
+    if (Test-Path $sqlPackage160Path) {
+        $dacfxversion = & "$sqlPackage160Path" /version
+    } elseif (Test-Path $sqlPackage170Path) {
+        $dacfxversion = & "$sqlPackage170Path" /version
+    } else {
+        throw "DACFx not found"
+    }
     return $dacfxversion
 }
 

--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -49,10 +49,11 @@ Describe "R" {
 }
 
 Describe "DACFx" {
-    It "DACFx" {
+    It "DACFx" { 
         (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*).DisplayName -Contains "Microsoft SQL Server Data-Tier Application Framework" | Should -BeTrue
-        $sqlPackagePath = 'C:\Program Files\Microsoft SQL Server\160\DAC\bin\SqlPackage.exe'
-        "${sqlPackagePath}" | Should -Exist
+        $sqlPackage160Path = 'C:\Program Files\Microsoft SQL Server\160\DAC\bin\SqlPackage.exe'
+        $sqlPackage170Path = 'C:\Program Files\Microsoft SQL Server\170\DAC\bin\SqlPackage.exe'
+        ((Test-Path "${sqlPackage160Path}") -Or (Test-Path "${sqlPackage170Path}")) | Should -BeTrue 
     }
 
     It "SqlLocalDB" -Skip:(-not (Test-IsWin19)) {


### PR DESCRIPTION
# Description

Fixing https://github.com/actions/runner-images/issues/12054
Modifying DacFx test and version checks to use updated path based on April 15th, 2025 release

New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ x ] Related issue / work item is attached
- [ x ] Tests are written (if applicable)
- [ x ] Documentation is updated (if applicable)
- [ x ] Changes are tested and related VM images are successfully generated
