### PR TITLE
[Ubuntu 22] Update Node.js version 20 as the default.

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -315,7 +315,7 @@
         "version": "4"
     },
     "node": {
-        "default": "18"
+        "default": "20"
     },
     "node_modules": [
         {


### PR DESCRIPTION
# Description
This PR updates the default Node.js version to 20 for Ubuntu 22.

#### Related issue:
https://github.com/actions/runner-images/issues/12143
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
