### PR TITLE
[Windows 22] Update Node.js version 20 as the default.

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -343,7 +343,7 @@
         ]
     },
     "node": {
-        "default": "18.*"
+        "default": "20.*"
     },
     "maven": {
         "version": "3.9"


### PR DESCRIPTION
# Description
This PR updates the default Node.js version to 20 for Windows 22.

#### Related issue:
https://github.com/actions/runner-images/issues/12034
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
