### PR TITLE
[Ubuntu, Windows] Update edgedriver URL and maven version on ubuntu

### DIFF
--- a/images/ubuntu/scripts/build/install-microsoft-edge.sh
+++ b/images/ubuntu/scripts/build/install-microsoft-edge.sh
@@ -34,11 +34,11 @@ mkdir -p $EDGEDRIVER_DIR
 edge_version=$(microsoft-edge --version | cut -d' ' -f 3)
 edge_version_major=$(echo $edge_version | cut -d'.' -f 1)
 
-edgedriver_version_url="https://msedgedriver.azureedge.net/LATEST_RELEASE_${edge_version_major}_LINUX"
+edgedriver_version_url="https://msedgedriver.microsoft.com/LATEST_RELEASE_${edge_version_major}_LINUX"
 # Convert a resulting file to normal UTF-8
 edgedriver_latest_version=$(curl -fsSL "$edgedriver_version_url" | iconv -f utf-16 -t utf-8 | tr -d '\r')
 
-edgedriver_url="https://msedgedriver.azureedge.net/${edgedriver_latest_version}/edgedriver_linux64.zip"
+edgedriver_url="https://msedgedriver.microsoft.com/${edgedriver_latest_version}/edgedriver_linux64.zip"
 edgedriver_archive_path=$(download_with_retry "$edgedriver_url")
 
 unzip -qq "$edgedriver_archive_path" -d "$EDGEDRIVER_DIR"

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -70,7 +70,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.10"
+        "maven": "3.9.11"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -67,7 +67,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.10"
+        "maven": "3.9.11"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",

--- a/images/windows/scripts/build/Install-EdgeDriver.ps1
+++ b/images/windows/scripts/build/Install-EdgeDriver.ps1
@@ -15,12 +15,12 @@ if (-not (Test-Path -Path $edgeDriverPath)) {
     New-Item -Path $edgeDriverPath -ItemType Directory -Force
 }
 
-$versionInfoUrl = "https://msedgedriver.azureedge.net/LATEST_RELEASE_$($edgeVersion.Major)_WINDOWS"
+$versionInfoUrl = "https://msedgedriver.microsoft.com/LATEST_RELEASE_$($edgeVersion.Major)_WINDOWS"
 $versionInfoFile = Invoke-DownloadWithRetry -Url $versionInfoUrl -Path "$edgeDriverPath\versioninfo.txt"
 $latestVersion = Get-Content -Path $versionInfoFile
 
 Write-Host "Download Microsoft Edge WebDriver..."
-$downloadUrl = "https://msedgedriver.azureedge.net/$latestVersion/edgedriver_win64.zip"
+$downloadUrl = "https://msedgedriver.microsoft.com/$latestVersion/edgedriver_win64.zip"
 $archivePath = Invoke-DownloadWithRetry $downloadUrl
 
 Write-Host "Expand Microsoft Edge WebDriver archive..."


### PR DESCRIPTION
# Description

- This PR will updates the url of edgedriver from msedgedriver.azureedge.net to msedgedriver.microsoft.com  in both ubuntu and Windows images.
- Maven version to 3.9.11 in Ubuntu images

#### Related issue:
https://github.com/actions/runner-images/issues/12597

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
