### PR TITLE
chore: Add ppa candidate repo to install 2.50.1 version of git

### DIFF
--- a/images/ubuntu/scripts/build/install-git.sh
+++ b/images/ubuntu/scripts/build/install-git.sh
@@ -7,7 +7,7 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
-GIT_REPO="ppa:git-core/ppa"
+GIT_REPO="ppa:git-core/candidate"
 
 ## Install git
 add-apt-repository $GIT_REPO -y


### PR DESCRIPTION
# Description
- Install git version `2.50.1`
- Install it from ppa candidate repo

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
