### PR TITLE
fix: wait for network config to settle

### DIFF
--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -234,6 +234,7 @@ build {
   provisioner "shell" {
     environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
       "${path.root}/../scripts/build/install-runner-package.sh",

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -235,6 +235,7 @@ build {
   provisioner "shell" {
     environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
       "${path.root}/../scripts/build/install-runner-package.sh",

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -233,6 +233,7 @@ build {
   provisioner "shell" {
     environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
       "${path.root}/../scripts/build/install-runner-package.sh",

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -234,6 +234,7 @@ build {
   provisioner "shell" {
     environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
       "${path.root}/../scripts/build/install-runner-package.sh",

--- a/images/macos/templates/macOS-15.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.anka.pkr.hcl
@@ -232,6 +232,7 @@ build {
   provisioner "shell" {
     environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
       "${path.root}/../scripts/build/install-runner-package.sh",

--- a/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.arm64.anka.pkr.hcl
@@ -233,6 +233,7 @@ build {
   provisioner "shell" {
     environment_vars = ["API_PAT=${var.github_api_pat}", "IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
+    pause_before     = "30s"
     scripts          = [
       "${path.root}/../scripts/build/install-actions-cache.sh",
       "${path.root}/../scripts/build/install-runner-package.sh",


### PR DESCRIPTION
Sometimes the install-actions-cache.sh fails to resolve api.github.com. This is probably happening due to the reboot in the provisioning step before. Add a 30 seconds pause like in the other block.

I read the section about macOS PRs. Feel free to pick that commit and and incorporate it in any form into your code base.