### PR TITLE
[Windows 2022] Update `strawberryperl` to `5.40.2.2`

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -317,7 +317,7 @@
             { "name": "packer" },
             {
                 "name": "strawberryperl" ,
-                "args": [ "--version", "5.32.1.1" ]
+                "args": [ "--version", "5.40.2.2" ]
             },
             { "name": "pulumi" },
             { "name": "swig" },


### PR DESCRIPTION
>Strawberry Perl is a perl environment for MS Windows containing all you need to run and develop perl applications. It is designed to be as close as possible to perl environment on UNIX systems.

* Update `strawberryperl` from `5.32.1.1` -> `5.40.2.2`
https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases