### PR TITLE
[Windows-2025] Enable permission inheritance for the C: drive

### DIFF
--- a/images/windows/scripts/build/Configure-System.ps1
+++ b/images/windows/scripts/build/Configure-System.ps1
@@ -36,6 +36,14 @@ if ($LASTEXITCODE -ne 0) {
     throw "Failed to grant Users full control of $env:SystemRoot\Temp"
 }
 
+# Enable inheritance for the entire C:\ drive
+if (Test-IsWin25) {
+    cmd /c "icacls C:\ /inheritance:e /c /q 2>&1" | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to enable inheritance for C:\ drive"
+    }
+}
+
 # Registry settings
 $registrySettings = @(
     @{Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU"; Name = "AUOptions"; Value = 1; PropertyType = "DWORD" }


### PR DESCRIPTION
# Description
This pull request enables inheritance for the entire `C: drive in the Windows-2025 image.

#### Related issue:
https://github.com/github/c2c-actions-support/issues/4894

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
