### PR TITLE
[Ubuntu] Upgrade docker-compose to fix build regression

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -252,7 +252,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.37.3",
+                "version": "2.38.2",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -212,7 +212,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.37.3",
+                "version": "2.38.2",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
# Description

Fix regression from introducing a breaking change causing stalled docker compose builds with bake used by default.

No version in v2.37 branch is usable.
The issue seems to be fixed in v2.38.0 proper.
I've picked v2.38.2 as the most conservative version having the most fixes added, while not upgrading past v2.39 for new functionality at the same time.

#### Related issue: #12685

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

Tested on stalled CI by upgrading with setup action to confirm resolving the regression. See issue for details, STR, logs and upstream tickets.