### PR TITLE
[Ubuntu] Improve kubectl installation script with retry logic and keyring checks

### DIFF
--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -20,8 +20,6 @@ use_checksum_comparison "${kind_binary_path}" "${kind_external_hash}"
 install "${kind_binary_path}" /usr/local/bin/kind
 
 ## Install kubectl
-apt-get update
-apt-get install ca-certificates apt-transport-https
 
 # Ensure keyrings directory exists only if it doesn't already
 [ -d /etc/apt/keyrings ] || sudo mkdir -p -m 755 /etc/apt/keyrings

--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -20,8 +20,23 @@ use_checksum_comparison "${kind_binary_path}" "${kind_external_hash}"
 install "${kind_binary_path}" /usr/local/bin/kind
 
 ## Install kubectl
-kubectl_minor_version=$(curl -fsSL "https://dl.k8s.io/release/stable.txt" | cut -d'.' -f1,2 )
-curl -fsSL https://pkgs.k8s.io/core:/stable:/$kubectl_minor_version/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+apt-get update
+apt-get install ca-certificates apt-transport-https
+
+# Ensure keyrings directory exists only if it doesn't already
+[ -d /etc/apt/keyrings ] || sudo mkdir -p -m 755 /etc/apt/keyrings
+
+kubectl_minor_version=$(curl -fsSL --retry 5 --retry-delay 10 "https://dl.k8s.io/release/stable.txt" | cut -d'.' -f1,2 )
+
+# Download and validate GPG key
+key_url="https://pkgs.k8s.io/core:/stable:/$kubectl_minor_version/deb/Release.key"
+if curl -fsSL --retry 5 --retry-delay 10 -A "Mozilla/5.0" "$key_url" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg; then
+    echo "Key downloaded and stored successfully."
+else
+    echo "Failed to download valid GPG key from: $key_url"
+    exit 1
+fi
+
 echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/'$kubectl_minor_version'/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
 apt-get update
 apt-get install kubectl


### PR DESCRIPTION
# Description
This PR will enhances the installation process by:

  1. Adding retry logic to curl commands for better reliability
  2. Ensuring /etc/apt/keyrings directory exists before storing GPG keys

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
