### PR TITLE
[Ubuntu] Updated docker-compose to 2.37.1

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -250,7 +250,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.36.2",
+                "version": "2.37.1",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -210,7 +210,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.36.2",
+                "version": "2.37.1",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
# Description
This PR updates the docker-compose version to 2.37.1 in Ubuntu 22.04 and 24.04

This is to add the fix for a regression bug found on the previous version. 
https://github.com/docker/compose/issues/12892

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
