### PR TITLE
[Ubuntu] Add PostgreSQL to arm64 images

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -259,9 +259,7 @@ $netCoreTools.AddNodes($(Get-DotnetTools))
 # Databases
 $databasesTools = $installedSoftware.AddHeader("Databases")
 $databasesTools.AddToolVersion("sqlite3", $(Get-SqliteVersion))
-if (Test-IsX64) {
-    $databasesTools.AddNode($(Build-PostgreSqlSection))
-}
+$databasesTools.AddNode($(Build-PostgreSqlSection))
 $databasesTools.AddNode($(Build-MySQLSection))
 if (Test-IsUbuntu22-X64) {
     $databasesTools.AddNode($(Build-MSSQLToolsSection))

--- a/images/ubuntu/scripts/tests/Databases.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Databases.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "PostgreSQL" -Skip:(Test-IsArm64) {
+Describe "PostgreSQL" {
     It "PostgreSQL Service" {
         "sudo systemctl start postgresql" | Should -ReturnZeroExitCode
         "pg_isready" | Should -OutputTextMatchingRegex "/var/run/postgresql:5432 - accepting connections"

--- a/images/ubuntu/templates/build.ubuntu-22_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-22_04-arm64.pkr.hcl
@@ -128,6 +128,7 @@ build {
       "${path.root}/../scripts/build/install-nodejs.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",

--- a/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
@@ -127,6 +127,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-nodejs.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",

--- a/images/ubuntu/templates/build.ubuntu-26_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-26_04-arm64.pkr.hcl
@@ -126,6 +126,7 @@ provisioner "shell" {
       "${path.root}/../scripts/build/install-nodejs.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
       "${path.root}/../scripts/build/install-ruby.sh",
       "${path.root}/../scripts/build/install-rust.sh",
       "${path.root}/../scripts/build/install-selenium.sh",


### PR DESCRIPTION
x64 images already have PostgreSQL installed. Since `psql` is such a popular tool among developers, and GitHub now maintains arm64 images, it makes sense to install it on arm64 images as well.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
