### PR TITLE
[Ubuntu] Update minikube to latest and fix gpg handling with retries

### DIFF
--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -50,7 +50,6 @@ rm -f /etc/apt/sources.list.d/kubernetes.list /tmp/k8s_release.key
 # Install Helm
 curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
-# Temporarily pinning the version
 # Download minikube
 curl -fsSL -O https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 

--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -32,10 +32,10 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 
 # Temporarily pinning the version
 # Download minikube
-curl -fsSL -O https://storage.googleapis.com/minikube/releases/v1.34.0/minikube-linux-amd64
+curl -fsSL -O https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 
 # Supply chain security - minikube
-minikube_hash=$(get_checksum_from_github_release "kubernetes/minikube" "linux-amd64" "1.34.0" "SHA256")
+minikube_hash=$(get_checksum_from_github_release "kubernetes/minikube" "linux-amd64" "latest" "SHA256")
 use_checksum_comparison "minikube-linux-amd64" "${minikube_hash}"
 
 # Install minikube


### PR DESCRIPTION
# Description
This PR will 

1. Adds retry and check to safely download and use kubectl's GPG key
2. Upgrade the minikube version to the latest

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
