### PR TITLE
[macOS] Disable conflicting components for Xcode 26 beta

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -9,7 +9,7 @@
                     "version": "26.0.0-Beta.6+17A5305f",
                     "symlinks": ["26.0"],
                     "sha256": "969b8dfe04c366a1900db6052aae7e711f3ecd34b1cfd08f51b5f98c031c2abd",
-                    "install_runtimes": "default"
+                    "install_runtimes": "none"
                 },
                 {
                     "link": "16.4",
@@ -61,7 +61,7 @@
                     "version": "26.0.0-Beta.6+17A5305f",
                     "symlinks": ["26.0"],
                     "sha256": "969b8dfe04c366a1900db6052aae7e711f3ecd34b1cfd08f51b5f98c031c2abd",
-                    "install_runtimes": "default"
+                    "install_runtimes": "none"
                 },
                 {
                     "link": "16.4",


### PR DESCRIPTION
# Description

These simulators cause too many small problems. Each of them is workable, but it is not the best price for providing beta runtimes.

#### Related issue:

https://github.com/actions/runner-images/issues/12862

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
