### PR TITLE
[ubuntu] Use is-enabled instead of list-unit-files for fwupd-refresh.timer check

### DIFF
--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
 
 Describe "fwupd removed" {
     It "Is not present on box" {
-        $systemctlOutput = & systemctl list-unit-files fwupd-refresh.timer
+        $systemctlOutput = & systemctl is-enabled fwupd-refresh.timer
         $systemctlOutput | Should -Match "masked"
     }
 }


### PR DESCRIPTION
# Description

This update modifies the verification method for checking the removal of fwupd-refresh.timer. Instead of using systemctl list-unit-files, it now leverages systemctl is-enabled, providing a more direct and reliable check for its status.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
