### PR TITLE
[macOS] Update edgedriver URL for intel macOS images.

### DIFF
--- a/images/macos/scripts/build/install-edge.sh
+++ b/images/macos/scripts/build/install-edge.sh
@@ -17,9 +17,9 @@ echo "Version of Microsoft Edge: ${edge_version}"
 
 echo "Installing Microsoft Edge WebDriver..."
 
-edge_driver_version_file_path=$(download_with_retry "https://msedgedriver.azureedge.net/LATEST_RELEASE_${edge_version_major}_MACOS")
+edge_driver_version_file_path=$(download_with_retry "https://msedgedriver.microsoft.com/LATEST_RELEASE_${edge_version_major}_MACOS")
 edge_driver_latest_version=$(iconv -f utf-16 -t utf-8 "$edge_driver_version_file_path" | tr -d '\r')
-edge_driver_url="https://msedgedriver.azureedge.net/${edge_driver_latest_version}/edgedriver_mac64.zip"
+edge_driver_url="https://msedgedriver.microsoft.com/${edge_driver_latest_version}/edgedriver_mac64.zip"
 
 echo "Compatible version of WebDriver: ${edge_driver_latest_version}"
 


### PR DESCRIPTION
# Description
1. Update Microsoft Edge WebDriver URL for intel macOS images.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
