### PR TITLE
Simplify Packer templates for Windows and Ubuntu images

### DIFF
--- a/docs/create-image-and-azure-resources.md
+++ b/docs/create-image-and-azure-resources.md
@@ -221,7 +221,7 @@ Where:
 - `TenantId` - Azure Tenant ID;
 - `InstallPassword` - password for the user used to install software (Windows only);
 - `Location` - location where resources will be created (e.g., "East US");
-- `ImageOS` - the type of OS that will be deployed as a temporary VM (e.g. "ubuntu24", "win25");
+- `ImageOS` - the type of OS that will be deployed as a temporary VM (e.g. "ubuntu2404", "windows2025");
 - `ImageName` and `ImageResourceGroupName` - name of the resource group where the managed image will be stored;
 - `TemplatePath` - path to the folder with Packer template files (e.g., "images/windows/templates").
 

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -215,7 +215,7 @@ Function GenerateResourcesAndImage {
         "-var=subscription_id=$($SubscriptionId)" `
         "-var=tenant_id=fake" `
         "-var=location=$($AzureLocation)" `
-        "-var=image_os=$($ImageType.ToLower())" `
+        "-var=image_os=$($ImageType.ToString().ToLower())" `
         "-var=managed_image_name=$($ManagedImageName)" `
         "-var=managed_image_resource_group_name=$($ResourceGroupName)" `
         "-var=install_password=$($InstallPassword)" `
@@ -285,7 +285,7 @@ Function GenerateResourcesAndImage {
             -var "subscription_id=$($SubscriptionId)" `
             -var "tenant_id=$($TenantId)" `
             -var "location=$($AzureLocation)" `
-            -var "image_os=$($ImageType.ToLower())" `
+            -var "image_os=$($ImageType.ToString().ToLower())" `
             -var "managed_image_name=$($ManagedImageName)" `
             -var "managed_image_resource_group_name=$($ResourceGroupName)" `
             -var "install_password=$($InstallPassword)" `

--- a/helpers/GenerateResourcesAndImage.ps1
+++ b/helpers/GenerateResourcesAndImage.ps1
@@ -20,23 +20,18 @@ Function Get-PackerTemplate {
         # Note: Double Join-Path is required to support PowerShell 5.1
         ([ImageType]::Windows2019) {
             $relativeTemplatePath = Join-Path (Join-Path "windows" "templates") "build.windows-2019.pkr.hcl"
-            $imageOS = "win19"
         }
         ([ImageType]::Windows2022) {
             $relativeTemplatePath = Join-Path (Join-Path "windows" "templates") "build.windows-2022.pkr.hcl"
-            $imageOS = "win22"
         }
         ([ImageType]::Windows2025) {
             $relativeTemplatePath = Join-Path (Join-Path "windows" "templates") "build.windows-2025.pkr.hcl"
-            $imageOS = "win25"
         }
         ([ImageType]::Ubuntu2204) {
             $relativeTemplatePath = Join-Path (Join-Path "ubuntu" "templates") "build.ubuntu-22_04.pkr.hcl"
-            $imageOS = "ubuntu22"
         }
         ([ImageType]::Ubuntu2404) {
             $relativeTemplatePath = Join-Path (Join-Path "ubuntu" "templates") "build.ubuntu-24_04.pkr.hcl"
-            $imageOS = "ubuntu24"
         }
         default { throw "Unknown type of image" }
     }
@@ -51,7 +46,6 @@ Function Get-PackerTemplate {
 
     return [PSCustomObject] @{
         "BuildName" = $buildName
-        "ImageOS"   = $imageOS
         "Path"      = [IO.Path]::GetDirectoryName($imageTemplatePath)
     }
 }
@@ -221,7 +215,7 @@ Function GenerateResourcesAndImage {
         "-var=subscription_id=$($SubscriptionId)" `
         "-var=tenant_id=fake" `
         "-var=location=$($AzureLocation)" `
-        "-var=image_os=$($PackerTemplate.ImageOS)" `
+        "-var=image_os=$($ImageType.ToLower())" `
         "-var=managed_image_name=$($ManagedImageName)" `
         "-var=managed_image_resource_group_name=$($ResourceGroupName)" `
         "-var=install_password=$($InstallPassword)" `
@@ -291,7 +285,7 @@ Function GenerateResourcesAndImage {
             -var "subscription_id=$($SubscriptionId)" `
             -var "tenant_id=$($TenantId)" `
             -var "location=$($AzureLocation)" `
-            -var "image_os=$($PackerTemplate.ImageOS)" `
+            -var "image_os=$($ImageType.ToLower())" `
             -var "managed_image_name=$($ManagedImageName)" `
             -var "managed_image_resource_group_name=$($ResourceGroupName)" `
             -var "install_password=$($InstallPassword)" `

--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -9,7 +9,7 @@ param(
     [String] [Parameter (Mandatory=$true)] $TempResourceGroupName,
     [String] [Parameter (Mandatory=$true)] $SubscriptionId,
     [String] [Parameter (Mandatory=$true)] $TenantId,
-    [String] [Parameter (Mandatory=$true)] $ImageOS, # e.g. "ubuntu2404", "ubuntu2204" or "win2019", "win2022", "win2025"
+    [String] [Parameter (Mandatory=$true)] $ImageOS, # e.g. "ubuntu2404", "ubuntu2204" or "windows2019", "windows2022", "windows2025"
     [String] [Parameter (Mandatory=$false)] $UseAzureCliAuth = "false",
     [String] [Parameter (Mandatory=$false)] $PluginVersion = "2.3.3",
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkName,

--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -9,7 +9,7 @@ param(
     [String] [Parameter (Mandatory=$true)] $TempResourceGroupName,
     [String] [Parameter (Mandatory=$true)] $SubscriptionId,
     [String] [Parameter (Mandatory=$true)] $TenantId,
-    [String] [Parameter (Mandatory=$true)] $ImageOS, # e.g. "ubuntu22", "ubuntu22" or "win19", "win22", "win25"
+    [String] [Parameter (Mandatory=$true)] $ImageOS, # e.g. "ubuntu2404", "ubuntu2204" or "win2019", "win2022", "win2025"
     [String] [Parameter (Mandatory=$false)] $UseAzureCliAuth = "false",
     [String] [Parameter (Mandatory=$false)] $PluginVersion = "2.3.3",
     [String] [Parameter (Mandatory=$false)] $VirtualNetworkName,

--- a/images/ubuntu/templates/locals.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/locals.ubuntu.pkr.hcl
@@ -1,12 +1,12 @@
 locals {
   image_properties_map = {
-      "ubuntu22" = {
+      "ubuntu2202" = {
             publisher       = "canonical"
             offer           = "0001-com-ubuntu-server-jammy"
             sku             = "22_04-lts"
             os_disk_size_gb = coalesce(var.os_disk_size_gb, 75)
       },
-      "ubuntu24" = {
+      "ubuntu2404" = {
             publisher       = "canonical"
             offer           = "ubuntu-24_04-lts"
             sku             = "server-gen1"

--- a/images/windows/templates/locals.windows.pkr.hcl
+++ b/images/windows/templates/locals.windows.pkr.hcl
@@ -1,18 +1,18 @@
 locals {
     image_properties_map = {
-      "win19" = {
+      "windows2019" = {
             publisher         = "MicrosoftWindowsServer"
             offer             = "WindowsServer"
             sku               = "2019-Datacenter"
             os_disk_size_gb = coalesce(var.os_disk_size_gb, 256)
       },
-      "win22" = {
+      "windows2022" = {
             publisher         = "MicrosoftWindowsServer"
             offer             = "WindowsServer"
             sku               = "2022-Datacenter"
             os_disk_size_gb = coalesce(var.os_disk_size_gb, 256)
       },
-      "win25" = {
+      "windows2025" = {
             publisher         = "MicrosoftWindowsServer"
             offer             = "WindowsServer"
             sku               = "2025-Datacenter"


### PR DESCRIPTION
# Description
Reference: https://github.com/actions/runner-images/pull/12305

I like this refactor but can we **please** stop introducing new ways of referencing the same image to generate.
The goal here is consistency, and reusing the same approach for referencing images helps maintain that across the codebase.

In this I am simply reusing `ImageType` as input for the `image_os` variable, which is used in the new map in `locals`, instead of adding extra code and creating a new reference for the same image type. 

_Current reference examples for image_
```
Windows2025
windows-2025
win25
```

```
Ubuntu2404
ubuntu-24_04
ubuntu24
```

I’ll leave this PR as an example of an approach that avoids introducing additional references and aims to stay more consistent. Please consider.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
