### PR TITLE
[Ubuntu] Replace WebClient with Invoke-WebRequest

### DIFF
--- a/images/ubuntu/scripts/helpers/Common.Helpers.psm1
+++ b/images/ubuntu/scripts/helpers/Common.Helpers.psm1
@@ -129,7 +129,7 @@ function Invoke-DownloadWithRetry {
     for ($retries = 20; $retries -gt 0; $retries--) {
         try {
             $attemptStartTime = Get-Date
-            (New-Object System.Net.WebClient).DownloadFile($Url, $DestinationPath)
+            Invoke-WebRequest -Uri $Url -Outfile $DestinationPath
             $attemptSeconds = [math]::Round(($(Get-Date) - $attemptStartTime).TotalSeconds, 2)
             Write-Host "Package downloaded in $attemptSeconds seconds"
             break


### PR DESCRIPTION
This PR replaces usage of the `WebClient` class with PowerShell’s native `Invoke-WebRequest` cmdlet.
https://learn.microsoft.com/en-us/dotnet/api/system.net.webclient?view=net-9.0#remarks

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
