### PR TITLE
[macOS] Update Xcode 26 to 26.0 Release

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,12 +4,12 @@
         "x64": {
             "versions": [
                 {
-                    "link": "26_Release_Candidate",
-                    "filename": "26_Release_Candidate_Universal",
-                    "version": "26_Release_Candidate+17A321",
+                    "link": "26",
+                    "filename": "26_Universal",
+                    "version": "26+17A324",
                     "symlinks": ["26.0"],
-                    "sha256": "d56b62964b21c25901e5e48db22ff40862ff490fd3f955704ecd53ca9076db4e",
-                    "install_runtimes": "none"
+                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
+                    "install_runtimes": "default"
                 },
                 {
                     "link": "16.4",
@@ -56,12 +56,12 @@
         "arm64":{
             "versions": [
                 {
-                    "link": "26_Release_Candidate",
-                    "filename": "26_Release_Candidate_Universal",
-                    "version": "26_Release_Candidate+17A321",
+                    "link": "26",
+                    "filename": "26_Universal",
+                    "version": "26+17A324",
                     "symlinks": ["26.0"],
-                    "sha256": "d56b62964b21c25901e5e48db22ff40862ff490fd3f955704ecd53ca9076db4e",
-                    "install_runtimes": "none"
+                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
+                    "install_runtimes": "default"
                 },
                 {
                     "link": "16.4",

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -1,14 +1,14 @@
 {
     "xcode": {
-        "default": "26_Release_Candidate",
+        "default": "26",
         "arm64":{
             "versions": [
                 {
-                    "link": "26_Release_Candidate",
-                    "filename": "26_Release_Candidate_Universal",
-                    "version": "26_Release_Candidate+17A321",
+                    "link": "26",
+                    "filename": "26_Universal",
+                    "version": "26+17A324",
                     "symlinks": ["26.0"],
-                    "sha256": "d56b62964b21c25901e5e48db22ff40862ff490fd3f955704ecd53ca9076db4e",
+                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
                     "install_runtimes": "default"
                 },
                 {


### PR DESCRIPTION
# Description

New Xcode was released. Delivering with runtimes.

#### Related issue:

https://github.com/actions/runner-images/issues/12991

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
