### PR TITLE
[Ubuntu] Pinning Pulumi stable version 

### DIFF
--- a/images/ubuntu/scripts/build/install-pulumi.sh
+++ b/images/ubuntu/scripts/build/install-pulumi.sh
@@ -9,7 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 # Dowload Pulumi
-version=$(curl -fsSL "https://www.pulumi.com/latest-version")
+version="3.178.0"
 download_url="https://get.pulumi.com/releases/sdk/pulumi-v${version}-linux-x64.tar.gz"
 archive_path=$(download_with_retry "$download_url")
 


### PR DESCRIPTION
This PR pins the pulumi version to `3.178.0`
The latest version of pulumi is changed to `3.178.0` from `3.180.0` and it is stable.
Repo:(https://github.com/pulumi/pulumi/releases/tag/v3.178.0)
Since, the latest version has been downgraded , builds are failing, Hence stable version is pinned.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
