### PR TITLE
[Windows-2025] Correct job name

### DIFF
--- a/.github/workflows/windows2025.yml
+++ b/.github/workflows/windows2025.yml
@@ -12,7 +12,7 @@ defaults:
     shell: pwsh
 
 jobs:
-  Windows_2022:
+  Windows_2025:
     if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2025'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
The job name for `windows-2025` CI incorrectly says `Windows_2022`, which is corrected by this PR.



## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
