### PR TITLE
[windows] Update uri for mongo releases

### DIFF
--- a/images/windows/scripts/build/Install-MongoDB.ps1
+++ b/images/windows/scripts/build/Install-MongoDB.ps1
@@ -7,7 +7,7 @@
 $toolsetContent = Get-ToolsetContent
 $toolsetVersion = $toolsetContent.mongodb.version
 
-$getMongoReleases = Invoke-WebRequest -Uri "mongodb.com/docs/manual/release-notes/$toolsetVersion/" -UseBasicParsing
+$getMongoReleases = Invoke-WebRequest -Uri "mongodb.com/docs/v$toolsetVersion/release-notes/$toolsetVersion/" -UseBasicParsing
 $targetReleases = $getMongoReleases.Links.href | Where-Object { $_ -like "#$toolsetVersion*---*" }
 
 $minorVersions = @()


### PR DESCRIPTION
# Description
Mongo documentation structure has changed for `v5.0*` and `v6.0*`.
This PR updates Uri used for parsing latest patch version
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
