### PR TITLE
[macOS] Update Packer version function

### DIFF
--- a/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -231,10 +231,8 @@ function Get-WgetVersion {
 }
 
 function Get-PackerVersion {
-    # Packer 1.7.1 has a bug and outputs version to stderr instead of stdout https://github.com/hashicorp/packer/issues/10855
-    $result = Run-Command "packer --version"
-    $packerVersion = [regex]::matches($result, "(\d+.){2}\d+").Value
-    return $packerVersion
+    $packerVersion = Run-Command "packer --version" | Select-String "Packer" | Select-Object -First 1 | Take-Part -Part 1
+    return ($packerVersion.Trim("v"))
 }
 
 function Get-OpenSSLVersion {


### PR DESCRIPTION
# Description

Packer may include update warning. New function version is a bit more precise.

Example of version message:
```txt
Packer v1.14.0

Your version of Packer is out of date! The latest version
is 1.14.1. You can update by downloading from www.packer.io/downloads
```

Example of output before fix:
```
- Packer 1.14.0 1.14.1
```

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
