### PR TITLE
[Windows-25] updating OpenSSL version to 3.5.2

### DIFF
--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -325,11 +325,11 @@
         "version": "latest"
     },
     "openssl": {
-        "version": "3.5.1",
+        "version": "3.5.2",
         "pinnedDetails": {
-            "link": "https://github.com/actions/runner-images-internal/pull/6702",
-            "reason": "Meaningful reason must be added at next update.",
-            "review-at": "2025-06-01",
+            "link": "https://github.com/openssl/openssl/releases/tag/openssl-3.5.2",
+            "reason": "Installer not found for version 3.5.1",
+            "review-at": "2025-10-10",
             "type": "preexisting-pinned-version-without-reason"
         }
     },


### PR DESCRIPTION
This PR updates the openSSL version to latest i.,e `3.5.2`

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
