### PR TITLE
[macOS]install platform specific CodeQL bundle to all macOS images.

### DIFF
--- a/images/macos/scripts/build/install-codeql-bundle.sh
+++ b/images/macos/scripts/build/install-codeql-bundle.sh
@@ -30,7 +30,7 @@ bundle_tag_name="codeql-bundle-v$bundle_version"
 echo "Downloading CodeQL bundle $bundle_version..."
 # Note that this is the all-platforms CodeQL bundle, to support scenarios where customers run
 # different operating systems within containers.
-archive_path=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle.tar.gz")
+archive_path=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle-osx64.tar.gz")
 
 codeql_toolcache_path=$AGENT_TOOLSDIRECTORY/CodeQL/$bundle_version/x64
 mkdir -p "$codeql_toolcache_path" 


### PR DESCRIPTION
# Description
1. Install platform specific CodeQL bundle to all macOS images.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
