### PR TITLE
[Ubuntu] Resolve TODOs, refactor /etc/environment parsing

### DIFF
--- a/images/ubuntu/scripts/helpers/etc-environment.sh
+++ b/images/ubuntu/scripts/helpers/etc-environment.sh
@@ -4,86 +4,212 @@
 ##  Desc:  Helper functions for source and modify /etc/environment
 ################################################################################
 
-# NB: sed expression use '%' as a delimiter in order to simplify handling
-#     values containing slashes (i.e. directory path)
-#     The values containing '%' will break the functions
+ETC_ENV="/etc/environment"
 
-get_etc_environment_variable() {
-    local variable_name=$1
+# ------------------------------------------------------------------------------
+# parse_etc_environment <file> <keys_array_ref> <map_assoc_ref>
+#   Reads key=value lines from a file into an indexed array (for order) and an
+#   associative array (for lookup). Uses a mapfile callback for processing.
+#
+#
+# Arguments:
+#   $1: file_path - The file to parse (e.g., /etc/environment).
+#   $2: keys_array_ref - The name of the indexed array to store keys in order.
+#   $3: map_assoc_ref - The name of the associative array for key-value pairs.
+# ------------------------------------------------------------------------------
+parse_etc_environment() {
+    local file_path="$1"
+    # Use namerefs (-n) to pass arrays/maps by reference for modification
+    local -n _keys="$2"
+    local -n _map="$3"
+    # Ensure the callback function is unset when this function returns
+    trap 'unset -f _parse_cb' RETURN
 
-    # remove `variable_name=` and possible quotes from the line
-    grep "^${variable_name}=" /etc/environment | sed -E "s%^${variable_name}=\"?([^\"]+)\"?.*$%\1%"
+    _keys=()
+    _map=()
+
+    # Define a callback function for mapfile to process each line
+    _parse_cb() {
+        local idx="$1" line="$2" key val
+
+        # Skip comments, blank lines, or lines that don't look like KEY=VALUE or _KEY=VALUE
+        [[ ! "$line" =~ ^[[:space:]]*[_[:alpha:]][^=]*=.*$ ]] && return
+
+        # Split on the first '=' to correctly handle values that contain '='.
+        IFS='=' read -r key val <<<"$line"
+
+        _keys[idx]="$key"
+        # Remove surrounding quotes from value if they exist
+        if [[ $val == \"*\" ]]; then
+            val="${val#\"}"
+            val="${val%\"}"
+        fi
+        _map["$key"]="$val"
+    }
+
+    # Read the file: -t removes newlines, -c1 processes one line at a time,
+    # -C executes the callback for each line.
+    mapfile -tc1 -C _parse_cb < "$file_path"
 }
 
-add_etc_environment_variable() {
-    local variable_name=$1
-    local variable_value=$2
+# ------------------------------------------------------------------------------
+# write_etc_environment <keys_array_ref> <map_assoc_ref>
+# ------------------------------------------------------------------------------
+# Writes key=value pairs from an associative map to a file.
+# - Maintains original order using the keys array.
+# - Values containing spaces are quoted.
+# - Writes to a temporary file first, then atomically moves it to /etc/environment
+#   using `sudo mv`, preventing partial writes or corruption.
+# ------------------------------------------------------------------------------
+write_etc_environment() {
+    local -n _keys="$1"
+    local -n _map="$2"
+    local tmp
+    tmp=$(mktemp)
 
-    echo "${variable_name}=${variable_value}" | sudo tee -a /etc/environment
+    for k in "${_keys[@]}"; do
+        # Ensure values with spaces are quoted
+        if [[ "${_map[$k]}" == *" "* ]]; then
+            printf '%s="%s"\n' "$k" "${_map[$k]}"
+        else
+            printf '%s=%s\n' "$k" "${_map[$k]}"
+        fi
+    done > "$tmp"
+
+    # atomically replace /etc/environment
+    sudo mv -f -- "$tmp" "${ETC_ENV}"
 }
 
-replace_etc_environment_variable() {
-    local variable_name=$1
-    local variable_value=$2
+# ------------------------------------------------------------------------------
+# _set_variable <keys_array_ref> <map_assoc_ref> <VAR> <VALUE>
+#   Sets a variable in the provided arrays. Does NOT write to disk.
+# ------------------------------------------------------------------------------
+_set_variable() {
+    # Double _ avoids circular name references when calling this function
+    local -n __keys="$1"
+    local -n __map="$2"
+    local var="$3"
+    local val="$4"
 
-    # modify /etc/environemnt in place by replacing a string that begins with variable_name
-    sudo sed -i -e "s%^${variable_name}=.*$%${variable_name}=${variable_value}%" /etc/environment
+    if [[ ! " ${__keys[*]} " =~ ${var} ]]; then
+        # If the key is new, add it to the end of our ordered list.
+        __keys+=("$var")
+    fi
+    __map["$var"]="$val"
 }
 
-set_etc_environment_variable() {
-    local variable_name=$1
-    local variable_value=$2
+# ------------------------------------------------------------------------------
+# _prepend_variable <keys_array_ref> <map_assoc_ref> <VAR> <ELEMENT>
+#   Prepends an element to a variable in the provided arrays.
+# ------------------------------------------------------------------------------
+_prepend_variable() {
+    local -n _keys="$1"
+    local -n _map="$2"
+    local var="$3"
+    local elem="$4"
 
-    if grep "^${variable_name}=" /etc/environment > /dev/null; then
-        replace_etc_environment_variable $variable_name $variable_value
+    local existing="${_map[$var]:-}"
+    # Disable the nameref and use the name itself, avoiding circular references
+    if [[ -n "$existing" ]]; then
+        _set_variable _keys _map "$var" "$elem:$existing"
     else
-        add_etc_environment_variable $variable_name $variable_value
+        _set_variable _keys _map "$var" "$elem"
     fi
 }
 
+# ------------------------------------------------------------------------------
+# _append_variable <keys_array_ref> <map_assoc_ref> <VAR> <ELEMENT>
+#   Appends an element to a variable in the provided arrays.
+# ------------------------------------------------------------------------------
+_append_variable() {
+    local -n _keys="$1"
+    local -n _map="$2"
+    local var="$3"
+    local elem="$4"
+
+    local existing="${_map[$var]:-}"
+    # Disable the nameref and use the name itself, avoiding circular references
+    if [[ -n "$existing" ]]; then
+        _set_variable _keys _map "$var" "$existing:$elem"
+    else
+        _set_variable _keys _map "$var" "$elem"
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# get_etc_environment_variable <VAR>
+# ------------------------------------------------------------------------------
+get_etc_environment_variable() {
+    local var="$1"
+    local -a keys; local -A map
+    parse_etc_environment "$ETC_ENV" keys map
+    printf "%s\n" "${map[$var]:-}"
+}
+
+# ------------------------------------------------------------------------------
+# set_etc_environment_variable <VAR> <VALUE>
+# ------------------------------------------------------------------------------
+set_etc_environment_variable() {
+    local var="$1" val="$2"
+    local -a keys; local -A map
+    parse_etc_environment "$ETC_ENV" keys map
+    _set_variable keys map "$var" "$val"
+    write_etc_environment keys map
+}
+
+# ------------------------------------------------------------------------------
+# prepend_etc_environment_variable <VAR> <ELEMENT>
+# ------------------------------------------------------------------------------
 prepend_etc_environment_variable() {
-    local variable_name=$1
-    local element=$2
-
-    # TODO: handle the case if the variable does not exist
-    existing_value=$(get_etc_environment_variable "${variable_name}")
-    set_etc_environment_variable "${variable_name}" "${element}:${existing_value}"
+    local var="$1" elem="$2"
+    local -a keys; local -A map
+    parse_etc_environment "$ETC_ENV" keys map
+    _prepend_variable keys map "$var" "$elem"
+    write_etc_environment keys map
 }
 
+# ------------------------------------------------------------------------------
+# append_etc_environment_variable <VAR> <ELEMENT>
+# ------------------------------------------------------------------------------
 append_etc_environment_variable() {
-    local variable_name=$1
-    local element=$2
-
-    # TODO: handle the case if the variable does not exist
-    existing_value=$(get_etc_environment_variable "${variable_name}")
-    set_etc_environment_variable "${variable_name}" "${existing_value}:${element}"
+    local var="$1" elem="$2"
+    local -a keys; local -A map
+    parse_etc_environment "$ETC_ENV" keys map
+    _append_variable keys map "$var" "$elem"
+    write_etc_environment keys map
 }
 
-prepend_etc_environment_path() {
-    local element=$1
+# ------------------------------------------------------------------------------
+# Convenience wrappers for PATH
+# ------------------------------------------------------------------------------
+prepend_etc_environment_path() { prepend_etc_environment_variable PATH "$1"; }
+append_etc_environment_path()  { append_etc_environment_variable PATH "$1"; }
 
-    prepend_etc_environment_variable PATH "${element}"
-}
-
-append_etc_environment_path() {
-    local element=$1
-
-    append_etc_environment_variable PATH "${element}"
-}
-
-# Process /etc/environment as if it were shell script with `export VAR=...` expressions
-#    The PATH variable is handled specially in order to do not override the existing PATH
-#    variable. The value of PATH variable read from /etc/environment is added to the end
-#    of value of the exiting PATH variable exactly as it would happen with real PAM app read
-#    /etc/environment
+# ------------------------------------------------------------------------------
+# reload_etc_environment
+#  – Re-exports variables from /etc/environment into the current shell.
+#    Special handling is applied to PATH to avoid overriding the current value,
+#    mimicking how PAM applies /etc/environment during login.
 #
-# TODO: there might be the others variables to be processed in the same way as "PATH" variable
-#       ie MANPATH, INFOPATH, LD_*, etc. In the current implementation the values from /etc/evironments
-#       replace the values of the current environment
+#    TODO (not yet implemented): The original script noted that other variables
+#    like MANPATH, INFOPATH, and LD_* may require similar treatment.
+#    This implementation currently merges only PATH and replaces others directly.
+#    This could be implemented in the future by using an array containing the
+#    variables and using an if check within the keys loop, to check if the
+#    variable is in the array, and then handle the same way we handle PATH.
+# ------------------------------------------------------------------------------
 reload_etc_environment() {
-    # add `export ` to every variable of /etc/environemnt except PATH and eval the result shell script
-    eval $(grep -v '^PATH=' /etc/environment | sed -e 's%^%export %')
+    local -a keys; local -A map
+    parse_etc_environment "$ETC_ENV" keys map
+
+    # export all but PATH
+    for k in "${keys[@]}"; do
+        [[ "$k" == PATH ]] && continue
+        export "$k"="${map[$k]}"
+    done
+
     # handle PATH specially
-    etc_path=$(get_etc_environment_variable PATH)
-    export PATH="$PATH:$etc_path"
+    if [[ -n "${map[PATH]:-}" ]]; then
+        export PATH="$PATH:${map[PATH]}"
+    fi
 }


### PR DESCRIPTION
# Description
Building an Ubuntu image currently relies on **scripts/…/etc-environment.sh** that  

1. uses multiple `sed/grep` passes,  
2. edits `/etc/environment` in place (risk of truncation on failure), 
3. cannot correctly prepend/append when the variable is initially empty, and
4. cannot handle spaces in environment variables

This PR rewrites the helper in pure Bash with array-based parsing, solving  
those issues while keeping the public API  
`get_/set_/append_/prepend_/reload_` intact.

### Motivation / Context
* Resolves the TODOs in the script.
* Allows better handling of edge cases such as spaces in the environment variable.
* Improves build robustness by writing `/etc/environment` atomically.  
* Simplifies future maintenance by avoiding fragile `sed` expressions.  

### What does this PR do?

* Replaces the old sed-driven helper with a single, tested implementation.  
* Adds atomic write (`mktemp && mv`) to avoid corrupting `/etc/environment`  
  on build interruption.  
* Automatically quotes values containing spaces.  
* **No behavioral change** for any variables runner-images currently writes.

### Size / Timing Impact

| variant        | mean ± σ (10 runs, `hyperfine`) | Δ time vs old |
| -------------- | ------------------------------- | ------------- |
| **new helper** | **1.353 s ± 0.032 s**           | **−24.5 %**   |
| old helper     | 1.793 s ± 0.041 s               | baseline      |

So the refactor shaves off about 24.5% off the test's runtime.

### How was this tested?

* **Local Docker harness** — built `Dockerfile` that mimics the
  runner-images layout, then ran:

  ```bash
  # Build container
  docker build -t env-test -f Dockerfile .

  # Start it detached
  cid=$(docker run -d env-test sleep infinity)

  # Copy helper scripts into the container
  docker cp images/ubuntu/scripts/helpers/etc-environment.sh \
        "$cid":/opt/runner-images/images/ubuntu/scripts/helpers/etc-environment.sh
  docker cp etc-environment-original.sh \
        "$cid":/opt/runner-images/images/ubuntu/scripts/helpers/etc-environment-og.sh

  # Functional tests + benchmark
  docker exec "$cid" bash /opt/runner-images/test-env-only.sh
  docker exec "$cid" bash /opt/runner-images/test-env-original.sh
  docker exec "$cid" hyperfine --warmup 3 \
        'bash /opt/runner-images/test-env-only.sh' \
        'bash /opt/runner-images/test-env-original.sh'
 
 Both helpers pass; the refactor shows the speed-up reported above.

> **Reproduce locally**:
> Full Dockerfile, helper scripts are in this Gist: https://gist.github.com/peppapig450/ff3bd4f5a80a16f8366c503314bf473b

### Backwards-Compatibility / Risk Assessment
* Removed functions were dead code (`add_etc_environment_variable`,
  `replace_etc_environment_variable`) – no call sites in repo.
* Variables starting with non-alpha  chars would be skipped the first time
  the file is rewritten; runner-images never emits such keys.
* Atomic write eliminates the “empty file if build step exits mid-sed” edge case.

### Unhandled Edge Cases
* Keys containing digits or dots first:
  - This is not used in the calling scripts so this should be okay.
* Comments at line end are currently treated as part of the value:
  - Also not used in the calling scripts.
 
#### Related issue:
N/A

## Check list
- [X] Changes are tested and related VM images are successfully generated
