### PR TITLE
[windows] Fix syntax of ssh-keyscan

### DIFF
--- a/images/windows/scripts/build/Install-Git.ps1
+++ b/images/windows/scripts/build/Install-Git.ps1
@@ -46,7 +46,7 @@ if ($LASTEXITCODE -ne 0) {
 Add-MachinePathItem "C:\Program Files\Git\bin"
 
 # Add well-known SSH host keys to ssh_known_hosts
-ssh-keyscan -t rsa, ecdsa, ed25519 github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
+ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 ssh-keyscan -t rsa ssh.dev.azure.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"
 
 Invoke-PesterTests -TestFile "Git"


### PR DESCRIPTION
# Description
Remove extraneous spaces between key types to fetch. The Windows image has only the RSA key for github[.]com in file "C:\Program Files\Git\etc\ssh\ssh_known_hosts". This PR removes spaces in the list of key types so that neither ecdsa nor ed25519 are interpreted as hostnames

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
