### PR TITLE
Update Release and Pull Request creation workflows

### DIFF
--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -10,13 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-
     - name: Create release for ${{ github.event.client_payload.ReleaseBranchName }}
-      uses: ncipollo/release-action@v1.16.0
+      uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 #v1.16.0
       with:
         tag: ${{ github.event.client_payload.ReleaseBranchName }}
         name: ${{ github.event.client_payload.ReleaseTitle }}
         body: ${{ github.event.client_payload.ReleaseBody }}
         prerelease: ${{ github.event.client_payload.Prerelease }}
         commit: ${{ github.event.client_payload.Commitish }}
+        allowUpdates: true

--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -26,15 +26,29 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          let response = await github.rest.pulls.create({
+          const pulls = await github.rest.pulls.list({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: "${{ github.event.client_payload.PullRequestTitle }}",
-            head: "${{ github.event.client_payload.ReleaseBranchName }}-docs",
+            head: `${context.repo.owner}:${{ github.event.client_payload.ReleaseBranchName }}-docs`,
             base: "${{ github.event.client_payload.PullRequestBase }}",
-            body: `${{ github.event.client_payload.PullRequestBody }}`
+            state: 'open'
           });
-          return response.data.number
+
+          if (pulls.data.length > 0) {
+            console.log(`Pull request already exists: ${pulls.data[0].html_url}`);
+            return pulls.data[0].number;
+          } else {
+            console.log('No existing pull request found, creating new one');
+            let response = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "${{ github.event.client_payload.PullRequestTitle }}",
+              head: "${{ github.event.client_payload.ReleaseBranchName }}-docs",
+              base: "${{ github.event.client_payload.PullRequestBase }}",
+              body: `${{ github.event.client_payload.PullRequestBody }}`
+            });
+            return response.data.number;
+          }
 
     - name: Request reviewers
       uses: actions/github-script@v7

--- a/.github/workflows/update_github_release.yml
+++ b/.github/workflows/update_github_release.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-
     - name: Update release for ${{ github.event.client_payload.ReleaseBranchName }}
       uses: actions/github-script@v7
       with:


### PR DESCRIPTION
# Description
This pull request updates the GitHub Actions workflows for creating pull requests and managing releases. The main improvements are to prevent duplicate pull requests, ensure releases can be updated, and improve security and maintainability by pinning action versions.

**Pull request creation improvements:**

* Added logic to check for existing open pull requests with the same branch and base before creating a new one, preventing duplicate pull requests. [[1]](diffhunk://#diff-309fddc424538bb928d4cc02352e7be7caa17631d883022b4eef91d43f0951a8R29-R41) [[2]](diffhunk://#diff-309fddc424538bb928d4cc02352e7be7caa17631d883022b4eef91d43f0951a8L37-R51)

**Release management improvements:**

* Updated the `ncipollo/release-action` usage to a specific commit hash for improved security and traceability, and enabled the `allowUpdates` option to allow updating existing releases.

**Workflow simplification:**

* Removed unnecessary `actions/checkout` steps from both the release creation and update workflows, reducing workflow complexity. [[1]](diffhunk://#diff-98f8dd2dd663e076bdeb897aef366ead8dcfbacf7b2006caa198b916af2eca29L13-R21) [[2]](diffhunk://#diff-09674acc123aa87ea4519ea6a67cc39b197f3bdde5f748c31dfb50b202316e8fL13-L14)

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
