### PR TITLE
[all OSs] Pin Rust to 1.89.0 due to a 1.90.0 breaking change

### DIFF
--- a/images/macos/scripts/build/install-rust.sh
+++ b/images/macos/scripts/build/install-rust.sh
@@ -10,7 +10,8 @@ echo "Installing Rustup..."
 brew_smart_install "rustup-init"
 
 echo "Installing Rust language..."
-rustup-init -y --no-modify-path --default-toolchain=stable --profile=minimal
+# Pin to 1.89.0 until https://github.com/actions/runner-images/issues/13041 && https://github.com/rust-lang/rust/issues/145936 is resolved
+rustup-init -y --no-modify-path --default-toolchain=1.89.0 --profile=minimal
 
 echo "Initialize environment variables..."
 CARGO_HOME=$HOME/.cargo

--- a/images/ubuntu/scripts/build/install-rust.sh
+++ b/images/ubuntu/scripts/build/install-rust.sh
@@ -11,7 +11,8 @@ source $HELPER_SCRIPTS/os.sh
 export RUSTUP_HOME=/etc/skel/.rustup
 export CARGO_HOME=/etc/skel/.cargo
 
-curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+# Pin to 1.89.0 until https://github.com/actions/runner-images/issues/13041 && https://github.com/rust-lang/rust/issues/145936 is resolved
+curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.89.0 --profile=minimal
 
 # Initialize environment variables
 source $CARGO_HOME/env

--- a/images/windows/scripts/build/Install-Rust.ps1
+++ b/images/windows/scripts/build/Install-Rust.ps1
@@ -18,7 +18,8 @@ Test-FileChecksum $rustupPath -ExpectedSHA256Sum $distributorFileHash
 #endregion
 
 # Install Rust by running rustup-init.exe (disabling the confirmation prompt with -y)
-& $rustupPath -y --default-toolchain=stable --profile=minimal
+# Pin to 1.89.0 until https://github.com/actions/runner-images/issues/13041 && https://github.com/rust-lang/rust/issues/145936 is resolved
+& $rustupPath -y --default-toolchain=1.89.0 --profile=minimal
 if ($LASTEXITCODE -ne 0) {
     throw "Rust installation failed with exit code $LASTEXITCODE"
 }


### PR DESCRIPTION
# Description

Initially reported issue highlights upcoming breaking change. Let's pin current version until some information on that behaviour provided in the developers repo: https://github.com/rust-lang/rust/issues/145936

#### Related issue:

https://github.com/actions/runner-images/issues/13041

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
