### PR TITLE
Update Xcode 26.0 to 26.0.1 on macOS15 and macOS 26

### DIFF
--- a/images/macos/toolsets/toolset-15.json
+++ b/images/macos/toolsets/toolset-15.json
@@ -3,12 +3,12 @@
         "default": "16.4",
         "x64": {
             "versions": [
-                {
-                    "link": "26",
-                    "filename": "26_Universal",
-                    "version": "26+17A324",
+                  {
+                    "link": "26.0.1",
+                    "filename": "26.0.1_Universal",
+                    "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
-                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
+                    "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
                     "install_runtimes": "default"
                 },
                 {
@@ -55,12 +55,12 @@
         },
         "arm64":{
             "versions": [
-                {
-                    "link": "26",
-                    "filename": "26_Universal",
-                    "version": "26+17A324",
+              {
+                    "link": "26.0.1",
+                    "filename": "26.0.1_Universal",
+                    "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
-                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
+                    "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
                     "install_runtimes": "default"
                 },
                 {

--- a/images/macos/toolsets/toolset-26.json
+++ b/images/macos/toolsets/toolset-26.json
@@ -1,14 +1,14 @@
 {
     "xcode": {
-        "default": "26",
+        "default": "26.0.1",
         "arm64":{
             "versions": [
-                {
-                    "link": "26",
-                    "filename": "26_Universal",
-                    "version": "26+17A324",
+              {
+                    "link": "26.0.1",
+                    "filename": "26.0.1_Universal",
+                    "version": "26.0.1+17A400",
                     "symlinks": ["26.0"],
-                    "sha256": "848f8de2c9f91ef2dad4eec8ff88655222a08f3eb32c4083432c51ae2480a70f",
+                    "sha256": "9881c457068c86ac91e94cca2d7116dfd01cb7179c22b0863b63c7f3bb7e7695",
                     "install_runtimes": "default"
                 },
                 {


### PR DESCRIPTION
# Description
Update Xcode 26.0 to 26.0.1 on macOS15 and macOS 26

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
