### PR TITLE
[Ubuntu 22] Fix podman networking test to ignore CNI plugins warnings

### DIFF
--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -348,8 +348,8 @@ Describe "Containers" {
     # https://github.com/actions/runner-images/issues/7753
     It "podman networking" -TestCases "podman CNI plugins" {
         "podman network create -d bridge test-net" | Should -ReturnZeroExitCode
-        $output = & { podman network ls 2>&1 }
-$output | Should -NotMatch 'level=error'
+        $output = podman network ls 2>&1
+$output | Where-Object { $_ -match 'level=error' } | Should -BeNullOrEmpty
         "podman network rm test-net" | Should -ReturnZeroExitCode
     }
 

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -348,9 +348,8 @@ Describe "Containers" {
     # https://github.com/actions/runner-images/issues/7753
     It "podman networking" -TestCases "podman CNI plugins" {
         "podman network create -d bridge test-net" | Should -ReturnZeroExitCode
-        $errorOutput = & { podman network ls } 2>&1 | Where-Object { $_ -match "Error" }
-$errorOutput | Should -BeNullOrEmpty
-
+        $output = & { podman network ls 2>&1 }
+$output | Should -NotMatch 'level=error'
         "podman network rm test-net" | Should -ReturnZeroExitCode
     }
 

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -348,7 +348,9 @@ Describe "Containers" {
     # https://github.com/actions/runner-images/issues/7753
     It "podman networking" -TestCases "podman CNI plugins" {
         "podman network create -d bridge test-net" | Should -ReturnZeroExitCode
-        "podman network ls" | Should -Not -OutputTextMatchingRegex "Error"
+        $errorOutput = & { podman network ls } 2>&1 | Where-Object { $_ -match "Error" }
+$errorOutput | Should -BeNullOrEmpty
+
         "podman network rm test-net" | Should -ReturnZeroExitCode
     }
 


### PR DESCRIPTION
- This PR updates the podman networking test in `Tools.Tests.ps1` to correctly handle in Ubuntu22 and verifies potential CNI plugin issues reported by the `podman network ls` command.

- Updated the test to filter out expected CNI config warnings in `podman network ls` output.
Prevents false failures due to missing CNI plugins when no actual errors are present.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
