### PR TITLE
[Windows 19 & Windows 22]Removing Ruby 3.0 and making 3.3 as a default version.

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -5,12 +5,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "3.0",
                 "3.1",
                 "3.2",
                 "3.3"
             ],
-            "default": "3.0"
+            "default": "3.3"
         },
         {
             "name": "Python",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -5,12 +5,11 @@
             "arch": "x64",
             "platform" : "win32",
             "versions": [
-                "3.0",
                 "3.1",
                 "3.2",
                 "3.3"
             ],
-            "default": "3.0"
+            "default": "3.3"
         },
         {
             "name": "Python",


### PR DESCRIPTION
# Description
This PR removes Ruby 3.0 and sets Ruby 3.3 as the default version.
#### Related issue:
https://github.com/actions/runner-images/issues/12033
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
