### PR TITLE
[ubuntu] Adjust provisioner pause after reboot

### DIFF
--- a/images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl
@@ -200,7 +200,7 @@ build {
 
   provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    pause_before        = "1m0s"
+    pause_before        = "5m0s"
     scripts             = ["${path.root}/../scripts/build/cleanup.sh"]
     start_retry_timeout = "10m"
   }

--- a/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
@@ -189,7 +189,7 @@ provisioner "shell" {
 
   provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-    pause_before        = "1m0s"
+    pause_before        = "5m0s"
     scripts             = ["${path.root}/../scripts/build/cleanup.sh"]
     start_retry_timeout = "10m"
   }


### PR DESCRIPTION
# Description
This pull request makes a minor adjustment to the build process for Ubuntu images by increasing the pause before executing a shell provisioner script. This change gives the system more time to stabilize before running cleanup operations.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
