### PR TITLE
[Windows] Update Toolsets for Windows Server 2019 and 2022 after PR merged #12247

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -446,8 +446,8 @@
         "version": "18"
     },
     "postgresql": {
-        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9",
-        "version": "14"
+        "version": "14",
+        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
     },
     "kotlin": {
         "version": "2.1.10",

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -447,9 +447,7 @@
     },
     "postgresql": {
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9",
-        "version": "14",
-        "vcRedistSignature": "8F985BE8FD256085C90A95D3C74580511A1DB975",
-        "installVcRedist": true
+        "version": "14"
     },
     "kotlin": {
         "version": "2.1.10",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -366,7 +366,7 @@
         "version": "8.4"
     },
     "postgresql": {
-        "version": "14"
+        "version": "14",
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
     },
     "kotlin": {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -367,9 +367,7 @@
     },
     "postgresql": {
         "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9",
-        "version": "14",
-        "vcRedistSignature": "8F985BE8FD256085C90A95D3C74580511A1DB975",
-        "installVcRedist": true
+        "version": "14"
     },
     "kotlin": {
         "version": "2.1.10",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -366,8 +366,8 @@
         "version": "8.4"
     },
     "postgresql": {
-        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9",
         "version": "14"
+        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
     },
     "kotlin": {
         "version": "2.1.10",


### PR DESCRIPTION
# Description
A recent PR, removes VCRedist 17 as a part of PostgreSQL Installation.
Still mention into toolsets for Windows Server 2019 and 2022.

[Windows] Update AzureCosmosDbEmulator signature and Removing VSredist 17 installation in Postgresql #12247

#### Related issue: 

#12265

## Check list
- [X] Related issue / work item is attached
- [!] Tests are written (if applicable)
- [!] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
