### PR TITLE
[Ubuntu] Add ssh_clear_authorized_keys to Packer template

### DIFF
--- a/images/ubuntu/templates/source.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/source.ubuntu.pkr.hcl
@@ -22,6 +22,7 @@ source "azure-arm" "image" {
   os_disk_size_gb                        = local.image_properties.os_disk_size_gb
   os_type                                = var.image_os_type
   private_virtual_network_with_public_ip = var.private_virtual_network_with_public_ip
+  ssh_clear_authorized_keys              = var.ssh_clear_authorized_keys
   temp_resource_group_name               = var.temp_resource_group_name
   virtual_network_name                   = var.virtual_network_name
   virtual_network_resource_group_name    = var.virtual_network_resource_group_name

--- a/images/ubuntu/templates/variable.ubuntu.pkr.hcl
+++ b/images/ubuntu/templates/variable.ubuntu.pkr.hcl
@@ -102,6 +102,10 @@ variable "source_image_version" {
   type    = string
   default = "latest"
 }
+variable "ssh_clear_authorized_keys" {
+  type    = bool
+  default = true
+}
 variable "temp_resource_group_name" {
   type    = string
   default = "${env("TEMP_RESOURCE_GROUP_NAME")}"


### PR DESCRIPTION
# Description
This pull request introduces a new configuration option to the Ubuntu image build process, allowing control over whether SSH authorized keys are cleared during image creation. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
