### PR TITLE
Adds shared_gallery_image_version_end_of_life_date

### DIFF
--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -37,6 +37,7 @@ source "azure-arm" "image" {
     image_version                        = var.gallery_image_version
     storage_account_type                 = var.gallery_storage_account_type
   }
+  shared_gallery_image_version_end_of_life_date = var.shared_gallery_image_version_end_of_life_date
 
   dynamic "azure_tag" {
     for_each = var.azure_tags

--- a/images/ubuntu/templates/variable.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/variable.ubuntu.pkr.hcl
@@ -70,6 +70,10 @@ variable "gallery_storage_account_type" {
   type    = string
   default = "${env("GALLERY_STORAGE_ACCOUNT_TYPE")}"
 }
+variable "shared_gallery_image_version_end_of_life_date" {
+  type    = string
+  default = "${env("SHARED_GALLERY_IMAGE_VERSION_END_OF_LIFE_DATE")}"
+}
 variable "image_os_type" {
   type    = string
   default = "Linux"

--- a/images/windows/templates/source.windows.pkr.hcl
+++ b/images/windows/templates/source.windows.pkr.hcl
@@ -43,6 +43,7 @@ source "azure-arm" "image" {
     image_version                        = var.gallery_image_version
     storage_account_type                 = var.gallery_storage_account_type
   }
+  shared_gallery_image_version_end_of_life_date = var.shared_gallery_image_version_end_of_life_date
 
   dynamic "azure_tag" {
     for_each = var.azure_tags

--- a/images/windows/templates/variable.windows.pkr.hcl
+++ b/images/windows/templates/variable.windows.pkr.hcl
@@ -78,6 +78,10 @@ variable "gallery_storage_account_type" {
   type    = string
   default = "${env("GALLERY_STORAGE_ACCOUNT_TYPE")}"
 }
+variable "shared_gallery_image_version_end_of_life_date" {
+  type    = string
+  default = "${env("SHARED_GALLERY_IMAGE_VERSION_END_OF_LIFE_DATE")}"
+}
 variable "image_os_type" {
   type    = string
   default = "Windows"


### PR DESCRIPTION
# Description
Adds shared_gallery_image_version_end_of_life_date.  This property is useful for downstream users adding images to galleries to be able to mark images with an EOL date.

#### Related issue: N/A

## Check list
- [N/A] Related issue / work item is attached
- [N/A] Tests are written (if applicable)
- [N/A] Documentation is updated (if applicable)
- [X] Changes are tested and related VM images are successfully generated
