### PR TITLE
Fix readme to indicate jq is 1.7.1

### DIFF
--- a/images/ubuntu/Ubuntu2404-Readme.md
+++ b/images/ubuntu/Ubuntu2404-Readme.md
@@ -79,7 +79,7 @@ to accomplish this.
 - Git LFS 3.6.1
 - Git-ftp 1.6.0
 - Haveged 1.9.14
-- jq 1.7
+- jq 1.7.1
 - Kind 0.29.0
 - Kubectl 1.33.1
 - Kustomize 5.6.0


### PR DESCRIPTION
# Description
Update readme to match shipping version and other readmes

Other readmes show the triple (https://github.com/search?q=repo%3Aactions%2Frunner-images+jq+language%3AMarkdown&type=code&l=Markdown):
https://github.com/actions/runner-images/blob/c471ba13993a4f5cf9979179d06da69fd7d31038/images/windows/Windows2025-Readme.md?plain=1#L73
https://github.com/actions/runner-images/blob/c471ba13993a4f5cf9979179d06da69fd7d31038/images/windows/Windows2019-Readme.md?plain=1#L73
https://github.com/actions/runner-images/blob/c471ba13993a4f5cf9979179d06da69fd7d31038/images/windows/Windows2022-Readme.md?plain=1#L73

And this readme says elsewhere that it's actually 1.7.1:
https://github.com/actions/runner-images/blob/c471ba13993a4f5cf9979179d06da69fd7d31038/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L280



#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
