### PR TITLE
[Windows-2022] SDK versions have been removed from Visual Studio 2022

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -214,8 +214,6 @@
             "Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.VC.ASAN",
             "Microsoft.VisualStudio.Component.Windows10SDK.19041",
-            "Microsoft.VisualStudio.Component.Windows10SDK.20348",
-            "Microsoft.VisualStudio.Component.Windows11SDK.22000",
             "Microsoft.VisualStudio.Component.Windows11SDK.22621",
             "Microsoft.VisualStudio.Component.Windows11SDK.26100",
             "Microsoft.VisualStudio.Component.Workflow",


### PR DESCRIPTION

The Windows SDK versions have been removed from the Visual Studio 2022 installer: `10.0.18362.0`, `10.0.20348.0` and `10.0.22000.0`  in Windows-2022 image.

#### Related issue:https://github.com/actions/runner-images/issues/12707

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
