### PR TITLE
Update SHA256 checksum for Azure Cosmos DB Emulator installation

### DIFF
--- a/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
+++ b/images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1
@@ -5,6 +5,6 @@
 
 Install-Binary -Type MSI `
     -Url "https://aka.ms/cosmosdb-emulator" `
-    -ExpectedSHA256Sum "BFBA892C3B9E27093A6AA36CD3C447D812CA32D6A4361DB64E753A63C90C2766"
+    -ExpectedSHA256Sum "97F88D4CDE762DF334CC0D372BDC7A2A1F20E1904731ECE6C0CD1C46581D5DD0"
 
 Invoke-PesterTests -TestFile "Tools" -TestName "Azure Cosmos DB Emulator"


### PR DESCRIPTION
This pull request updates the SHA-256 checksum for the Azure Cosmos DB Emulator installer in the `Install-AzureCosmosDbEmulator.ps1` script to ensure the integrity of the downloaded file.

* [`images/windows/scripts/build/Install-AzureCosmosDbEmulator.ps1`](diffhunk://#diff-3fd42c6657bf2d49f7f32b9ada2c4f809369ff6c125d8539de640a76e0a57dd7L8-R8): Updated the `-ExpectedSHA256Sum` parameter to use the new checksum value `97F88D4CDE762DF334CC0D372BDC7A2A1F20E1904731ECE6C0CD1C46581D5DD0`.

Fixes #12426 