### PR TITLE
[Windows] Update NSIS toolset to 3.11

### DIFF
--- a/images/windows/Windows2019-Readme.md
+++ b/images/windows/Windows2019-Readme.md
@@ -76,7 +76,7 @@
 - gdb 8.1
 - GNU Binutils 2.30
 - Newman 6.2.1
-- NSIS 3.10
+- NSIS 3.11
 - OpenSSL 1.1.1w
 - Packer 1.12.0
 - Parcel 2.15.4
@@ -547,4 +547,3 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 | mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019     | sha256:f2d95688a349c6d6fc1509ac8d41259e7cfcda6a7f10c14f9294cece8b1cc0dc  | 2025-07-08 |
 | mcr.microsoft.com/windows/nanoserver:1809                                 | sha256:c357ed591af7b24f2d4a12b1947da5e6ebe559d89f41471f6928902c7cda7206  | 2025-07-05 |
 | mcr.microsoft.com/windows/servercore:ltsc2019                             | sha256:2a7cfebaed9241227ad68b1fc7cb764867ea1c56624ece03f926eb8bdf0c998f  | 2025-07-05 |
-

--- a/images/windows/Windows2022-Readme.md
+++ b/images/windows/Windows2022-Readme.md
@@ -75,7 +75,7 @@
 - gdb 11.2
 - GNU Binutils 2.39
 - Newman 6.2.1
-- NSIS 3.10
+- NSIS 3.11
 - OpenSSL 1.1.1w
 - Packer 1.12.0
 - Pulumi 3.181.0
@@ -542,4 +542,3 @@ Note: MSYS2 is pre-installed on image but not added to PATH.
 | mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022     | sha256:425ca73da19ca274edd1b466e1009342b476306de6918eb246758b9482f47927  | 2025-07-08 |
 | mcr.microsoft.com/windows/nanoserver:ltsc2022                             | sha256:9a57174ce85e979529e4f0cd58dff2e837b65fc7832b7585b4882f6cce0e255d  | 2025-07-05 |
 | mcr.microsoft.com/windows/servercore:ltsc2022                             | sha256:3281482945016cdaefbe417edd8338de8119e077b6941f74e78b050da1b7bd97  | 2025-07-05 |
-

--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -428,7 +428,7 @@
         "version": "5.0"
     },
     "nsis": {
-        "version": "3.10"
+        "version": "3.11"
     },
     "php": {
         "version": "8.4"

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -348,7 +348,7 @@
         "version": "5.0"
     },
     "nsis": {
-        "version": "3.10"
+        "version": "3.11"
     },
     "llvm": {
         "version": "20"


### PR DESCRIPTION
# Description
Updates the NSIS (Nullsoft Scriptable Install System) toolset to version 3.11 for `windows-2019` and `windows-2022`. Minor bugfix and security update, release notes can be found [here](https://nsis.sourceforge.io/Docs/AppendixF.html#v3.11). No breaking changes.

I use the preinstalled NSIS toolset to generate installers for several of my projects and would like it to use the latest.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:
#12614
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
