### PR TITLE
Deprecate macOS 13 and macOS 13 Arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 | macOS 15 Arm64 | `macos-15` or `macos-15-xlarge` | [macOS-15-arm64] |
 | macOS 14 | `macos-latest-large` or `macos-14-large`| [macOS-14] |
 | macOS 14 Arm64 |`macos-latest`, `macos-14`, `macos-latest-xlarge` or `macos-14-xlarge`| [macOS-14-arm64] |
-| macOS 13 | `macos-13` or `macos-13-large` | [macOS-13] |
-| macOS 13 Arm64 | `macos-13-xlarge` | [macOS-13-arm64] |
+| macOS 13 ![Deprecated](https://img.shields.io/badge/-Deprecated-red) | `macos-13` or `macos-13-large` | [macOS-13] |
+| macOS 13 Arm64 ![Deprecated](https://img.shields.io/badge/-Deprecated-red) | `macos-13-xlarge` | [macOS-13-arm64] |
 | Windows Server 2025 | `windows-2025` | [windows-2025] |
 | Windows Server 2022 | `windows-latest` or `windows-2022` | [windows-2022] |
 | Windows Server 2019 ![Deprecated](https://img.shields.io/badge/-Deprecated-red) | `windows-2019` | [windows-2019] |


### PR DESCRIPTION
# Description

I see that the[ Intel Mac runners are being deprecated](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/), and the  process will start on Sept 1st 2025 (so Apologies if I have jumped the gun on this). In the process of updating my workflows, I came to this repo find out what other MacOs options I have. I figured adding the deprecation badge that to the macOS 13 and macOS 13 Arm64 runners would be helpful to others.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
