### PR TITLE
Add a filename variable to toolset 13 and 14.json file

### DIFF
--- a/images/macos/toolsets/toolset-13.json
+++ b/images/macos/toolsets/toolset-13.json
@@ -3,22 +3,22 @@
         "default": "15.2",
         "x64": {
             "versions": [
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
-                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
-                { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
-                { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
+                { "link": "15.2", "filename": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "filename": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "filename": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "14.3.1", "filename": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
+                { "link": "14.2", "filename": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
+                { "link": "14.1", "filename": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
                 ]
         },
         "arm64":{
             "versions": [
-                { "link": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
-                { "link": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
-                { "link": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
-                { "link": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
-                { "link": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
-                { "link": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
+                { "link": "15.2", "filename": "15.2", "version": "15.2.0+15C500b", "install_runtimes": "default", "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B"},
+                { "link": "15.1", "filename": "15.1", "version": "15.1.0+15C65", "install_runtimes": "default", "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05"},
+                { "link": "15.0.1", "filename": "15.0.1", "version": "15.0.1+15A507", "symlinks": ["15.0"], "install_runtimes": "default", "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8"},
+                { "link": "14.3.1", "filename": "14.3.1", "version": "14.3.1+14E300c","symlinks": ["14.3"], "install_runtimes": "default", "sha256": "B5CC7BF37447C32A971B37D71C7DA1AF7ABB45CEE4B96FE126A1D3B0D2C260AF"},
+                { "link": "14.2", "filename": "14.2", "version": "14.2.0+14C18", "install_runtimes": "default", "sha256": "686B9D53CA49E50D563BC0104B1E8B4F7CCFE80064A6D689965FB819BF8EFE72"},
+                { "link": "14.1", "filename": "14.1", "version": "14.1.0+14B47b", "install_runtimes": "default", "sha256": "12F8A3AEF78BF354470AD8B351ADDD925C8EDAD888137D138CA50A8130EB9F2F"}
             ]
         }
     },

--- a/images/macos/toolsets/toolset-14.json
+++ b/images/macos/toolsets/toolset-14.json
@@ -5,6 +5,7 @@
             "versions": [
                 {
                     "link": "16.2",
+                    "filename": "16.2",
                     "version": "16.2+16C5032a",
                     "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
                     "install_runtimes": [
@@ -15,36 +16,42 @@
                 },
                 {
                     "link": "16.1",
+                    "filename": "16.1",
                     "version": "16.1+16B40",
                     "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.4",
+                    "filename": "15.4",
                     "version": "15.4.0+15F31d",
                     "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.3",
+                    "filename": "15.3",
                     "version": "15.3.0+15E204a",
                     "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.2",
+                    "filename": "15.2",
                     "version": "15.2.0+15C500b",
                     "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.1",
+                    "filename": "15.1",
                     "version": "15.1.0+15C65",
                     "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.0.1",
+                    "filename": "15.0.1",
                     "version": "15.0.1+15A507",
                     "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8",
                     "symlinks": ["15.0"],
@@ -56,6 +63,7 @@
             "versions": [
                 {
                     "link": "16.2",
+                    "filename": "16.2",
                     "version": "16.2+16C5032a",
                     "sha256": "0e367d06eb7c334ea143bada5e4422f56688aabff571bedf0d2ad9434b7290de",
                     "install_runtimes": [
@@ -67,36 +75,42 @@
                 },
                 {
                     "link": "16.1",
+                    "filename": "16.1",
                     "version": "16.1+16B40",
                     "sha256": "8ca961d55981f983d21b99a95a6b0ac04905b837f6e11346ee86d28f12afe720",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.4",
+                    "filename": "15.4",
                     "version": "15.4.0+15F31d",
                     "sha256": "82d3d61804ff3f4c7c82085e91dc701037ddaa770e542848b2477e22f4e8aa7a",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.3",
+                    "filename": "15.3",
                     "version": "15.3.0+15E204a",
                     "sha256": "f13f6a2e2df432c3008e394640b8549a18c285acd7fd148d6c4bac8c3a5af234",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.2",
+                    "filename": "15.2",
                     "version": "15.2.0+15C500b",
                     "sha256": "04E93680C6DDBEC84666531BE412DE778AFC8EAC6AB2037F4C2BE7290818B59B",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.1",
+                    "filename": "15.1",
                     "version": "15.1.0+15C65",
                     "sha256": "857D8DB537BAC82BF99DE0E1D3895D214D4D02101C1340CEF3DAF6E821BA1D05",
                     "install_runtimes": "default"
                 },
                 {
                     "link": "15.0.1",
+                    "filename": "15.0.1",
                     "version": "15.0.1+15A507",
                     "sha256": "5AC17AE6060CAFC3C7112C6DA0B153450BE21F1DE6632777FBA9FBC9D999C9E8",
                     "symlinks": ["15.0"],


### PR DESCRIPTION
# Description
1. Add a filename variable to toolset 13 and 14.json file as all Xcodes on "VendorOS workflow" is causing the vendor-toolset workflow to fail.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
