### PR TITLE
[Ubuntu 22] update docker compose plugin version

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -251,7 +251,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.35.1",
+                "version": "2.36.0",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
# Description
This PR upgrades Docker Compose to version v2.36.0 for the Ubuntu 22 image. it will fix known https://github.com/docker/compose/issues/12747 in earlier versions of Docker Compose caused issues with parallel operations. 

Also see #12228 that fixes for Ubuntu 24

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
#12160

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
