### PR TITLE
set rustup profile to default

### DIFF
--- a/images/macos/scripts/build/install-rust.sh
+++ b/images/macos/scripts/build/install-rust.sh
@@ -10,13 +10,10 @@ echo "Installing Rustup..."
 brew_smart_install "rustup-init"
 
 echo "Installing Rust language..."
-rustup-init -y --no-modify-path --default-toolchain=stable --profile=minimal
+rustup-init -y --no-modify-path --default-toolchain=stable
 
 echo "Initialize environment variables..."
 CARGO_HOME=$HOME/.cargo
-
-echo "Install common tools..."
-rustup component add rustfmt clippy
 
 echo "Cleanup Cargo registry cached data..."
 rm -rf $CARGO_HOME/registry/*

--- a/images/ubuntu/scripts/build/install-rust.sh
+++ b/images/ubuntu/scripts/build/install-rust.sh
@@ -11,13 +11,10 @@ source $HELPER_SCRIPTS/os.sh
 export RUSTUP_HOME=/etc/skel/.rustup
 export CARGO_HOME=/etc/skel/.cargo
 
-curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable
 
 # Initialize environment variables
 source $CARGO_HOME/env
-
-# Install common tools
-rustup component add rustfmt clippy
 
 if is_ubuntu22; then
     cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated

--- a/images/windows/scripts/build/Install-Rust.ps1
+++ b/images/windows/scripts/build/Install-Rust.ps1
@@ -18,7 +18,7 @@ Test-FileChecksum $rustupPath -ExpectedSHA256Sum $distributorFileHash
 #endregion
 
 # Install Rust by running rustup-init.exe (disabling the confirmation prompt with -y)
-& $rustupPath -y --default-toolchain=stable --profile=minimal
+& $rustupPath -y --default-toolchain=stable
 if ($LASTEXITCODE -ne 0) {
     throw "Rust installation failed with exit code $LASTEXITCODE"
 }
@@ -35,10 +35,6 @@ rustup target add i686-pc-windows-msvc
 rustup target add x86_64-pc-windows-gnu
 
 # Install common tools
-rustup component add rustfmt clippy
-if ($LASTEXITCODE -ne 0) {
-    throw "Rust component installation failed with exit code $LASTEXITCODE"
-}
 if (-not (Test-IsWin25)) {
     cargo install --locked bindgen-cli cbindgen cargo-audit cargo-outdated
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
`rustup` in GitHub Actions has been updated to `1.28.2`. Since `1.28.2` (https://github.com/rust-lang/rustup/commit/f439f4837650703f17e63d3b58011218b18eb07c), when a repository uses `rust-toolchain.toml` to automatically install the nightly toolchain, rustup consults the profile specified in `~/.rustup/settings.toml` instead of defaulting to the default profile. This behavior is reasonable, as it aligns with how `rustup toolchain install` works. However, it breaks usage for nightly toolchain users on GitHub Actions because the profile in GitHub Actions is set to `minimal`, which means `rustfmt` and `clippy` are no longer installed automatically. This PR changes the profile to `default` to fix it.