### PR TITLE
[Windows] Update MinGW on 2022 and 2025, disable alert for 2019

### DIFF
--- a/images/windows/toolsets/toolset-2019.json
+++ b/images/windows/toolsets/toolset-2019.json
@@ -437,9 +437,9 @@
     "kotlin": {
         "version": "2.1.10",
         "pinnedDetails": {
-            "link": "https://youtrack.jetbrains.com/issues/KT?preview=KT-76169",
-            "reason": "this was pinned due to a new version 2.1.20 released has an issue with kotlinc-js -version` and kapt -version",
-            "review-at": "2025-03-31"
+            "link": "https://github.com/actions/runner-images/issues/12045",
+            "reason": "Image is deprecated and will be removed soon",
+            "review-at": "2027-01-01"
         }
     },
     "openssl": {

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -128,14 +128,8 @@
         }
     },
     "mingw": {
-        "version": "12.2.0",
-        "runtime": "ucrt",
-        "pinnedDetails": {
-            "link": "https://github.com/actions/runner-images-internal/pull/6702",
-            "reason": "Meaningful reason must be added at next update.",
-            "review-at": "2025-06-01",
-            "type": "preexisting-pinned-version-without-reason"
-        }
+        "version": "14.*",
+        "runtime": "ucrt"
     },
     "MsysPackages": {
         "msys2": [],

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -110,14 +110,8 @@
         }
     },
     "mingw": {
-        "version": "14.2.0",
-        "runtime": "ucrt",
-        "pinnedDetails": {
-            "link": "https://github.com/actions/runner-images-internal/pull/6702",
-            "reason": "Meaningful reason must be added at next update.",
-            "review-at": "2025-06-01",
-            "type": "preexisting-pinned-version-without-reason"
-        }
+        "version": "15.*",
+        "runtime": "ucrt"
     },
     "MsysPackages": {
         "msys2": [],


### PR DESCRIPTION
# Description

- Push MinGW version to 14.* for Windows 2022
- Push MinGW version to 15.* for Windows 2025
- Disable Kotlin pinning notification for Windows 2019

#### Related issue:

https://github.com/actions/runner-images/issues/13097

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
