### PR TITLE
[Windows] Removed Go versions 1.20 & 1.21, and updated to the latest version, 1.24, setting it as the default.

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -72,12 +72,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.20.*",
-                "1.21.*",
                 "1.22.*",
-                "1.23.*"
+                "1.23.*",
+                "1.24.*"
             ],
-            "default": "1.21.*"
+            "default": "1.24.*"
         }
     ],
     "powershellModules": [

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -71,12 +71,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.20.*",
-                "1.21.*",
                 "1.22.*",
-                "1.23.*"
+                "1.23.*",
+                "1.24.*"
             ],
-            "default": "1.21.*"
+            "default": "1.24.*"
         }
     ],
     "powershellModules": [

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -51,11 +51,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "1.21.*",
                 "1.22.*",
-                "1.23.*"
+                "1.23.*",
+                "1.24.*"
             ],
-            "default": "1.23.*"
+            "default": "1.24.*"
         }
     ],
     "powershellModules": [


### PR DESCRIPTION
This PR removes Go versions 1.20 and 1.21, upgrades to version 1.24, and sets it as the default.

#### Related issue:
https://github.com/actions/runner-images/issues/11711

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
