### PR TITLE
[macOS] Remove stale VCPKG workaround

### DIFF
--- a/images/macos/scripts/build/install-vcpkg.sh
+++ b/images/macos/scripts/build/install-vcpkg.sh
@@ -10,18 +10,11 @@ source ~/utils/utils.sh
 VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
 echo "export VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" | tee -a ~/.bashrc
 
-# workaround https://github.com/microsoft/vcpkg/issues/27786
-
-mkdir -p /Users/runner/.vcpkg
-touch /Users/runner/.vcpkg/vcpkg.path.txt
-
 # Install vcpkg
 sudo git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
 sudo $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 $VCPKG_INSTALLATION_ROOT/vcpkg integrate install
 sudo chmod -R 0777 $VCPKG_INSTALLATION_ROOT
 ln -sf $VCPKG_INSTALLATION_ROOT/vcpkg /usr/local/bin
-
-rm -rf /Users/runner/.vcpkg
 
 invoke_tests "Common" "vcpkg"


### PR DESCRIPTION
# Description

We don't need that workaround at the moment.

#### Related issue:

#12085

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
