### PR TITLE
Adding Xcode 26.0.1 to macOS 15 images

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -7,7 +7,6 @@
                     "link": "26.0.1",
                     "filename": "26.0.1_Universal",
                     "version": "26.0.1+17A400",
-                    "symlinks": ["26.0.1"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
                     "install_runtimes": "default"
                 },
@@ -67,7 +66,6 @@
                     "link": "26.0.1",
                     "filename": "26.0.1_Universal",
                     "version": "26.0.1+17A400",
-                    "symlinks": ["26.0.1"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
                     "install_runtimes": "default"
                 },

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -4,6 +4,14 @@
         "x64": {
             "versions": [
                 {
+                    "link": "26.0.1",
+                    "filename": "26.0.1",
+                    "version": "26.0.1+17A400",
+                    "symlinks": ["26.0.1"],
+                    "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
+                    "install_runtimes": "default"
+                },
+                {
                     "link": "26",
                     "filename": "26_Universal",
                     "version": "26+17A324",
@@ -55,6 +63,14 @@
         },
         "arm64":{
             "versions": [
+                   {
+                    "link": "26.0.1",
+                    "filename": "26.0.1",
+                    "version": "26.0.1+17A400",
+                    "symlinks": ["26.0.1"],
+                    "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
+                    "install_runtimes": "default"
+                },
                 {
                     "link": "26",
                     "filename": "26_Universal",

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -5,7 +5,7 @@
             "versions": [
                 {
                     "link": "26.0.1",
-                    "filename": "26.0.1",
+                    "filename": "26.0.1_Apple_silicon",
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0.1"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
@@ -65,7 +65,7 @@
             "versions": [
                    {
                     "link": "26.0.1",
-                    "filename": "26.0.1",
+                    "filename": "26.0.1_Apple_silicon",
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0.1"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -5,7 +5,7 @@
             "versions": [
                 {
                     "link": "26.0.1",
-                    "filename": "26.0.1_Apple_silicon",
+                    "filename": "26.0.1_Universal",
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0.1"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
@@ -65,7 +65,7 @@
             "versions": [
                    {
                     "link": "26.0.1",
-                    "filename": "26.0.1_Apple_silicon",
+                    "filename": "26.0.1_Universal",
                     "version": "26.0.1+17A400",
                     "symlinks": ["26.0.1"],
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",

--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -11,14 +11,6 @@
                     "install_runtimes": "default"
                 },
                 {
-                    "link": "26",
-                    "filename": "26_Universal",
-                    "version": "26+17A324",
-                    "symlinks": ["26.0"],
-                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
-                    "install_runtimes": "default"
-                },
-                {
                     "link": "16.4",
                     "filename": "16.4",
                     "version": "16.4.0+16F6",
@@ -67,14 +59,6 @@
                     "filename": "26.0.1_Universal",
                     "version": "26.0.1+17A400",
                     "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
-                    "install_runtimes": "default"
-                },
-                {
-                    "link": "26",
-                    "filename": "26_Universal",
-                    "version": "26+17A324",
-                    "symlinks": ["26.0"],
-                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
                     "install_runtimes": "default"
                 },
                 {


### PR DESCRIPTION
# Description
Adding Xcode26.0.1 to macOS 15 images

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
