### PR TITLE
Validate authenticode signature using the certificate Subject

### DIFF
--- a/images/windows/scripts/build/Install-AWSTools.ps1
+++ b/images/windows/scripts/build/Install-AWSTools.ps1
@@ -11,7 +11,7 @@ Install-ChocoPackage awscli
 Install-Binary `
     -Url "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe" `
     -InstallArgs ("/silent", "/install") `
-    -ExpectedSignature "CFC0CE0547A698E5F3FA78F819654CE016D76464"
+    -ExpectedSubject 'CN="Amazon Web Services, Inc.", OU=AWS Systems Manager, O="Amazon Web Services, Inc.", L=Seattle, S=Washington, C=US, SERIALNUMBER=4152954, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US'
 $env:Path = $env:Path + ";$env:ProgramFiles\Amazon\SessionManagerPlugin\bin"
 
 # Install AWS SAM CLI

--- a/images/windows/scripts/build/Install-AzureCli.ps1
+++ b/images/windows/scripts/build/Install-AzureCli.ps1
@@ -15,7 +15,7 @@ New-Item -ItemType 'Directory' -Path $azureCliExtensionPath | Out-Null
 
 Install-Binary -Type MSI `
     -Url 'https://aka.ms/installazurecliwindowsx64' `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Update-Environment
 

--- a/images/windows/scripts/build/Install-AzureCli.ps1
+++ b/images/windows/scripts/build/Install-AzureCli.ps1
@@ -15,7 +15,7 @@ New-Item -ItemType 'Directory' -Path $azureCliExtensionPath | Out-Null
 
 Install-Binary -Type MSI `
     -Url 'https://aka.ms/installazurecliwindowsx64' `
-    -ExpectedSignature '245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D'
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 Update-Environment
 

--- a/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
+++ b/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
@@ -18,10 +18,10 @@ Write-Host "Installing BizTalk Project Build Component..."
 Install-Binary `
     -LocalPath "$setupPath\Bootstrap.msi" `
     -ExtraInstallArgs ("/l*v", "$setupPath\bootstrap.log") `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 Install-Binary `
     -LocalPath "$setupPath\BuildComponentSetup.msi" `
     -ExtraInstallArgs ("/l*v", "$setupPath\buildComponentSetup.log") `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Invoke-PesterTests -TestFile "BizTalk" -TestName "BizTalk Build Component Setup"

--- a/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
+++ b/images/windows/scripts/build/Install-BizTalkBuildComponent.ps1
@@ -4,7 +4,6 @@
 ################################################################################
 
 $downloadUrl = "https://aka.ms/BuildComponentSetup.EN"
-$signatureThumbprint = "8740DF4ACB749640AD318E4BE842F72EC651AD80"
 
 Write-Host "Downloading BizTalk Project Build Component archive..."
 $zipFile = Invoke-DownloadWithRetry $downloadUrl
@@ -19,10 +18,10 @@ Write-Host "Installing BizTalk Project Build Component..."
 Install-Binary `
     -LocalPath "$setupPath\Bootstrap.msi" `
     -ExtraInstallArgs ("/l*v", "$setupPath\bootstrap.log") `
-    -ExpectedSignature $signatureThumbprint
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 Install-Binary `
     -LocalPath "$setupPath\BuildComponentSetup.msi" `
     -ExtraInstallArgs ("/l*v", "$setupPath\buildComponentSetup.log") `
-    -ExpectedSignature $signatureThumbprint
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 Invoke-PesterTests -TestFile "BizTalk" -TestName "BizTalk Build Component Setup"

--- a/images/windows/scripts/build/Install-Chocolatey.ps1
+++ b/images/windows/scripts/build/Install-Chocolatey.ps1
@@ -13,9 +13,8 @@ Add-MachinePathItem 'C:\ProgramData\Chocolatey\bin'
 Update-Environment
 
 # Verify and run choco installer
-$signatureThumbprint = "B009C875F4E10FFBC62B785BAF4FC4D6BC2D5711"
 $installScriptPath = Invoke-DownloadWithRetry 'https://chocolatey.org/install.ps1'
-Test-FileSignature -Path $installScriptPath -ExpectedThumbprint $signatureThumbprint
+Test-FileSignature -Path $installScriptPath -ExpectedSubject 'CN="Chocolatey Software, Inc", O="Chocolatey Software, Inc", L=Topeka, S=Kansas, C=US'
 Invoke-Expression $installScriptPath
 
 # Turn off confirmation

--- a/images/windows/scripts/build/Install-Chrome.ps1
+++ b/images/windows/scripts/build/Install-Chrome.ps1
@@ -6,7 +6,7 @@
 # Download and install latest Chrome browser
 Install-Binary `
     -Url 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi' `
-    -ExpectedSignature '607A3EDAA64933E94422FC8F0C80388E0590986C'
+    -ExpectedSubject 'CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US, SERIALNUMBER=3582691, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US'
 
 # Prepare firewall rules
 Write-Host "Adding the firewall rule for Google update blocking..."

--- a/images/windows/scripts/build/Install-CloudFoundryCli.ps1
+++ b/images/windows/scripts/build/Install-CloudFoundryCli.ps1
@@ -20,7 +20,6 @@ Expand-7ZipArchive -Path $cloudFoundryArchPath -DestinationPath $cloudFoundryCli
 Add-MachinePathItem $cloudFoundryCliPath
 
 # Validate cf signature
-$cloudFoundrySignatureThumbprint = "2C6B2F1562698503A6E4A25F2DF058E12E23A190"
-Test-FileSignature -Path "$cloudFoundryCliPath\cf.exe" -ExpectedThumbprint $cloudFoundrySignatureThumbprint
+Test-FileSignature -Path "$cloudFoundryCliPath\cf.exe" -ExpectedSubject 'CN="LF Projects, LLC", O="LF Projects, LLC", L=Wilmington, S=Delaware, C=US'
 
 Invoke-PesterTests -TestFile "CLI.Tools" -TestName "CloudFoundry CLI"

--- a/images/windows/scripts/build/Install-DACFx.ps1
+++ b/images/windows/scripts/build/Install-DACFx.ps1
@@ -5,6 +5,6 @@
 
 Install-Binary -Type MSI `
     -Url 'https://aka.ms/dacfx-msi' `
-    -ExpectedSignature '8F985BE8FD256085C90A95D3C74580511A1DB975'
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 Invoke-PesterTests -TestFile "Tools" -TestName "DACFx"

--- a/images/windows/scripts/build/Install-DACFx.ps1
+++ b/images/windows/scripts/build/Install-DACFx.ps1
@@ -5,6 +5,6 @@
 
 Install-Binary -Type MSI `
     -Url 'https://aka.ms/dacfx-msi' `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Invoke-PesterTests -TestFile "Tools" -TestName "DACFx"

--- a/images/windows/scripts/build/Install-EdgeDriver.ps1
+++ b/images/windows/scripts/build/Install-EdgeDriver.ps1
@@ -27,7 +27,7 @@ Write-Host "Expand Microsoft Edge WebDriver archive..."
 Expand-7ZipArchive -Path $archivePath -DestinationPath $edgeDriverPath
 
 #Validate the EdgeDriver signature
-Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedSubject "CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Write-Host "Setting the environment variables..."
 [Environment]::SetEnvironmentVariable("EdgeWebDriver", $EdgeDriverPath, "Machine")

--- a/images/windows/scripts/build/Install-EdgeDriver.ps1
+++ b/images/windows/scripts/build/Install-EdgeDriver.ps1
@@ -27,13 +27,7 @@ Write-Host "Expand Microsoft Edge WebDriver archive..."
 Expand-7ZipArchive -Path $archivePath -DestinationPath $edgeDriverPath
 
 #Validate the EdgeDriver signature
-$signatureThumbprint = @(
-                         "7920AC8FB05E0FFFE21E8FF4B4F03093BA6AC16E",
-                         "0BD8C56733FDCC06F8CB919FF5A200E39B1ACF71",
-                         "F6EECCC7FF116889C2D5466AE7243D7AA7698689",
-                         "6ACE61BAE3F09F4DD2697806D73E022CBFE70EB4"
-                        )
-Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedThumbprint $signatureThumbprint
+Test-FileSignature -Path "$edgeDriverPath\msedgedriver.exe" -ExpectedSubject "CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
 
 Write-Host "Setting the environment variables..."
 [Environment]::SetEnvironmentVariable("EdgeWebDriver", $EdgeDriverPath, "Machine")

--- a/images/windows/scripts/build/Install-Firefox.ps1
+++ b/images/windows/scripts/build/Install-Firefox.ps1
@@ -53,8 +53,7 @@ Write-Host "Expand Gecko WebDriver archive..."
 Expand-7ZipArchive -Path $geckoDriverArchPath -DestinationPath $geckoDriverPath
 
 # Validate Gecko WebDriver signature
-$geckoDriverSignatureThumbprint = "6663D5C4FDAF9EFD5F823A26C9C410DC9928C44A"
-Test-FileSignature -Path "$geckoDriverPath/geckodriver.exe" -ExpectedThumbprint $geckoDriverSignatureThumbprint
+Test-FileSignature -Path "$geckoDriverPath/geckodriver.exe" -ExpectedSubject 'CN=Mozilla Corporation, OU=Firefox Engineering Operations, O=Mozilla Corporation, L=San Francisco, S=California, C=US'
 
 Write-Host "Setting the environment variables..."
 Add-MachinePathItem -PathItem $geckoDriverPath

--- a/images/windows/scripts/build/Install-GoogleCloudCLI.ps1
+++ b/images/windows/scripts/build/Install-GoogleCloudCLI.ps1
@@ -7,6 +7,6 @@
 Install-Binary `
   -Url 'https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe' `
   -InstallArgs @("/S", "/allusers", "/noreporting") `
-  -ExpectedSignature '607A3EDAA64933E94422FC8F0C80388E0590986C'
+  -ExpectedSubject 'CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US, SERIALNUMBER=3582691, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US'
 
 Invoke-PesterTests -TestFile "Tools" -TestName "GoogleCloudCLI"

--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -24,7 +24,7 @@ $latestVersion = $minorVersions[0]
 Install-Binary `
     -Url "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-$latestVersion-signed.msi" `
     -ExtraInstallArgs @('TARGETDIR=C:\PROGRA~1\MongoDB ADDLOCAL=ALL') `
-    -ExpectedSignature $toolsetContent.mongodb.signature
+    -ExpectedSubject 'CN="MONGODB, INC.", O="MONGODB, INC.", L=New York, S=New York, C=US'
 
 # Add mongodb to the PATH
 $mongoPath = (Get-CimInstance Win32_Service -Filter "Name LIKE 'mongodb'").PathName
@@ -51,7 +51,7 @@ if (Test-IsWin25) {
     Install-Binary -Type MSI `
         -Url $mongoshDownloadUrl `
         -ExtraInstallArgs @('ALLUSERS=1') `
-        -ExpectedSignature 'A5BBE2A6DA1D2A6E057EF870267E6A91E4D56BAA'
+        -ExpectedSubject 'CN="MongoDB, Inc.", O="MongoDB, Inc.", L=New York, S=New York, C=US'
 }
 
 Invoke-PesterTests -TestFile "Databases" -TestName "MongoDB"

--- a/images/windows/scripts/build/Install-MysqlCli.ps1
+++ b/images/windows/scripts/build/Install-MysqlCli.ps1
@@ -30,7 +30,7 @@ $mysqlVersionUrl = "https://cdn.mysql.com/Downloads/MySQL-${mysqlVersionMajorMin
 
 Install-Binary `
     -Url $mysqlVersionUrl `
-    -ExpectedSignature (Get-ToolsetContent).mysql.signature
+    -ExpectedSubject 'CN="Oracle America, Inc.", O="Oracle America, Inc.", L=Redwood City, S=California, C=US, SERIALNUMBER=2101822, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US'
 
 # Adding mysql in system environment path
 $mysqlPath = $(Get-ChildItem -Path "C:\PROGRA~1\MySQL" -Directory)[0].FullName

--- a/images/windows/scripts/build/Install-PostgreSQL.ps1
+++ b/images/windows/scripts/build/Install-PostgreSQL.ps1
@@ -66,7 +66,7 @@ $installerArgs = @("--install_runtimes 0", "--superpassword root", "--enable_acl
 Install-Binary `
     -Url $installerUrl `
     -InstallArgs $installerArgs `
-    -ExpectedSignature (Get-ToolsetContent).postgresql.signature `
+    -ExpectedSubject 'CN=EnterpriseDB Corporation, O=EnterpriseDB Corporation, S=Massachusetts, C=US' `
     -InstallerLogPath "$env:TEMP\**\install-postgresql.log"
 
 # Get Path to pg_ctl.exe

--- a/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
+++ b/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
@@ -6,4 +6,4 @@
 Install-Binary -Type MSI `
     -Url "https://go.microsoft.com/fwlink/?linkid=2242656" `
     -ExtraInstallArgs @("ADDLOCAL=ALL", "IACCEPTMSOLEDBSQLLICENSETERMS=YES") `
-    -ExpectedSignature '6E78B3DCE2998F6C2457C3E54DA90A01034916AE'
+    -ExpectedSubject $script:MicrosoftPublisherSubject

--- a/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
+++ b/images/windows/scripts/build/Install-SQLOLEDBDriver.ps1
@@ -6,4 +6,4 @@
 Install-Binary -Type MSI `
     -Url "https://go.microsoft.com/fwlink/?linkid=2242656" `
     -ExtraInstallArgs @("ADDLOCAL=ALL", "IACCEPTMSOLEDBSQLLICENSETERMS=YES") `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)

--- a/images/windows/scripts/build/Install-SQLPowerShellTools.ps1
+++ b/images/windows/scripts/build/Install-SQLPowerShellTools.ps1
@@ -8,12 +8,12 @@ $baseUrl = "https://download.microsoft.com/download/B/1/7/B1783FE9-717B-4F78-A39
 # install required MSIs
 Install-Binary `
     -Url "${baseUrl}/SQLSysClrTypes.msi" `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Install-Binary `
     -Url "${baseUrl}/SharedManagementObjects.msi" `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Install-Binary `
     -Url "${baseUrl}/PowerShellTools.msi" `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)

--- a/images/windows/scripts/build/Install-SQLPowerShellTools.ps1
+++ b/images/windows/scripts/build/Install-SQLPowerShellTools.ps1
@@ -4,17 +4,16 @@
 ################################################################################
 
 $baseUrl = "https://download.microsoft.com/download/B/1/7/B1783FE9-717B-4F78-A39A-A2E27E3D679D/ENU/x64"
-$signatureThumbrint = "9ACA9419E53D3C9E56396DD2335FF683A8B0B8F3"
 
 # install required MSIs
 Install-Binary `
     -Url "${baseUrl}/SQLSysClrTypes.msi" `
-    -ExpectedSignature $signatureThumbrint
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 Install-Binary `
     -Url "${baseUrl}/SharedManagementObjects.msi" `
-    -ExpectedSignature $signatureThumbrint
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 Install-Binary `
     -Url "${baseUrl}/PowerShellTools.msi" `
-    -ExpectedSignature $signatureThumbrint
+    -ExpectedSubject $script:MicrosoftPublisherSubject

--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -50,7 +50,7 @@ if (Test-IsWin19) {
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/p/?linkid=2196241' `
         -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-        -ExpectedSubject $script:MicrosoftPublisherSubject
+        -ExpectedSubject $(Get-MicrosoftPublisher)
 }
 
 if (Test-IsWin22) {
@@ -58,7 +58,7 @@ if (Test-IsWin22) {
     Install-Binary -Type EXE `
     -Url 'https://go.microsoft.com/fwlink/p/?LinkID=2033908' `
     -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 }
 
 if (-not (Test-IsWin19)) {
@@ -66,7 +66,7 @@ if (-not (Test-IsWin19)) {
      Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/?linkid=2286561' `
         -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-        -ExpectedSubject $script:MicrosoftPublisherSubject
+        -ExpectedSubject $(Get-MicrosoftPublisher)
 }
 
 Invoke-PesterTests -TestFile "VisualStudio"

--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -11,8 +11,7 @@ if (Test-IsWin19) {
         -Edition $vsToolset.edition `
         -Channel $vsToolset.channel `
         -RequiredComponents $vsToolset.workloads `
-        -ExtraArgs "--allWorkloads --includeRecommended --remove Component.CPython3.x64" `
-        -SignatureThumbprint $vsToolset.signature
+        -ExtraArgs "--allWorkloads --includeRecommended --remove Component.CPython3.x64"
 }
 
 if ( (Test-IsWin22) -or (Test-IsWin25) ) {
@@ -23,8 +22,7 @@ if ( (Test-IsWin22) -or (Test-IsWin25) ) {
         -Channel $vsToolset.channel `
         -InstallChannel $vsToolset.installChannel `
         -RequiredComponents $vsToolset.workloads `
-        -ExtraArgs "--allWorkloads --includeRecommended --remove Component.CPython3.x64" `
-        -SignatureThumbprint $vsToolset.signature
+        -ExtraArgs "--allWorkloads --includeRecommended --remove Component.CPython3.x64"
 }
 
 # Find the version of VS installed for this instance
@@ -46,13 +44,13 @@ if (Test-IsWin19) {
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/p/?LinkId=838916' `
         -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit") `
-        -ExpectedSignature 'C91545B333C52C4465DE8B90A3FAF4E1D9C58DFA'
+        -ExpectedSubject 'CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'
 
     # Install Windows 11 SDK version 10.0.22621.0
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/p/?linkid=2196241' `
         -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-        -ExpectedSignature 'E4C5C5FCDB68B930EE4E19BC25D431EF6D864C51'
+        -ExpectedSubject $script:MicrosoftPublisherSubject
 }
 
 if (Test-IsWin22) {
@@ -60,7 +58,7 @@ if (Test-IsWin22) {
     Install-Binary -Type EXE `
     -Url 'https://go.microsoft.com/fwlink/p/?LinkID=2033908' `
     -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-    -ExpectedSignature '7535269B94C1FEA4A5EF6D808E371DA242F27936'
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 }
 
 if (-not (Test-IsWin19)) {
@@ -68,7 +66,7 @@ if (-not (Test-IsWin19)) {
      Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/?linkid=2286561' `
         -InstallArgs @("/q", "/norestart", "/ceip off", "/features OptionId.UWPManaged OptionId.UWPCPP OptionId.UWPLocalized OptionId.DesktopCPPx86 OptionId.DesktopCPPx64 OptionId.DesktopCPParm64") `
-        -ExpectedSignature '573EF451A68C33FB904346D44551BEF3BB5BBF68'
+        -ExpectedSubject $script:MicrosoftPublisherSubject
 }
 
 Invoke-PesterTests -TestFile "VisualStudio"

--- a/images/windows/scripts/build/Install-WDK.ps1
+++ b/images/windows/scripts/build/Install-WDK.ps1
@@ -9,15 +9,13 @@ if (Test-IsWin19) {
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/?linkid=2173743' `
         -InstallArgs @("/features", "+", "/quiet") `
-        -ExpectedSignature '44796EB5BD439B4BFB078E1DC2F8345AE313CBB1'
+        -ExpectedSubject $script:MicrosoftPublisherSubject
 
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2166289"
-    $wdkSignatureThumbprint = "914A09C2E02C696AF394048BCB8D95449BCD5B9E"
     $wdkExtensionPath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"
 } elseif (Test-IsWin22) {
     # SDK is available through Visual Studio
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2294834"
-    $wdkSignatureThumbprint = "7920AC8FB05E0FFFE21E8FF4B4F03093BA6AC16E"
 } else {
     throw "Invalid version of Visual Studio is found. Either 2019 or 2022 are required"
 }
@@ -26,7 +24,7 @@ if (Test-IsWin19) {
 Install-Binary -Type EXE `
     -Url $wdkUrl `
     -InstallArgs @("/features", "+", "/quiet") `
-    -ExpectedSignature $wdkSignatureThumbprint
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 if (Test-IsWin19){
     # Need to install the VSIX to get the build targets when running VSBuild

--- a/images/windows/scripts/build/Install-WDK.ps1
+++ b/images/windows/scripts/build/Install-WDK.ps1
@@ -9,7 +9,7 @@ if (Test-IsWin19) {
     Install-Binary -Type EXE `
         -Url 'https://go.microsoft.com/fwlink/?linkid=2173743' `
         -InstallArgs @("/features", "+", "/quiet") `
-        -ExpectedSubject $script:MicrosoftPublisherSubject
+        -ExpectedSubject $(Get-MicrosoftPublisher)
 
     $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2166289"
     $wdkExtensionPath = "C:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix"
@@ -24,7 +24,7 @@ if (Test-IsWin19) {
 Install-Binary -Type EXE `
     -Url $wdkUrl `
     -InstallArgs @("/features", "+", "/quiet") `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 if (Test-IsWin19){
     # Need to install the VSIX to get the build targets when running VSBuild

--- a/images/windows/scripts/build/Install-WebPlatformInstaller.ps1
+++ b/images/windows/scripts/build/Install-WebPlatformInstaller.ps1
@@ -5,6 +5,6 @@
 
 Install-Binary -Type MSI `
     -Url 'https://go.microsoft.com/fwlink/?LinkId=287166' `
-    -ExpectedSignature 'C3A3D43788E7ABCD287CB4F5B6583043774F99D2'
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 Invoke-PesterTests -TestFile "Tools" -TestName "WebPlatformInstaller"

--- a/images/windows/scripts/build/Install-WebPlatformInstaller.ps1
+++ b/images/windows/scripts/build/Install-WebPlatformInstaller.ps1
@@ -5,6 +5,6 @@
 
 Install-Binary -Type MSI `
     -Url 'https://go.microsoft.com/fwlink/?LinkId=287166' `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Invoke-PesterTests -TestFile "Tools" -TestName "WebPlatformInstaller"

--- a/images/windows/scripts/build/Install-WinAppDriver.ps1
+++ b/images/windows/scripts/build/Install-WinAppDriver.ps1
@@ -11,6 +11,6 @@ $downloadUrl = Resolve-GithubReleaseAssetUrl `
 
 Install-Binary `
     -Url $downloadUrl `
-    -ExpectedSubject $script:MicrosoftPublisherSubject
+    -ExpectedSubject $(Get-MicrosoftPublisher)
 
 Invoke-PesterTests -TestFile "WinAppDriver" -TestName "WinAppDriver"

--- a/images/windows/scripts/build/Install-WinAppDriver.ps1
+++ b/images/windows/scripts/build/Install-WinAppDriver.ps1
@@ -11,6 +11,6 @@ $downloadUrl = Resolve-GithubReleaseAssetUrl `
 
 Install-Binary `
     -Url $downloadUrl `
-    -ExpectedSignature '2485A7AFA98E178CB8F30C9838346B514AEA4769'
+    -ExpectedSubject $script:MicrosoftPublisherSubject
 
 Invoke-PesterTests -TestFile "WinAppDriver" -TestName "WinAppDriver"

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -21,6 +21,7 @@ Export-ModuleMember -Function @(
 Export-ModuleMember -Function @(
     'Install-Binary'
     'Invoke-DownloadWithRetry'
+    'Get-MicrosoftPublisher'
     'Get-ToolsetContent'
     'Get-TCToolPath'
     'Get-TCToolVersionPath'

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -1,8 +1,6 @@
 [CmdletBinding()]
 param()
 
-$script:MicrosoftPublisherSubject = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-
 . $PSScriptRoot\AndroidHelpers.ps1
 Export-ModuleMember -Function @(
     'Get-AndroidPackages'

--- a/images/windows/scripts/helpers/ImageHelpers.psm1
+++ b/images/windows/scripts/helpers/ImageHelpers.psm1
@@ -1,6 +1,8 @@
 [CmdletBinding()]
 param()
 
+$script:MicrosoftPublisherSubject = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+
 . $PSScriptRoot\AndroidHelpers.ps1
 Export-ModuleMember -Function @(
     'Get-AndroidPackages'

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -1051,3 +1051,12 @@ function Update-Environment {
         }
     }
 }
+
+function Get-MicrosoftPublisher {
+    <#
+    .SYNOPSIS
+        Returns well-known subject for the Microsoft signing certificate
+    #>
+
+    return "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+}

--- a/images/windows/scripts/helpers/InstallHelpers.ps1
+++ b/images/windows/scripts/helpers/InstallHelpers.ps1
@@ -21,8 +21,8 @@ function Install-Binary {
     .PARAMETER ExtraInstallArgs
         Additional arguments that will be passed to the installer. Cannot be used together with InstallArgs.
 
-    .PARAMETER ExpectedSignature
-        The expected signature of the binary. If specified, the binary's signature is checked before installation.
+    .PARAMETER ExpectedSubject
+        The expected signature subject of the binary. If specified, the binary's signature is checked before installation.
 
     .PARAMETER ExpectedSHA256Sum
         The expected SHA256 sum of the binary. If specified, the binary's SHA256 sum is checked before installation.
@@ -35,7 +35,7 @@ function Install-Binary {
         This is only displayed when the installation fails.
 
     .EXAMPLE
-        Install-Binary -Url "https://go.microsoft.com/fwlink/p/?linkid=2083338" -Type EXE -InstallArgs ("/features", "+", "/quiet") -ExpectedSignature "A5C7D5B7C838D5F89DDBEDB85B2C566B4CDA881F"
+        Install-Binary -Url "https://go.microsoft.com/fwlink/p/?linkid=2083338" -Type EXE -InstallArgs ("/features", "+", "/quiet") -ExpectedSubject "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     #>
 
     Param
@@ -48,7 +48,7 @@ function Install-Binary {
         [String] $Type,
         [String[]] $InstallArgs,
         [String[]] $ExtraInstallArgs,
-        [String[]] $ExpectedSignature,
+        [String] $ExpectedSubject,
         [String] $ExpectedSHA256Sum,
         [String] $ExpectedSHA512Sum,
         [String] $InstallerLogPath
@@ -78,11 +78,11 @@ function Install-Binary {
         $filePath = Invoke-DownloadWithRetry -Url $Url -Path "${env:TEMP_DIR}\$fileName"
     }
 
-    if ($PSBoundParameters.ContainsKey('ExpectedSignature')) {
-        if ($ExpectedSignature) {
-            Test-FileSignature -Path $filePath -ExpectedThumbprint $ExpectedSignature
+    if ($PSBoundParameters.ContainsKey('ExpectedSubject')) {
+        if ($ExpectedSubject) {
+            Test-FileSignature -Path $filePath -ExpectedSubject $ExpectedSubject
         } else {
-            throw "ExpectedSignature parameter is specified, but no signature is provided."
+            throw "ExpectedSubject parameter is specified, but no value is provided."
         }
     }
 
@@ -975,28 +975,28 @@ function Test-FileSignature {
         Tests the file signature of a given file.
 
     .DESCRIPTION
-        The Test-FileSignature function checks the signature of a file against the expected thumbprints. 
+        The Test-FileSignature function checks the signature of a file against the expected subject. 
         It uses the Get-AuthenticodeSignature cmdlet to retrieve the signature information of the file.
-        If the signature status is not valid or the thumbprint does not match the expected thumbprints, an exception is thrown.
+        If the signature status is not valid or the subject of the signing certificate does not match the expected subject, an exception is thrown.
 
     .PARAMETER Path
         Specifies the path of the file to test.
 
-    .PARAMETER ExpectedThumbprint
-        Specifies the expected thumbprints to match against the file's signature.
+    .PARAMETER ExpectedSubject
+        Specifies the expected subject to match against the file's signature.
 
     .EXAMPLE
-        Test-FileSignature -Path "C:\Path\To\File.exe" -ExpectedThumbprint "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0"
+        Test-FileSignature -Path "C:\Path\To\File.exe" -ExpectedSubject "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
 
-        This example tests the signature of the file "C:\Path\To\File.exe" against the expected thumbprint "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0".
+        This example tests the signature of the file "C:\Path\To\File.exe" against the expected subject "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US".
 
     #>
 
     param(
         [Parameter(Mandatory = $true, Position = 0)]
         [string] $Path,
-        [Parameter(Mandatory = $true)]
-        [string[]] $ExpectedThumbprint
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string] $ExpectedSubject
     )
 
     $signature = Get-AuthenticodeSignature $Path
@@ -1005,19 +1005,15 @@ function Test-FileSignature {
         throw "Signature status is not valid. Status: $($signature.Status)"
     }
 
-    foreach ($thumbprint in $ExpectedThumbprint) {
-        if ($signature.SignerCertificate.Thumbprint.Contains($thumbprint)) {
-            Write-Output "Signature for $Path is valid"
-            $signatureMatched = $true
-            return
-        }
+    if ($signature.SignerCertificate.EnhancedKeyUsageList.FriendlyName -notcontains "Code Signing") {
+        throw "Certificate is not for code signing. Key usage: $($signature.SignerCertificate.EnhancedKeyUsageList)"
     }
 
-    if ($signatureMatched) {
-        Write-Output "Signature for $Path is valid"
-    } else {
-        throw "Signature thumbprint do not match expected."
+    if ($signature.SignerCertificate.Subject -ne $ExpectedSubject) {
+        throw "Certificate subject does not match. Subject: $($signature.SignerCertificate.Subject)"
     }
+
+    Write-Output "Signature for $Path is valid"
 }
 
 function Update-Environment {

--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -51,7 +51,7 @@ Function Install-VisualStudio {
     $bootstrapperFilePath = Invoke-DownloadWithRetry $BootstrapperUrl
 
     # Verify that the bootstrapper is signed by Microsoft
-    Test-FileSignature -Path $bootstrapperFilePath -ExpectedThumbprint $SignatureThumbprint
+    Test-FileSignature -Path $bootstrapperFilePath -ExpectedSubject $script:MicrosoftPublisherSubject
 
     try {
         $responseData = @{

--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -32,8 +32,7 @@ Function Install-VisualStudio {
         [Parameter(Mandatory)] [String] $Channel,
         [String] $InstallChannel = "",
         [Parameter(Mandatory)] [String[]] $RequiredComponents,
-        [String] $ExtraArgs = "",
-        [Parameter(Mandatory)] [String[]] $SignatureThumbprint
+        [String] $ExtraArgs = ""
     )
     
     

--- a/images/windows/scripts/helpers/VisualStudioHelpers.ps1
+++ b/images/windows/scripts/helpers/VisualStudioHelpers.ps1
@@ -51,7 +51,7 @@ Function Install-VisualStudio {
     $bootstrapperFilePath = Invoke-DownloadWithRetry $BootstrapperUrl
 
     # Verify that the bootstrapper is signed by Microsoft
-    Test-FileSignature -Path $bootstrapperFilePath -ExpectedSubject $script:MicrosoftPublisherSubject
+    Test-FileSignature -Path $bootstrapperFilePath -ExpectedSubject $(Get-MicrosoftPublisher)
 
     try {
         $responseData = @{

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -218,10 +218,6 @@
         "subversion" : "16",
         "edition" : "Enterprise",
         "channel": "release",
-        "signature": [
-                      "8F985BE8FD256085C90A95D3C74580511A1DB975",
-                      "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D" 
-                    ],
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",
@@ -426,12 +422,10 @@
         "version": "3.9"
     },
     "mysql": {
-        "version": "5.7",
-        "signature": "DD34D7C71F160972DE0CE25B695A0D6A9C95BD91"
+        "version": "5.7"
     },
     "mongodb": {
-        "version": "5.0",
-        "signature": "A5BBE2A6DA1D2A6E057EF870267E6A91E4D56BAA"
+        "version": "5.0"
     },
     "nsis": {
         "version": "3.10"
@@ -443,8 +437,7 @@
         "version": "18"
     },
     "postgresql": {
-        "version": "14",
-        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
+        "version": "14"
     },
     "kotlin": {
         "version": "2.1.10",

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -156,10 +156,6 @@
         "edition" : "Enterprise",
         "channel": "release",
         "installChannel": "624045707_-738089513",
-        "signature": [
-            "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D",
-            "8F985BE8FD256085C90A95D3C74580511A1DB975"
-        ],
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",
@@ -346,12 +342,10 @@
         "version": "3.9"
     },
     "mysql": {
-        "version": "8.0",
-        "signature": "E8A8C17382A6DE62A3B443565E4A96843F834656"
+        "version": "8.0"
     },
     "mongodb": {
-        "version": "5.0",
-        "signature": "A5BBE2A6DA1D2A6E057EF870267E6A91E4D56BAA"
+        "version": "5.0"
     },
     "nsis": {
         "version": "3.10"
@@ -363,8 +357,7 @@
         "version": "8.4"
     },
     "postgresql": {
-        "version": "14",
-        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
+        "version": "14"
     },
     "kotlin": {
         "version": "2.1.10",

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -138,10 +138,6 @@
         "edition" : "Enterprise",
         "channel": "release",
         "installChannel": "624045707_-738089513",
-        "signature": [
-            "245D262748012A4FE6CE8BA6C951A4C4AFBC3E5D",
-            "8F985BE8FD256085C90A95D3C74580511A1DB975"
-        ],
         "workloads": [
             "Component.Dotfuscator",
             "Component.Linux.CMake",
@@ -310,12 +306,10 @@
         "version": "3.9"
     },
     "mysql": {
-        "version": "8.0",
-        "signature": "E8A8C17382A6DE62A3B443565E4A96843F834656"
+        "version": "8.0"
     },
     "mongodb": {
-        "version": "7.0",
-        "signature": "A5BBE2A6DA1D2A6E057EF870267E6A91E4D56BAA"
+        "version": "7.0"
     },
     "llvm": {
         "version": "20"
@@ -324,8 +318,7 @@
         "version": "8.4"
     },
     "postgresql": {
-        "version": "17",
-        "signature": "698BA51AA27CC31282AACA5055E4B9190BC6C0E9"
+        "version": "17"
     },
     "kotlin": {
         "version": "2.1.10",


### PR DESCRIPTION
# Description

This PR switches verification of authenticode signature to use the certificate subject instead of the thumbprint. This prevents  occasional verification failures caused by certficate renewal.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue: https://github.com/github/hosted-runners-images/issues/111

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
