### PR TITLE
Revert "[Windows 2022] Update `strawberryperl` to `5.40.2.2`"

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -317,7 +317,7 @@
             { "name": "packer" },
             {
                 "name": "strawberryperl" ,
-                "args": [ "--version", "5.40.2.2" ]
+                "args": [ "--version", "5.32.1.1" ]
             },
             { "name": "pulumi" },
             { "name": "swig" },


### PR DESCRIPTION
Reverts actions/runner-images#12508

Breaking cmake default version.
Hence reverting