### PR TITLE
[Ubuntu] Upgrade Kotlin to latest

### DIFF
--- a/images/ubuntu/scripts/build/install-kotlin.sh
+++ b/images/ubuntu/scripts/build/install-kotlin.sh
@@ -9,7 +9,7 @@
 source $HELPER_SCRIPTS/install.sh
 
 KOTLIN_ROOT="/usr/share"
-download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"kotlin-compiler\") and endswith(\".zip\")" "2.1.10")
+download_url=$(resolve_github_release_asset_url "JetBrains/kotlin" "contains(\"kotlin-compiler\") and endswith(\".zip\")" "latest")
 archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - Kotlin

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -387,7 +387,7 @@ Describe "Kotlin" {
     }
 
     It "kotlinc-js" {
-        "kotlinc-js -version" | Should -ReturnZeroExitCode
+        "kotlinc-js -help" | Should -ReturnZeroExitCode
     }
 }
 


### PR DESCRIPTION
# Description
This PR will update Kotlin to latest for Ubuntu 
Running `kotlinc-js -help` confirms that the Kotlin/JS CLI tool is installed and accessible.

#### Related issue:https://github.com/actions/runner-images/issues/12589

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
