### PR TITLE
[macOS]Pin Git to 2.50.1 version

### DIFF
--- a/images/macos/scripts/build/install-git.sh
+++ b/images/macos/scripts/build/install-git.sh
@@ -7,7 +7,15 @@
 source ~/utils/utils.sh
 
 echo "Installing Git..."
-brew_smart_install "git"
+#brew_smart_install "git"
+
+# pin Git to 2.50.1 due to problem is in Git latest version 2.51.0
+COMMIT=6b39030bc0d0a0a8df99afe37e5ae4d61ba07c88
+FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/g/git.rb"
+FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/g/git.rb"
+mkdir -p "$(dirname $FORMULA_PATH)"
+curl -fsSL $FORMULA_URL -o $FORMULA_PATH
+HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install git
 
 git config --global --add safe.directory "*"
 


### PR DESCRIPTION
# Description
1. Pin Git to 2.50.1 due to problem with Git latest version 2.51.0
2. Related Issue: [#12936](https://github.com/actions/runner-images/issues/12936)

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
