### PR TITLE
[macOS] Pin kotlin to latest version(2.2.0)

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -15,15 +15,6 @@ for package in $common_packages; do
             brew install hashicorp/tap/packer
             ;;
 
-        kotlin)
-            # Pin kotlin bottle to 2.1.10 due to an issue with the latest version
-            # https://youtrack.jetbrains.com/issue/KT-76169/kotlinc-js-version-and-kapt-version-returning-non-zero-status-code-on-v2.1.20
-            kotlin_commit="442af88a2925f8c0e079eaf4fa62261133d2d7c4"
-            kotlin_rb_link="https://raw.githubusercontent.com/Homebrew/homebrew-core/$kotlin_commit/Formula/k/kotlin.rb"
-            kotlin_rb_path=$(download_with_retry "$kotlin_rb_link")
-            brew install "$kotlin_rb_path"
-            ;;
-
         cmake)
             # Pin cmake bottle to 3.31.6 due to a backward compatibility issue with the latest version
             # https://github.com/actions/runner-images/issues/11926

--- a/images/macos/scripts/tests/BasicTools.Tests.ps1
+++ b/images/macos/scripts/tests/BasicTools.Tests.ps1
@@ -133,7 +133,7 @@ Describe "Kotlin" {
     $kotlinPackages = @("kapt", "kotlin", "kotlinc", "kotlinc-jvm", "kotlinc-js")
 
     It "<toolName> is available" -TestCases ($kotlinPackages | ForEach-Object { @{ toolName = $_ } }) {
-        "$toolName -version" | Should -ReturnZeroExitCode
+        "$toolName -help" | Should -ReturnZeroExitCode
     }
 }
 


### PR DESCRIPTION
# Description
1. Pin kotlin to latest version(2.2.0)
2. Replaced -version with -help in a test case due to disabled version output for the compiler without a compilable target.
<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
