### PR TITLE
Make os_disk_size_gb a variable in Packer templates.

### DIFF
--- a/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
@@ -94,6 +94,11 @@ variable "managed_image_resource_group_name" {
   default = "${env("ARM_RESOURCE_GROUP")}"
 }
 
+variable "os_disk_size_gb" {
+  type    = string
+  default = "75"
+}
+
 variable "private_virtual_network_with_public_ip" {
   type    = bool
   default = false
@@ -146,7 +151,7 @@ source "azure-arm" "build_image" {
   location                               = "${var.location}"
   managed_image_name                     = "${local.managed_image_name}"
   managed_image_resource_group_name      = "${var.managed_image_resource_group_name}"
-  os_disk_size_gb                        = "75"
+  os_disk_size_gb                        = "${var.os_disk_size_gb}"
   os_type                                = "Linux"
   private_virtual_network_with_public_ip = "${var.private_virtual_network_with_public_ip}"
   subscription_id                        = "${var.subscription_id}"

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -94,6 +94,11 @@ variable "managed_image_resource_group_name" {
   default = "${env("ARM_RESOURCE_GROUP")}"
 }
 
+variable "os_disk_size_gb" {
+  type    = string
+  default = "75"
+}
+
 variable "private_virtual_network_with_public_ip" {
   type    = bool
   default = false
@@ -146,7 +151,7 @@ source "azure-arm" "build_image" {
   location                               = "${var.location}"
   managed_image_name                     = "${local.managed_image_name}"
   managed_image_resource_group_name      = "${var.managed_image_resource_group_name}"
-  os_disk_size_gb                        = "75"
+  os_disk_size_gb                        = "${var.os_disk_size_gb}"
   os_type                                = "Linux"
   private_virtual_network_with_public_ip = "${var.private_virtual_network_with_public_ip}"
   subscription_id                        = "${var.subscription_id}"

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -94,6 +94,11 @@ variable "managed_image_resource_group_name" {
   default = "${env("ARM_RESOURCE_GROUP")}"
 }
 
+variable "os_disk_size_gb" {
+  type    = string
+  default = "75"
+}
+
 variable "private_virtual_network_with_public_ip" {
   type    = bool
   default = false
@@ -146,7 +151,7 @@ source "azure-arm" "build_image" {
   location                               = "${var.location}"
   managed_image_name                     = "${local.managed_image_name}"
   managed_image_resource_group_name      = "${var.managed_image_resource_group_name}"
-  os_disk_size_gb                        = "75"
+  os_disk_size_gb                        = "${var.os_disk_size_gb}"
   os_type                                = "Linux"
   private_virtual_network_with_public_ip = "${var.private_virtual_network_with_public_ip}"
   subscription_id                        = "${var.subscription_id}"

--- a/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
@@ -69,6 +69,11 @@ variable "managed_image_resource_group_name" {
   default = "${env("ARM_RESOURCE_GROUP")}"
 }
 
+variable "os_disk_size_gb" {
+  type    = string
+  default = "75"
+}
+
 variable "private_virtual_network_with_public_ip" {
   type    = bool
   default = false
@@ -141,7 +146,7 @@ source "azure-arm" "build_image" {
 
   // VM Configuration
   vm_size         = "${var.vm_size}"
-  os_disk_size_gb = "75"
+  os_disk_size_gb = "${var.os_disk_size_gb}"
   os_type         = "Linux"
 
   dynamic "azure_tag" {

--- a/images/windows/templates/windows-2019.pkr.hcl
+++ b/images/windows/templates/windows-2019.pkr.hcl
@@ -104,6 +104,11 @@ variable "object_id" {
   default = "${env("ARM_OBJECT_ID")}"
 }
 
+variable "os_disk_size_gb" {
+  type    = string
+  default = "256"
+}
+
 variable "private_virtual_network_with_public_ip" {
   type    = bool
   default = false
@@ -159,7 +164,7 @@ source "azure-arm" "image" {
   managed_image_resource_group_name      = "${var.managed_image_resource_group_name}"
   managed_image_storage_account_type     = "${var.managed_image_storage_account_type}"
   object_id                              = "${var.object_id}"
-  os_disk_size_gb                        = "256"
+  os_disk_size_gb                        = "${var.os_disk_size_gb}"
   os_type                                = "Windows"
   private_virtual_network_with_public_ip = "${var.private_virtual_network_with_public_ip}"
   subscription_id                        = "${var.subscription_id}"

--- a/images/windows/templates/windows-2022.pkr.hcl
+++ b/images/windows/templates/windows-2022.pkr.hcl
@@ -104,6 +104,11 @@ variable "object_id" {
   default = "${env("ARM_OBJECT_ID")}"
 }
 
+variable "os_disk_size_gb" {
+  type    = string
+  default = "256"
+}
+
 variable "private_virtual_network_with_public_ip" {
   type    = bool
   default = false
@@ -159,7 +164,7 @@ source "azure-arm" "image" {
   managed_image_resource_group_name      = "${var.managed_image_resource_group_name}"
   managed_image_storage_account_type     = "${var.managed_image_storage_account_type}"
   object_id                              = "${var.object_id}"
-  os_disk_size_gb                        = "256"
+  os_disk_size_gb                        = "${var.os_disk_size_gb}"
   os_type                                = "Windows"
   private_virtual_network_with_public_ip = "${var.private_virtual_network_with_public_ip}"
   subscription_id                        = "${var.subscription_id}"

--- a/images/windows/templates/windows-2025.pkr.hcl
+++ b/images/windows/templates/windows-2025.pkr.hcl
@@ -104,6 +104,11 @@ variable "object_id" {
   default = "${env("ARM_OBJECT_ID")}"
 }
 
+variable "os_disk_size_gb" {
+  type    = string
+  default = "150"
+}
+
 variable "private_virtual_network_with_public_ip" {
   type    = bool
   default = false
@@ -159,7 +164,7 @@ source "azure-arm" "image" {
   managed_image_resource_group_name      = "${var.managed_image_resource_group_name}"
   managed_image_storage_account_type     = "${var.managed_image_storage_account_type}"
   object_id                              = "${var.object_id}"
-  os_disk_size_gb                        = "150"
+  os_disk_size_gb                        = "${var.os_disk_size_gb}"
   os_type                                = "Windows"
   private_virtual_network_with_public_ip = "${var.private_virtual_network_with_public_ip}"
   subscription_id                        = "${var.subscription_id}"


### PR DESCRIPTION
# Description
This is a minimum change to ensure that os_disk_size_gb is declared as a variable in each of the Packer templates rather than being hard coded.  This will allow users to override the variable in the packer template using the environment variable PKR_VAR_os_disk_size_gb [see here](https://developer.hashicorp.com/packer/guides/hcl/variables#from-environment-variables).  

Issues around this have been raised before and the advice was to use sed to modify the templates as part of the build process but this feels like a much cleaner and more user friendly approach without requiring extra parameters to be passed to the templates or to the helper scripts.  

The purpose of this change is to allow users to easily create images with larger disks to suit their needs with no breaking changes or impact to existing users.

#### Related issue:
#8503
#9193 

## Check list
- [X] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
