### PR TITLE
Revert "Remove W19 readme"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 | macOS 13 Arm64 | `macos-13-xlarge` | [macOS-13-arm64] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fmacos-13-arm64.json) |
 | Windows Server 2025 | `windows-2025` | [windows-2025] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fwin25.json) |
 | Windows Server 2022 | `windows-latest` or `windows-2022` | [windows-2022] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fwin22.json) |
-| ![Deprecated](https://img.shields.io/badge/-Deprecated-red) Windows Server 2019 | `windows-2019` | [windows-2019] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fwin19.json) |
+| Windows Server 2019 | `windows-2019` | [windows-2019] | ![Deprecated](https://img.shields.io/badge/-Deprecated-red) |
 
 ### Label scheme
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 | macOS 13 Arm64 | `macos-13-xlarge` | [macOS-13-arm64] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fmacos-13-arm64.json) |
 | Windows Server 2025 | `windows-2025` | [windows-2025] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fwin25.json) |
 | Windows Server 2022 | `windows-latest` or `windows-2022` | [windows-2022] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fwin22.json) |
-| Windows Server 2019 | `windows-2019` | windows-2019 | ![Deprecated](https://img.shields.io/badge/-Deprecated-red) |
+| ![Deprecated](https://img.shields.io/badge/-Deprecated-red) Windows Server 2019 | `windows-2019` | [windows-2019] | ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fsubir0071%2F385e39188f4280878bada99250e99db7%2Fraw%2Fwin19.json) |
 
 ### Label scheme
 
@@ -39,6 +39,7 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 
 [ubuntu-24.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
 [ubuntu-22.04]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+[windows-2019]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
 [windows-2025]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
 [windows-2022]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
 [macOS-13]: https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

--- a/images/windows/Windows2019-Readme.md
+++ b/images/windows/Windows2019-Readme.md
@@ -1,0 +1,554 @@
+| Announcements |
+|-|
+| [[Windows, Ubuntu, MacOS] CodeQL bundle will contain only platform-specific binaries on 2025-06-30](https://github.com/actions/runner-images/issues/12453) |
+| [[Windows Server 2025] image will no longer have  D:/ drive accessible to users from 2025-07-14](https://github.com/actions/runner-images/issues/12416) |
+| [[Windows, Ubuntu, MacOS] Breaking change: Updating  Azure PowerShell Module version as 12.5.x   from  2025-07-04](https://github.com/actions/runner-images/issues/12333) |
+| [[Windows & Ubuntu] .NET 6 will be removed from the images on  2025-08-01.](https://github.com/actions/runner-images/issues/12241) |
+| [The Windows 2019 Actions runner image will begin deprecation on 2025-06-01 and will be fully unsupported by 2025-06-30](https://github.com/actions/runner-images/issues/12045) |
+| [Windows Server 2025 is now available](https://github.com/actions/runner-images/issues/11228) |
+***
+# Windows Server 2019
+- OS Version: 10.0.17763 Build 7434
+- Image Version: 20250623.2.0
+
+## Windows features
+- Windows Subsystem for Linux (WSLv1): Enabled
+
+## Installed Software
+
+### Language and Runtime
+- Bash 5.2.37(1)-release
+- Go 1.24.4
+- Julia 1.11.5
+- Kotlin 2.1.10
+- LLVM 18.1.8
+- Node 18.20.8
+- Perl 5.32.1
+- PHP 8.4.8
+- Python 3.9.13
+- Ruby 3.3.8
+
+### Package Management
+- Chocolatey 2.4.3
+- Composer 2.8.9
+- Helm 3.18.2
+- Miniconda 25.3.1 (pre-installed on the image but not added to PATH)
+- NPM 10.8.2
+- NuGet 6.14.0.116
+- pip 25.1.1 (python 3.9)
+- Pipx 1.7.1
+- RubyGems 3.5.22
+- Vcpkg (build from commit 2e58bb35ff)
+- Yarn 1.22.22
+
+#### Environment variables
+| Name                    | Value        |
+| ----------------------- | ------------ |
+| VCPKG_INSTALLATION_ROOT | C:\vcpkg     |
+| CONDA                   | C:\Miniconda |
+
+### Project Management
+- Ant 1.10.15
+- Gradle 8.14
+- Maven 3.9.10
+- sbt 1.11.2
+
+### Tools
+- 7zip 24.09
+- aria2 1.37.0
+- azcopy 10.29.1
+- Bazel 8.3.0
+- Bazelisk 1.26.0
+- Bicep 0.36.1
+- Cabal 3.14.2.0
+- CMake 3.31.6
+- CodeQL Action Bundle 2.22.0
+- Docker 27.5.1
+- Docker Compose v2 2.32.2
+- Docker-wincred 0.9.3
+- ghc 9.12.2
+- Git 2.50.0.windows.1
+- Git LFS 3.6.1
+- Google Cloud CLI 527.0.0
+- ImageMagick 7.1.1-47
+- InnoSetup 6.4.0
+- jq 1.7.1
+- Kind 0.29.0
+- Kubectl 1.33.2
+- Mercurial 5.0
+- gcc 8.1.0
+- gdb 8.1
+- GNU Binutils 2.30
+- Newman 6.2.1
+- NSIS 3.10
+- OpenSSL 1.1.1w
+- Packer 1.12.0
+- Parcel 2.15.4
+- Pulumi 3.178.0
+- R 4.4.2
+- Service Fabric SDK 10.1.2493.9590
+- Stack 3.5.1
+- Subversion (SVN) 1.14.5
+- Swig 4.1.1
+- VSWhere 3.1.7
+- WinAppDriver 1.2.2009.02003
+- WiX Toolset 3.14.1.8722
+- yamllint 1.37.1
+- zstd 1.5.7
+- Ninja 1.13.0
+
+### CLI Tools
+- Alibaba Cloud CLI 3.0.284
+- AWS CLI 2.27.40
+- AWS SAM CLI 1.141.0
+- AWS Session Manager CLI 1.2.707.0
+- Azure CLI 2.74.0
+- Azure DevOps CLI extension 1.0.1
+- Cloud Foundry CLI 8.14.1
+- GitHub CLI 2.74.2
+
+### Rust Tools
+- Cargo 1.87.0
+- Rust 1.87.0
+- Rustdoc 1.87.0
+- Rustup 1.28.2
+
+#### Packages
+- bindgen 0.72.0
+- cargo-audit 0.21.2
+- cargo-outdated 0.17.0
+- cbindgen 0.29.0
+- Clippy 0.1.87
+- Rustfmt 1.8.0
+
+### Browsers and Drivers
+- Google Chrome 137.0.7151.120
+- Chrome Driver 137.0.7151.119
+- Microsoft Edge 137.0.3296.93
+- Microsoft Edge Driver 137.0.3296.93
+- Mozilla Firefox 139.0.4
+- Gecko Driver 0.36.0
+- IE Driver 4.14.0.0
+- Selenium server 4.33.0
+
+#### Environment variables
+| Name              | Value                              |
+| ----------------- | ---------------------------------- |
+| CHROMEWEBDRIVER   | C:\SeleniumWebDrivers\ChromeDriver |
+| EDGEWEBDRIVER     | C:\SeleniumWebDrivers\EdgeDriver   |
+| GECKOWEBDRIVER    | C:\SeleniumWebDrivers\GeckoDriver  |
+| SELENIUM_JAR_PATH | C:\selenium\selenium-server.jar    |
+
+### Java
+| Version             | Environment Variable |
+| ------------------- | -------------------- |
+| 8.0.452+9 (default) | JAVA_HOME_8_X64      |
+| 11.0.27+6           | JAVA_HOME_11_X64     |
+| 17.0.15+6           | JAVA_HOME_17_X64     |
+| 21.0.7+6.0          | JAVA_HOME_21_X64     |
+
+### Shells
+| Name          | Target                            |
+| ------------- | --------------------------------- |
+| gitbash.exe   | C:\Program Files\Git\bin\bash.exe |
+| msys2bash.cmd | C:\msys64\usr\bin\bash.exe        |
+| wslbash.exe   | C:\Windows\System32\bash.exe      |
+
+### MSYS2
+- Pacman 6.1.0
+
+#### Notes
+```
+Location: C:\msys64
+
+Note: MSYS2 is pre-installed on image but not added to PATH.
+```
+
+### BizTalk Server
+- BizTalk Server Project Build Component 3.13.832.0
+
+### Cached Tools
+
+#### Go
+- 1.22.12
+- 1.23.10
+- 1.24.4
+
+#### Node.js
+- 18.20.8
+- 20.19.3
+- 22.16.0
+
+#### Python
+- 3.9.13
+- 3.10.11
+- 3.11.9
+- 3.12.10
+- 3.13.5
+
+#### PyPy
+- 2.7.18 [PyPy 7.3.19]
+- 3.6.12 [PyPy 7.3.3]
+- 3.7.13 [PyPy 7.3.9]
+- 3.8.16 [PyPy 7.3.11]
+- 3.9.19 [PyPy 7.3.16]
+- 3.10.16 [PyPy 7.3.19]
+
+#### Ruby
+- 3.1.7
+- 3.2.8
+- 3.3.8
+
+### Databases
+
+#### PostgreSQL
+| Property             | Value                                                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| ServiceName          | postgresql-x64-14                                                                                                                    |
+| Version              | 14.18                                                                                                                                |
+| ServiceStatus        | Stopped                                                                                                                              |
+| ServiceStartType     | Disabled                                                                                                                             |
+| EnvironmentVariables | PGBIN=C:\Program Files\PostgreSQL\14\bin <br> PGDATA=C:\Program Files\PostgreSQL\14\data <br> PGROOT=C:\Program Files\PostgreSQL\14  |
+| Path                 | C:\Program Files\PostgreSQL\14                                                                                                       |
+| UserName             | postgres                                                                                                                             |
+| Password             | root                                                                                                                                 |
+
+#### MongoDB
+| Version  | ServiceName | ServiceStatus | ServiceStartType |
+| -------- | ----------- | ------------- | ---------------- |
+| 5.0.31.0 | MongoDB     | Stopped       | Disabled         |
+
+### Database tools
+- Azure CosmosDb Emulator 2.14.23.0
+- DacFx 170.0.94.3
+- MySQL 5.7.44.0
+- SQL OLEDB Driver 18.7.4.0
+- SQLPS 1.0
+
+### Web Servers
+| Name   | Version | ConfigFile                            | ServiceName | ServiceStatus | ListenPort |
+| ------ | ------- | ------------------------------------- | ----------- | ------------- | ---------- |
+| Apache | 2.4.55  | C:\tools\Apache24\conf\httpd.conf     | Apache      | Stopped       | 80         |
+| Nginx  | 1.27.5  | C:\tools\nginx-1.27.5\conf\nginx.conf | nginx       | Stopped       | 80         |
+
+### Visual Studio Enterprise 2019
+| Name                          | Version        | Path                                                           |
+| ----------------------------- | -------------- | -------------------------------------------------------------- |
+| Visual Studio Enterprise 2019 | 16.11.36128.20 | C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise |
+
+#### Workloads, components and extensions
+| Package                                                                   | Version         |
+| ------------------------------------------------------------------------- | --------------- |
+| Component.Android.NDK.R16B                                                | 16.11.36123.19  |
+| Component.Android.SDK25.Private                                           | 16.0.28625.61   |
+| Component.Android.SDK30                                                   | 16.10.31205.252 |
+| Component.Ant                                                             | 1.9.3.8         |
+| Component.Dotfuscator                                                     | 16.10.31205.252 |
+| Component.Linux.CMake                                                     | 16.2.29003.222  |
+| Component.MDD.Android                                                     | 16.0.28517.75   |
+| Component.MDD.Linux                                                       | 16.5.29515.121  |
+| Component.MDD.Linux.GCC.arm                                               | 16.5.29515.121  |
+| Component.Microsoft.VisualStudio.LiveShare                                | 1.0.4441        |
+| Component.Microsoft.VisualStudio.RazorExtension                           | 16.10.31205.252 |
+| Component.Microsoft.VisualStudio.Tools.Applications                       | 16.0.31110.1    |
+| Component.Microsoft.VisualStudio.Web.AzureFunctions                       | 16.10.31205.252 |
+| Component.Microsoft.Web.LibraryManager                                    | 16.10.31205.180 |
+| Component.Microsoft.WebTools.BrowserLink.WebLivePreview                   | 0.7.22.39845    |
+| Component.Microsoft.Windows.DriverKit                                     | 10.0.21381.0    |
+| Component.OpenJDK                                                         | 16.11.31827.77  |
+| Component.UnityEngine.x64                                                 | 16.10.31205.252 |
+| Component.Unreal                                                          | 16.1.28810.153  |
+| Component.Unreal.Android                                                  | 16.1.28810.153  |
+| Component.VSInstallerProjects                                             | 1.0.2           |
+| Component.WixToolset.VisualStudioExtension.Dev16                          | 1.0.0.22        |
+| Component.WixToolset.VisualStudioExtension.Schemas3                       | 1.0.0.22        |
+| Component.Xamarin                                                         | 16.11.36101.21  |
+| Microsoft.Component.Azure.DataLake.Tools                                  | 16.10.31205.252 |
+| Microsoft.Component.ClickOnce                                             | 16.11.31603.221 |
+| Microsoft.Component.MSBuild                                               | 16.11.33214.272 |
+| Microsoft.Component.NetFX.Native                                          | 16.5.29515.121  |
+| Microsoft.Component.PythonTools                                           | 16.11.31314.313 |
+| Microsoft.Component.PythonTools.Miniconda                                 | 16.11.31314.313 |
+| Microsoft.Component.PythonTools.Web                                       | 16.10.31205.252 |
+| Microsoft.Component.VC.Runtime.UCRTSDK                                    | 16.0.28625.61   |
+| Microsoft.ComponentGroup.Blend                                            | 16.0.28315.86   |
+| Microsoft.ComponentGroup.ClickOnce.Publish                                | 16.11.31603.221 |
+| Microsoft.Net.Component.3.5.DeveloperTools                                | 16.0.28517.75   |
+| Microsoft.Net.Component.4.5.1.TargetingPack                               | 16.11.31605.320 |
+| Microsoft.Net.Component.4.5.2.TargetingPack                               | 16.0.28517.75   |
+| Microsoft.Net.Component.4.5.TargetingPack                                 | 16.11.31605.320 |
+| Microsoft.Net.Component.4.6.1.TargetingPack                               | 16.0.28517.75   |
+| Microsoft.Net.Component.4.6.2.TargetingPack                               | 16.0.28517.75   |
+| Microsoft.Net.Component.4.6.TargetingPack                                 | 16.0.28517.75   |
+| Microsoft.Net.Component.4.7.1.TargetingPack                               | 16.10.31205.252 |
+| Microsoft.Net.Component.4.7.2.SDK                                         | 16.4.29409.204  |
+| Microsoft.Net.Component.4.7.2.TargetingPack                               | 16.10.31205.252 |
+| Microsoft.Net.Component.4.7.TargetingPack                                 | 16.10.31205.252 |
+| Microsoft.Net.Component.4.8.SDK                                           | 16.4.29313.120  |
+| Microsoft.Net.Component.4.TargetingPack                                   | 16.11.31605.320 |
+| Microsoft.Net.ComponentGroup.4.6.2.DeveloperTools                         | 16.3.29207.166  |
+| Microsoft.Net.ComponentGroup.4.7.1.DeveloperTools                         | 16.3.29207.166  |
+| Microsoft.Net.ComponentGroup.4.7.DeveloperTools                           | 16.3.29207.166  |
+| Microsoft.Net.ComponentGroup.DevelopmentPrerequisites                     | 16.3.29207.166  |
+| Microsoft.Net.ComponentGroup.TargetingPacks.Common                        | 16.0.28516.191  |
+| Microsoft.NetCore.Component.DevelopmentTools                              | 16.11.33214.272 |
+| Microsoft.NetCore.Component.Web                                           | 16.11.33214.272 |
+| Microsoft.VisualStudio.Component.AppInsights.Tools                        | 16.11.36128.20  |
+| Microsoft.VisualStudio.Component.AspNet45                                 | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Azure.AuthoringTools                     | 16.11.31827.77  |
+| Microsoft.VisualStudio.Component.Azure.ClientLibs                         | 16.11.34829.67  |
+| Microsoft.VisualStudio.Component.Azure.Compute.Emulator                   | 16.11.31827.77  |
+| Microsoft.VisualStudio.Component.Azure.Kubernetes.Tools                   | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Azure.Powershell                         | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.Azure.ResourceManager.Tools              | 16.4.29409.204  |
+| Microsoft.VisualStudio.Component.Azure.ServiceFabric.Tools                | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.Azure.Storage.Emulator                   | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.Azure.Waverton                           | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Azure.Waverton.BuildTools                | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.ClassDesigner                            | 16.0.28528.71   |
+| Microsoft.VisualStudio.Component.CloudExplorer                            | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.CodeMap                                  | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.Common.Azure.Tools                       | 16.11.36128.20  |
+| Microsoft.VisualStudio.Component.CoreEditor                               | 16.1.28811.260  |
+| Microsoft.VisualStudio.Component.Debugger.JustInTime                      | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.Debugger.Snapshot                        | 16.5.29813.82   |
+| Microsoft.VisualStudio.Component.Debugger.TimeTravel                      | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.DiagnosticTools                          | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.DockerTools                              | 16.11.33214.272 |
+| Microsoft.VisualStudio.Component.DotNetModelBuilder                       | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.DslTools                                 | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.EntityFramework                          | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.FSharp                                   | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.FSharp.Desktop                           | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.FSharp.WebTemplates                      | 16.3.29207.166  |
+| Microsoft.VisualStudio.Component.GraphDocument                            | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.Graphics                                 | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Graphics.Tools                           | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.IISExpress                               | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.IntelliCode                              | 16.11.35122.84  |
+| Microsoft.VisualStudio.Component.IntelliTrace.FrontEnd                    | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.JavaScript.Diagnostics                   | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.JavaScript.TypeScript                    | 16.11.31404.150 |
+| Microsoft.VisualStudio.Component.LinqToSql                                | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.LiveUnitTesting                          | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.ManagedDesktop.Core                      | 16.4.29318.151  |
+| Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites             | 16.11.33214.272 |
+| Microsoft.VisualStudio.Component.Merq                                     | 16.2.29012.281  |
+| Microsoft.VisualStudio.Component.MonoDebugger                             | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.MSODBC.SQL                               | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.MSSQL.CMDLnUtils                         | 16.0.28707.177  |
+| Microsoft.VisualStudio.Component.Node.Tools                               | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.NuGet                                    | 16.1.28829.92   |
+| Microsoft.VisualStudio.Component.NuGet.BuildTools                         | 16.1.28829.92   |
+| Microsoft.VisualStudio.Component.PortableLibrary                          | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Roslyn.Compiler                          | 16.0.28714.129  |
+| Microsoft.VisualStudio.Component.Roslyn.LanguageServices                  | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Sharepoint.Tools                         | 16.4.29409.204  |
+| Microsoft.VisualStudio.Component.SQL.ADAL                                 | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.SQL.CLR                                  | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.SQL.DataSources                          | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.SQL.LocalDB.Runtime                      | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.SQL.SSDT                                 | 16.3.29207.166  |
+| Microsoft.VisualStudio.Component.TeamOffice                               | 16.4.29409.204  |
+| Microsoft.VisualStudio.Component.TestTools.CodedUITest                    | 16.0.28327.66   |
+| Microsoft.VisualStudio.Component.TestTools.WebLoadTest                    | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.TextTemplating                           | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.TypeScript.4.3                           | 16.0.31506.151  |
+| Microsoft.VisualStudio.Component.Unity                                    | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.UWP.VC.ARM64                             | 16.3.29207.166  |
+| Microsoft.VisualStudio.Component.VC.14.25.x86.x64                         | 16.11.32428.96  |
+| Microsoft.VisualStudio.Component.VC.140                                   | 16.11.33801.447 |
+| Microsoft.VisualStudio.Component.VC.ASAN                                  | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.ATL                                   | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.VC.ATL.ARM                               | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.VC.ATL.ARM.Spectre                       | 16.5.29721.120  |
+| Microsoft.VisualStudio.Component.VC.ATL.ARM64                             | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre                     | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VC.ATL.Spectre                           | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VC.ATLMFC                                | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre                        | 16.5.29721.120  |
+| Microsoft.VisualStudio.Component.VC.CLI.Support                           | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.CMake.Project                         | 16.3.29103.31   |
+| Microsoft.VisualStudio.Component.VC.CoreIde                               | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.DiagnosticTools                       | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VC.Llvm.Clang                            | 16.11.31603.221 |
+| Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset                     | 16.3.29207.166  |
+| Microsoft.VisualStudio.Component.VC.MFC.ARM                               | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.VC.MFC.ARM.Spectre                       | 16.5.29721.120  |
+| Microsoft.VisualStudio.Component.VC.MFC.ARM64                             | 16.4.29313.120  |
+| Microsoft.VisualStudio.Component.VC.MFC.ARM64.Spectre                     | 16.5.29721.120  |
+| Microsoft.VisualStudio.Component.VC.Modules.x86.x64                       | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.Redist.14.Latest                      | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VC.Redist.MSM                            | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VC.Runtimes.ARM.Spectre                  | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre                | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre              | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.TestAdapterForBoostTest               | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.VC.TestAdapterForGoogleTest              | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.VC.Tools.ARM                             | 16.11.32406.258 |
+| Microsoft.VisualStudio.Component.VC.Tools.ARM64                           | 16.11.32406.258 |
+| Microsoft.VisualStudio.Component.VC.Tools.ARM64EC                         | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.Tools.x86.x64                         | 16.11.32406.258 |
+| Microsoft.VisualStudio.Component.VC.v141.ARM                              | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.v141.ARM.Spectre                      | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VC.v141.ARM64                            | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.v141.ARM64.Spectre                    | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VC.v141.ATL                              | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.ATL.ARM                          | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.ATL.ARM.Spectre                  | 16.5.29721.120  |
+| Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64                        | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.ATL.ARM64.Spectre                | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.ATL.Spectre                      | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.MFC                              | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.MFC.ARM.Spectre                  | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.MFC.ARM64.Spectre                | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.MFC.Spectre                      | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.VC.v141.x86.x64                          | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre                  | 16.5.29515.121  |
+| Microsoft.VisualStudio.Component.VSSDK                                    | 16.0.28315.86   |
+| Microsoft.VisualStudio.Component.Wcf.Tooling                              | 16.0.28625.61   |
+| Microsoft.VisualStudio.Component.Web                                      | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.WebDeploy                                | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.Windows10SDK                             | 16.4.29409.204  |
+| Microsoft.VisualStudio.Component.Windows10SDK.16299                       | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Windows10SDK.17134                       | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Windows10SDK.17763                       | 16.0.28517.75   |
+| Microsoft.VisualStudio.Component.Windows10SDK.18362                       | 16.1.28829.92   |
+| Microsoft.VisualStudio.Component.Windows10SDK.19041                       | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Windows10SDK.20348                       | 16.11.31603.221 |
+| Microsoft.VisualStudio.Component.Windows11SDK.22000                       | 16.11.31727.170 |
+| Microsoft.VisualStudio.Component.WinXP                                    | 16.10.31205.252 |
+| Microsoft.VisualStudio.Component.Workflow                                 | 16.0.28315.86   |
+| Microsoft.VisualStudio.ComponentGroup.ArchitectureTools.Native            | 16.0.28621.142  |
+| Microsoft.VisualStudio.ComponentGroup.Azure.CloudServices                 | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.Azure.Prerequisites                 | 16.10.31303.231 |
+| Microsoft.VisualStudio.ComponentGroup.Azure.ResourceManager.Tools         | 16.0.28528.71   |
+| Microsoft.VisualStudio.ComponentGroup.AzureFunctions                      | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging                      | 16.11.34827.16  |
+| Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core                  | 16.2.29012.281  |
+| Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang            | 16.11.31603.221 |
+| Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard              | 16.11.33214.272 |
+| Microsoft.VisualStudio.ComponentGroup.UWP.Support                         | 16.11.33214.272 |
+| Microsoft.VisualStudio.ComponentGroup.UWP.VC                              | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141                         | 16.1.28810.153  |
+| Microsoft.VisualStudio.ComponentGroup.UWP.Xamarin                         | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.VisualStudioExtension.Prerequisites | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.Web                                 | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.Web.Client                          | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.Web.CloudTools                      | 16.10.31205.180 |
+| Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions                  | 16.11.32413.511 |
+| Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.CMake            | 16.11.32413.511 |
+| Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine   | 16.11.32413.511 |
+| Microsoft.VisualStudio.Workload.Azure                                     | 16.11.35026.282 |
+| Microsoft.VisualStudio.Workload.CoreEditor                                | 16.10.31205.180 |
+| Microsoft.VisualStudio.Workload.Data                                      | 16.0.28720.110  |
+| Microsoft.VisualStudio.Workload.DataScience                               | 16.10.31205.180 |
+| Microsoft.VisualStudio.Workload.ManagedDesktop                            | 16.11.33214.272 |
+| Microsoft.VisualStudio.Workload.ManagedGame                               | 16.10.31205.180 |
+| Microsoft.VisualStudio.Workload.NativeCrossPlat                           | 16.10.31205.180 |
+| Microsoft.VisualStudio.Workload.NativeDesktop                             | 16.11.36128.20  |
+| Microsoft.VisualStudio.Workload.NativeGame                                | 16.11.36128.20  |
+| Microsoft.VisualStudio.Workload.NativeMobile                              | 16.10.31205.180 |
+| Microsoft.VisualStudio.Workload.NetCoreTools                              | 16.11.33214.272 |
+| Microsoft.VisualStudio.Workload.NetCrossPlat                              | 16.11.33214.272 |
+| Microsoft.VisualStudio.Workload.NetWeb                                    | 16.11.33214.272 |
+| Microsoft.VisualStudio.Workload.Node                                      | 16.10.31205.180 |
+| Microsoft.VisualStudio.Workload.Office                                    | 16.11.33214.272 |
+| Microsoft.VisualStudio.Workload.Python                                    | 16.11.33328.57  |
+| Microsoft.VisualStudio.Workload.Universal                                 | 16.11.36128.20  |
+| Microsoft.VisualStudio.Workload.VisualStudioExtension                     | 16.10.31205.180 |
+| ms-biztalk.BizTalk                                                        | 3.13.2.0        |
+| ProBITools.MicrosoftAnalysisServicesModelingProjects                      | 2.9.18          |
+| ProBITools.MicrosoftReportProjectsforVisualStudio                         | 2.6.11          |
+| SSIS.SqlServerIntegrationServicesProjects                                 | 4.6             |
+| VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects             | 1.0.2           |
+| Windows Driver Kit                                                        | 10.1.22000.1    |
+| Windows Driver Kit Visual Studio Extension                                | 10.0.21381.0    |
+| Windows Software Development Kit                                          | 10.1.22621.755  |
+| WixToolset.WixToolsetVisualStudio2019Extension                            | 1.0.0.22        |
+
+#### Microsoft Visual C++
+| Name                                         | Architecture | Version     |
+| -------------------------------------------- | ------------ | ----------- |
+| Microsoft Visual C++ 2010 Redistributable    | x64          | 10.0.40219  |
+| Microsoft Visual C++ 2010 Redistributable    | x86          | 10.0.40219  |
+| Microsoft Visual C++ 2013 Additional Runtime | x64          | 12.0.40660  |
+| Microsoft Visual C++ 2013 Minimum Runtime    | x64          | 12.0.40660  |
+| Microsoft Visual C++ 2013 Additional Runtime | x86          | 12.0.21005  |
+| Microsoft Visual C++ 2013 Minimum Runtime    | x86          | 12.0.21005  |
+| Microsoft Visual C++ 2019 Debug Runtime      | x64          | 14.29.30157 |
+| Microsoft Visual C++ 2019 Debug Runtime      | x86          | 14.29.30157 |
+| Microsoft Visual C++ 2022 Additional Runtime | x64          | 14.44.35208 |
+| Microsoft Visual C++ 2022 Minimum Runtime    | x64          | 14.44.35208 |
+| Microsoft Visual C++ 2022 Additional Runtime | x86          | 14.44.35208 |
+| Microsoft Visual C++ 2022 Minimum Runtime    | x86          | 14.44.35208 |
+
+#### Installed Windows SDKs
+- 10.0.14393.0
+- 10.0.16299.0
+- 10.0.17134.0
+- 10.0.17763.0
+- 10.0.18362.0
+- 10.0.19041.0
+- 10.0.20348.0
+- 10.0.22000.0
+- 10.0.22621.0
+
+### .NET Core Tools
+- .NET Core SDK: 6.0.136, 6.0.203, 6.0.321, 6.0.428, 8.0.117, 8.0.206, 8.0.314, 8.0.411, 9.0.107, 9.0.205, 9.0.301
+- .NET Framework: 4.7.2, 4.8
+- Microsoft.AspNetCore.App: 6.0.5, 6.0.26, 6.0.36, 8.0.6, 8.0.17, 9.0.6
+- Microsoft.NETCore.App: 6.0.5, 6.0.26, 6.0.36, 8.0.6, 8.0.17, 9.0.6
+- Microsoft.WindowsDesktop.App: 6.0.5, 6.0.26, 6.0.36, 8.0.6, 8.0.17, 9.0.6
+- nbgv 3.7.115+d31f50f4d1
+
+### PowerShell Tools
+- PowerShell 7.4.10
+
+#### Powershell Modules
+- Az: 12.1.0
+- AWSPowershell: 5.0.0
+- DockerMsftProvider: 1.0.0.8
+- MarkdownPS: 1.10
+- Microsoft.Graph: 2.28.0
+- Pester: 3.4.0, 5.7.1
+- PowerShellGet: 1.0.0.1, 2.2.5
+- PSScriptAnalyzer: 1.24.0
+- PSWindowsUpdate: 2.2.1.5
+- SqlServer: 22.2.0
+- VSSetup: 2.2.16
+
+### Android
+| Package Name               | Version                                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Android Command Line Tools | 8.0                                                                                                                                                                                                                                                                                                                                                                                 |
+| Android Emulator           | 35.5.10                                                                                                                                                                                                                                                                                                                                                                             |
+| Android SDK Build-tools    | 36.0.0<br>35.0.0 35.0.1<br>34.0.0<br>33.0.0 33.0.1 33.0.2 33.0.3<br>32.0.0<br>31.0.0<br>30.0.2                                                                                                                                                                                                                                                                                      |
+| Android SDK Platforms      | android-36 (rev 2)<br>android-35-ext15 (rev 1)<br>android-35-ext14 (rev 1)<br>android-35 (rev 2)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1)<br>android-33 (rev 3)<br>android-32 (rev 1)<br>android-31 (rev 1)<br>android-30 (rev 3) |
+| Android SDK Platform-Tools | 36.0.0                                                                                                                                                                                                                                                                                                                                                                              |
+| Android Support Repository | 47.0.0                                                                                                                                                                                                                                                                                                                                                                              |
+| CMake                      | 3.18.1<br>3.22.1<br>3.31.5                                                                                                                                                                                                                                                                                                                                                          |
+| Google APIs                | addon-google_apis-google-21<br>addon-google_apis-google-22<br>addon-google_apis-google-23<br>addon-google_apis-google-24                                                                                                                                                                                                                                                            |
+| Google Play services       | 49                                                                                                                                                                                                                                                                                                                                                                                  |
+| Google Repository          | 58                                                                                                                                                                                                                                                                                                                                                                                  |
+| NDK                        | 26.3.11579264<br>27.2.12479018<br>28.1.13356709                                                                                                                                                                                                                                                                                                                                     |
+
+#### Environment variables
+| Name                    | Value                                    |
+| ----------------------- | ---------------------------------------- |
+| ANDROID_HOME            | C:\Android\android-sdk                   |
+| ANDROID_NDK             | C:\Android\android-sdk\ndk\27.2.12479018 |
+| ANDROID_NDK_HOME        | C:\Android\android-sdk\ndk\27.2.12479018 |
+| ANDROID_NDK_LATEST_HOME | C:\Android\android-sdk\ndk\28.1.13356709 |
+| ANDROID_NDK_ROOT        | C:\Android\android-sdk\ndk\27.2.12479018 |
+| ANDROID_SDK_ROOT        | C:\Android\android-sdk                   |
+
+### Cached Docker images
+| Repository:Tag                                                            | Digest                                                                   | Created    |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------- |
+| mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019  | sha256:b679037695b2d508ed7e20afe1f02e69e5ecaa6232e9809f6e512ea8ddfe08e5  | 2025-06-10 |
+| mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019 | sha256:2061198adfaafa26f28f9b758910651597ab312504928f63ef842e12da4f8e1d  | 2025-06-10 |
+| mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019     | sha256:64aaee0de7cc78a6c833c1ae60e6c1814a9348ab378a206a35c99e482e9beb2b  | 2025-06-10 |
+| mcr.microsoft.com/windows/nanoserver:1809                                 | sha256:7c720f345ff7784cee12a5464bb5d5222c6348bd6da2cd29d666e49867958b0e  | 2025-06-04 |
+| mcr.microsoft.com/windows/servercore:ltsc2019                             | sha256:862b24ccf5e399fc3bea746c7ac68c16f3fbcfa199532a3e506b7e03e57217b9  | 2025-06-04 |
+


### PR DESCRIPTION
Reverts actions/runner-images#12519, fix link

Let's keep doc available for customers until decommission. 
ADO deprecation date: https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=windows-images%2Cyaml#windows-server-2019-hosted-image-deprecation-schedule