### PR TITLE
Bug: Mask `fwupd` timer on ubuntu images

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -59,6 +59,14 @@ ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests
 # Disable motd updates metadata
 sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
 
+# Remove fwupd if installed. We're running on VMs in Azure and the fwupd package is not needed.
+# Leaving it enable means periodic refreshes show in network traffic and firewall logs
+if dpkg -l | grep -q fwupd; then
+    echo "Removing fwupd package..."
+    apt-get purge -y fwupd
+fi
+
+# If fwupd config still exists, disable the motd updates
 if [[ -f "/etc/fwupd/daemon.conf" ]]; then
     sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf
     systemctl mask fwupd-refresh.timer

--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -61,15 +61,16 @@ sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
 
 # Remove fwupd if installed. We're running on VMs in Azure and the fwupd package is not needed.
 # Leaving it enable means periodic refreshes show in network traffic and firewall logs
-if dpkg -l | grep -q fwupd; then
-    echo "Removing fwupd package..."
-    apt-get purge -y fwupd
+# Check if fwupd-refresh.timer exists in systemd
+if systemctl list-unit-files fwupd-refresh.timer &>/dev/null; then
+    echo "Masking fwupd-refresh.timer..."
+    systemctl mask fwupd-refresh.timer
 fi
 
+# This is a legacy check, leaving for earlier versions of Ubuntu
 # If fwupd config still exists, disable the motd updates
 if [[ -f "/etc/fwupd/daemon.conf" ]]; then
     sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf
-    systemctl mask fwupd-refresh.timer
 fi
 
 # Disable to load providers

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -7,9 +7,9 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
     }
 }
 
-Describe "fwupd removed" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) -or -not [String]::IsNullOrEmpty($env:RUNNER_NAME)) {
+Describe "fwupd removed" {
     It "Is not present on box" {
-        $fwupdmgrCommand = Get-Command fwupdmgr -ErrorAction SilentlyContinue
-        $fwupdmgrCommand | Should -BeNullOrEmpty
+        $systemctlOutput = & systemctl list-unit-files fwupd-refresh.timer
+        $systemctlOutput | Should -Match "masked"
     }
 }

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -6,3 +6,10 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
         $freeSpace | Should -BeGreaterOrEqual 17GB
     }
 }
+
+Describe "fwupd removed" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) -or -not [String]::IsNullOrEmpty($env:RUNNER_NAME)) {
+    It "Is not present on box" {
+        $fwupdmgrCommand = Get-Command fwupdmgr -ErrorAction SilentlyContinue
+        $fwupdmgrCommand | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
We're running on VMs in Azure and the fwupd package is not needed.

Leaving it enable means periodic refreshes show in network traffic and firewall logs.

The current check has a bug, meaning the timer isn't masked. 

In the current `fwupd` version there isn't a `daemon.conf` file present so the `if` condition doesn't run and doesn't mask the systemd unit. 
```
❯ cat /etc/fwupd/daemon.conf                                                                                                                                                             
[bat error]: '/etc/fwupd/daemon.conf': No such file or directory (os error 2)
```

#### Related issue:
- https://github.com/github/hosted-runners/issues/1377

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
