### PR TITLE
[macOS]Add Mozila Firfox to macOS 13,14 and 15 arm64 images.

### DIFF
--- a/images/macos/scripts/tests/Browsers.Tests.ps1
+++ b/images/macos/scripts/tests/Browsers.Tests.ps1
@@ -53,7 +53,7 @@ Describe "Edge" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64 -or $os.IsSequoi
     }
 }
 
-Describe "Firefox" -Skip:($os.IsVenturaArm64 -or $os.IsSonomaArm64 -or $os.IsSequoiaArm64) {
+Describe "Firefox" {
     It "Firefox" {
         $firefoxLocation = "/Applications/Firefox.app/Contents/MacOS/firefox"
         $firefoxLocation | Should -Exist

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -248,7 +248,8 @@ build {
       "${path.root}/../scripts/build/install-safari.sh",
       "${path.root}/../scripts/build/install-chrome.sh",
       "${path.root}/../scripts/build/install-bicep.sh",
-      "${path.root}/../scripts/build/install-codeql-bundle.sh"
+      "${path.root}/../scripts/build/install-codeql-bundle.sh",
+      "${path.root}/../scripts/build/install-firefox.sh"
     ]
   }
 

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -247,9 +247,9 @@ build {
       "${path.root}/../scripts/build/install-android-sdk.sh",
       "${path.root}/../scripts/build/install-safari.sh",
       "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
       "${path.root}/../scripts/build/install-bicep.sh",
-      "${path.root}/../scripts/build/install-codeql-bundle.sh",
-      "${path.root}/../scripts/build/install-firefox.sh"
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
   }
 

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -247,9 +247,9 @@ build {
       "${path.root}/../scripts/build/install-vcpkg.sh",
       "${path.root}/../scripts/build/install-safari.sh",
       "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
       "${path.root}/../scripts/build/install-bicep.sh",
-      "${path.root}/../scripts/build/install-codeql-bundle.sh",
-      "${path.root}/../scripts/build/install-firefox.sh"
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
   }
 

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -248,7 +248,8 @@ build {
       "${path.root}/../scripts/build/install-safari.sh",
       "${path.root}/../scripts/build/install-chrome.sh",
       "${path.root}/../scripts/build/install-bicep.sh",
-      "${path.root}/../scripts/build/install-codeql-bundle.sh"
+      "${path.root}/../scripts/build/install-codeql-bundle.sh",
+      "${path.root}/../scripts/build/install-firefox.sh"
     ]
   }
 

--- a/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
@@ -247,7 +247,8 @@ build {
       "${path.root}/../scripts/build/install-safari.sh",
       "${path.root}/../scripts/build/install-chrome.sh",
       "${path.root}/../scripts/build/install-bicep.sh",
-      "${path.root}/../scripts/build/install-codeql-bundle.sh"
+      "${path.root}/../scripts/build/install-codeql-bundle.sh",
+      "${path.root}/../scripts/build/install-firefox.sh"
     ]
   }
 

--- a/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
@@ -246,9 +246,9 @@ build {
       "${path.root}/../scripts/build/install-vcpkg.sh",
       "${path.root}/../scripts/build/install-safari.sh",
       "${path.root}/../scripts/build/install-chrome.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
       "${path.root}/../scripts/build/install-bicep.sh",
-      "${path.root}/../scripts/build/install-codeql-bundle.sh",
-      "${path.root}/../scripts/build/install-firefox.sh"
+      "${path.root}/../scripts/build/install-codeql-bundle.sh"
     ]
   }
 


### PR DESCRIPTION
# Description
1.Add Mozila Firfox to macOS 13,14 and 15 arm64 images.
2. User raised public [issue 12049](https://github.com/actions/runner-images/issues/12049)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
