### PR TITLE
Bugfix/bump docker compose version

### DIFF
--- a/images/ubuntu/Ubuntu2204-Readme.md
+++ b/images/ubuntu/Ubuntu2204-Readme.md
@@ -74,7 +74,7 @@ to accomplish this.
 - CMake 3.31.6
 - CodeQL Action Bundle 2.22.1
 - Docker Amazon ECR Credential Helper 0.10.1
-- Docker Compose v2 2.36.2
+- Docker Compose v2 2.37.0
 - Docker-Buildx 0.25.0
 - Docker Client 28.0.4
 - Docker Server 28.0.4

--- a/images/ubuntu/Ubuntu2404-Readme.md
+++ b/images/ubuntu/Ubuntu2404-Readme.md
@@ -69,7 +69,7 @@ to accomplish this.
 - CMake 3.31.6
 - CodeQL Action Bundle 2.22.1
 - Docker Amazon ECR Credential Helper 0.10.1
-- Docker Compose v2 2.36.2
+- Docker Compose v2 2.37.0
 - Docker-Buildx 0.25.0
 - Docker Client 28.0.4
 - Docker Server 28.0.4

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -250,7 +250,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.36.2",
+                "version": "2.37.0",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -210,7 +210,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.36.2",
+                "version": "2.37.0",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
# Description
Bumping Docker Compose version to 2.37.0


#### Related issue: #12649

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
