### PR TITLE
SBOM Issue: SYFT downgraded to 1.24.0

### DIFF
--- a/.github/workflows/create_sbom_report.yml
+++ b/.github/workflows/create_sbom_report.yml
@@ -57,9 +57,13 @@ jobs:
       - name: Install SYFT tool on Windows
         if: ${{ runner.os == 'Windows' }}
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b D:/syft
-      - name: Install SYFT tool on Ubuntu or macOS
-        if: ${{ runner.os != 'Windows' }}
+      - name: Install SYFT tool on Ubuntu 
+        if: ${{ runner.os == 'Linux' }}
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+      - name: Install SYFT v1.24.0 on macOS
+        if: ${{ runner.os == 'macOS' }}
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.24.0
+      
       #Running section.
       - name: Run SYFT on Windows
         if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
# Description
Bug fixing
Downgraded Syft to version v1.24.0 for macOS platforms  in the SBOM generation workflow to avoid indefinite hangs caused by privilege prompts in newer versions (e.g., v1.26.0).

The downgrade is scoped only to runner.os == 'macOS', and Windows/Linux runners will continue using the latest available Syft version.No other workflow logic is changed.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
