### PR TITLE
add oras into ubuntu-24.04 which is missing

### DIFF
--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -299,6 +299,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-nvm.sh",
       "${path.root}/../scripts/build/install-nodejs.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
+      "${path.root}/../scripts/build/install-oras-cli.sh",
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

ubuntu 20.04 and 22.04 contain oras as well

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
