### PR TITLE
[macOS] Add Xcode 26 beta 1 without runtimes on macOS-15-arm64 image

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -43,6 +43,13 @@
         "arm64":{
             "versions": [
                 {
+                    "link": "26_beta",
+                    "version": "26.0.0-Beta+17A5241e",
+                    "symlinks": ["26.0"],
+                    "sha256": "664ad6ec7a3139e9c43b95620c73f8950a802c3d469bb47e6d89f3eab9541b1c",
+                    "install_runtimes": "none"
+                },
+                {
                     "link": "16.4",
                     "version": "16.4.0+16F6",
                     "sha256": "2dbf65ba28fb85b34e72c14c529a42d5c3189ab0f11fb29fdebd5f4ee6c87900",


### PR DESCRIPTION
# Description

Adding new Xcode 26.0 Beta 1 to macOS-15 arm64-based aka `macos-15` in GitHub Actions

#### Related issue:
- https://github.com/actions/runner-images/issues/12355

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
