### PR TITLE
 [doc] Updating Windows-2025 image as windows-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To build a VM machine from this repo's source, see the [instructions](docs/creat
 | macOS 14 Arm64 | `macos-14` or `macos-14-xlarge`| [macOS-14-arm64] |
 | macOS 13 | `macos-13` or `macos-13-large` | [macOS-13] |
 | macOS 13 Arm64 | `macos-13-xlarge` | [macOS-13-arm64] |
-| Windows Server 2025 | `windows-2025` | [windows-2025] |
-| Windows Server 2022 | `windows-latest` or `windows-2022` | [windows-2022] |
+| Windows Server 2025 | `windows-latest` or `windows-2025` | [windows-2025] |
+| Windows Server 2022 | `windows-2022` | [windows-2022] |
 | Windows Server 2019 ![Deprecated](https://img.shields.io/badge/-Deprecated-red) | `windows-2019` | [windows-2019] |
 
 ### Label scheme


### PR DESCRIPTION
# Description
Updating Windows-2025 image as windows-latest

#### Related issue:
https://github.com/actions/runner-images/issues/12677

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
