### PR TITLE
[Windows25] Updating Openssl version to 3.5.1

### DIFF
--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -329,7 +329,7 @@
         }
     },
     "openssl": {
-        "version": "3.4.1",
+        "version": "3.5.1",
         "pinnedDetails": {
             "link": "https://github.com/actions/runner-images-internal/pull/6702",
             "reason": "Meaningful reason must be added at next update.",


### PR DESCRIPTION
This PR will update the OpenSSL version to `3.5.1` for windows25.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
