### PR TITLE
[Windows] Update Install-AzureCosmosDbEmulator.ps1 SHA256Sum

### DIFF
--- a/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
+++ b/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
@@ -5,6 +5,6 @@
 
 Install-Binary -Type MSI `
     -Url "https://aka.ms/cosmosdb-emulator" `
-    -ExpectedSHA256Sum "7BAFEE9F90272C01F7924A1D8E62EE0954F555E229C7166B815253E526E666C4"
+    -ExpectedSHA256Sum "AB040B9A0FBC4766E179554B9899B947C41E3A259F8A0FC63022DB8D0C562769"
 
 Invoke-PesterTests -TestFile "Tools" -TestName "Azure Cosmos DB Emulator"


### PR DESCRIPTION
# Description

Bug fixing

SHA256SUM changed to the value of azure-cosmosdb-emulator-2.14.22-5aad492b.msi downloaded today.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
