### PR TITLE
Update EdgeDriver signature validation to include latest thumbprint

### DIFF
--- a/images/windows/scripts/build/Install-EdgeDriver.ps1
+++ b/images/windows/scripts/build/Install-EdgeDriver.ps1
@@ -29,7 +29,8 @@ Expand-7ZipArchive -Path $archivePath -DestinationPath $edgeDriverPath
 #Validate the EdgeDriver signature
 $signatureThumbprint = @(
                          "7920AC8FB05E0FFFE21E8FF4B4F03093BA6AC16E",
-                         "0BD8C56733FDCC06F8CB919FF5A200E39B1ACF71"
+                         "0BD8C56733FDCC06F8CB919FF5A200E39B1ACF71",
+                         "F6EECCC7FF116889C2D5466AE7243D7AA7698689"
                         )
 Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedThumbprint $signatureThumbprint
 


### PR DESCRIPTION
This pull request updates the `Install-EdgeDriver.ps1` script to include an additional valid signature thumbprint for verifying the EdgeDriver binary.

Issue #12404 

Key change:

* [`Install-EdgeDriver.ps1`](diffhunk://#diff-91ad89baa9640b4777fe5185cd1a9d61c13f70a3c47239b4ecb1870cd74cba6eL32-R33): Added a new thumbprint (`F6EECCC7FF116889C2D5466AE7243D7AA7698689`) to the `$signatureThumbprint` array to ensure compatibility with updated EdgeDriver signatures.

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated