### PR TITLE
[Windows 2025] Add InnoSetup.

### DIFF
--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -83,9 +83,7 @@ if (Test-IsWin19) {
     $tools.AddToolVersion("Google Cloud CLI", $(Get-GoogleCloudCLIVersion))
 }
 $tools.AddToolVersion("ImageMagick", $(Get-ImageMagickVersion))
-if (-not (Test-IsWin25)) {
-    $tools.AddToolVersion("InnoSetup", $(Get-InnoSetupVersion))
-}
+$tools.AddToolVersion("InnoSetup", $(Get-InnoSetupVersion))
 $tools.AddToolVersion("jq", $(Get-JQVersion))
 $tools.AddToolVersion("Kind", $(Get-KindVersion))
 $tools.AddToolVersion("Kubectl", $(Get-KubectlVersion))

--- a/images/windows/scripts/tests/ChocoPackages.Tests.ps1
+++ b/images/windows/scripts/tests/ChocoPackages.Tests.ps1
@@ -28,7 +28,7 @@ Describe "GitVersion" -Skip:(-not (Test-IsWin19)) {
     }
 }
 
-Describe "InnoSetup" -Skip:(Test-IsWin25) {
+Describe "InnoSetup" {
     It "InnoSetup" {
         (Get-Command -Name iscc).CommandType | Should -BeExactly "Application"
     }

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -278,6 +278,7 @@
             { "name": "aria2" },
             { "name": "azcopy10" },
             { "name": "Bicep" },
+            { "name": "innosetup" },
             { "name": "jq" },
             { "name": "NuGet.CommandLine" },
             { "name": "packer" },


### PR DESCRIPTION
# Description
This PR adds InnoSetup to windows 2025 image.
#### Related issue:
https://github.com/actions/runner-images/issues/12947
## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
