### PR TITLE
[windows] Suppress Progress Output and Disable Checksum Verification

### DIFF
--- a/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
+++ b/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
@@ -4,7 +4,6 @@
 ####################################################################################
 
 Install-Binary -Type MSI `
-    -Url "https://aka.ms/cosmosdb-emulator" `
-    -ExpectedSHA256Sum "BFBA892C3B9E27093A6AA36CD3C447D812CA32D6A4361DB64E753A63C90C2766"
+    -Url "https://aka.ms/cosmosdb-emulator"
 
 Invoke-PesterTests -TestFile "Tools" -TestName "Azure Cosmos DB Emulator"

--- a/images/windows/scripts/build/Install-WSL2.ps1
+++ b/images/windows/scripts/build/Install-WSL2.ps1
@@ -7,8 +7,7 @@ $downloadUrl =  Resolve-GithubReleaseAssetUrl `
     -UrlMatchPattern "wsl.*.x64.msi"
 
 Install-Binary -Type MSI `
-    -Url $downloadUrl `
-    -ExpectedSHA256Sum "AF1C1CBDB2F8E323A74224F200B3A4E25C0CF6DD5DAE7D0D14CB64109E429ED8"
+    -Url $downloadUrl
 
 Write-Host "Performing wsl --install --no-distribution"
 wsl.exe --install --no-distribution

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -198,6 +198,7 @@ function Invoke-DownloadWithRetry {
     for ($retries = 20; $retries -gt 0; $retries--) {
         try {
             $attemptStartTime = Get-Date
+            $ProgressPreference = 'SilentlyContinue'
             Invoke-WebRequest -Uri $Url -OutFile $Path -UseBasicParsing
             $attemptSeconds = [math]::Round(($(Get-Date) - $attemptStartTime).TotalSeconds, 2)
             Write-Host "Package downloaded in $attemptSeconds seconds"
@@ -794,7 +795,7 @@ function Get-ChecksumFromGithubRelease {
         [Parameter(Mandatory = $true)]
         [Alias("File", "Asset")]
         [string] $FileName,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [ValidateSet("SHA256", "SHA512")]
         [string] $HashType
     )
@@ -867,7 +868,7 @@ function Get-ChecksumFromUrl {
         [Parameter(Mandatory = $true)]
         [Alias("File", "Asset")]
         [string] $FileName,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [ValidateSet("SHA256", "SHA512")]
         [Alias("Type")]
         [string] $HashType


### PR DESCRIPTION
# Description
This Pr will 

1. Set $ProgressPreference = 'SilentlyContinue' in helper script to clean up console output
2. Removed checksum verification for WSL2 and Azure CosmosDB emulator setups to simplify installation

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
