### PR TITLE
 [Ubuntu] Upgrade Git installation to latest version from source

### DIFF
--- a/images/ubuntu/scripts/build/install-git.sh
+++ b/images/ubuntu/scripts/build/install-git.sh
@@ -1,18 +1,29 @@
 #!/bin/bash -e
 ################################################################################
 ##  File:  install-git.sh
-##  Desc:  Install Git and Git-FTP
+##  Desc:  Install the latest Git (from source) and Git-FTP
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-GIT_REPO="ppa:git-core/ppa"
-
-## Install git
-add-apt-repository $GIT_REPO -y
+# Install dependencies for building Git
 apt-get update
-apt-get install git
+apt-get install libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext
+
+# Fetch the latest Git version number automatically
+GIT_LATEST_VERSION=$(curl -s https://mirrors.edge.kernel.org/pub/software/scm/git/ | \
+    grep -oP 'git-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.tar\.gz)' | sort -V | tail -1)
+
+# Download and extract the latest Git source
+cd /tmp
+curl -o git.tar.gz https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_LATEST_VERSION}.tar.gz
+tar -xzf git.tar.gz
+cd git-${GIT_LATEST_VERSION}
+
+# Build and install Git
+make prefix=/usr/local all
+sudo make prefix=/usr/local install
 
 # Git version 2.35.2 introduces security fix that breaks action\checkout https://github.com/actions/checkout/issues/760
 cat <<EOF >> /etc/gitconfig
@@ -23,11 +34,9 @@ EOF
 # Install git-ftp
 apt-get install git-ftp
 
-# Remove source repo's
-add-apt-repository --remove $GIT_REPO
 
-# Document apt source repo's
-echo "git-core $GIT_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
+# Document custom installation
+echo "git ${GIT_LATEST_VERSION}" >> $HELPER_SCRIPTS/apt-sources.txt
 
 # Add well-known SSH host keys to known_hosts
 ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /etc/ssh/ssh_known_hosts


### PR DESCRIPTION
# Description
This PR updates the install-git.sh script to install the latest version of Git directly from source, instead of using the git-core/ppa. This change ensures that the installation is always up-to-date with the newest Git release available on [kernel.org](https://kernel.org/).

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
