### PR TITLE
Parse Tags like in GenerateResourcesAndImage.ps1

### DIFF
--- a/images.CI/linux-and-win/build-image.ps1
+++ b/images.CI/linux-and-win/build-image.ps1
@@ -38,7 +38,14 @@ $SensitiveData = @(
     ':  ->'
 )
 
-$azure_tags = $Tags | ConvertTo-Json -Compress
+# Prepare tags
+$TagsJson = $Tags | ConvertTo-Json -Compress
+if ($PSVersionTable.PSVersion.Major -eq 5) {
+    $TagsJson = $TagsJson -replace '"', '\"'
+}
+elseif ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -le 2) {
+    $TagsJson = $TagsJson -replace '"', '\"'
+}
 
 Write-Host "Show Packer Version"
 packer --version
@@ -66,7 +73,7 @@ packer build    -only "$buildName*" `
                 -var "virtual_network_subnet_name=$VirtualNetworkSubnet" `
                 -var "allowed_inbound_ip_addresses=$($AllowedInboundIpAddresses)" `
                 -var "use_azure_cli_auth=$UseAzureCliAuth" `
-                -var "azure_tags=$azure_tags" `
+                -var "azure_tags=$TagsJson" `
                 -color=false `
                 $TemplatePath `
         | Where-Object {


### PR DESCRIPTION
# Description
Bug fixing. Adjust the logic of dealing with Tags in a way that is an exact copy of the logic within GenerateResourcesAndImage.ps1 . This solves a parsing error.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
