### PR TITLE
[macOS] Unpin Cmake from 3.31.6 version

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -15,28 +15,6 @@ for package in $common_packages; do
             brew install hashicorp/tap/packer
             ;;
 
-        cmake)
-            # Pin cmake to 3.31.6 due to a backward compatibility issue
-            # https://github.com/actions/runner-images/issues/11926
-            cmake_commit="b4e46db74e74a8c1650b38b1da222284ce1ec5ce"
-            tap_name="local/pinned"
-            
-            echo "Creating local tap (no git)..."
-            brew tap-new --no-git "$tap_name" >/dev/null
-            
-            cmake_formula_dir="$(brew --repo "$tap_name")/Formula"
-            mkdir -p "$cmake_formula_dir"
-            
-            cmake_rb_link="https://raw.githubusercontent.com/Homebrew/homebrew-core/$cmake_commit/Formula/c/cmake.rb"
-            cmake_rb_path="$cmake_formula_dir/cmake.rb"
-            
-            echo "Downloading cmake.rb from $cmake_rb_link"
-            curl -fsSL "$cmake_rb_link" -o "$cmake_rb_path"
-            
-            echo "Installing cmake 3.31.6 from custom tap..."
-            brew install "$tap_name/cmake"
-            ;;
-
         tcl-tk@8)
             brew_smart_install "$package"
             if is_VenturaX64 || is_SonomaX64; then


### PR DESCRIPTION
# Description

Using tap breaks packages that depend on Cmake.

#### Related issue:

https://github.com/actions/runner-images/issues/12934
https://github.com/actions/runner-images/issues/12912

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
