### PR TITLE
[Windows] Add v143 ARM64 build tools to windows-2025-vs2026

### DIFF
--- a/images/windows/toolsets/toolset-2025-vs2026.json
+++ b/images/windows/toolsets/toolset-2025-vs2026.json
@@ -171,6 +171,7 @@
             "Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre",
             "Microsoft.VisualStudio.Component.VC.ASAN",
             "Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64",
+            "Microsoft.VisualStudio.Component.VC.14.44.17.14.ARM64",
             "Microsoft.VisualStudio.Component.Windows11SDK.26100",
             "Microsoft.VisualStudio.Component.Workflow",
             "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang",


### PR DESCRIPTION
# Description
Bug fix. Adds the v143 (MSVC 14.44 / VS 17.14) ARM64 toolset component to `windows-2025-vs2026`.

The pinned v143 toolset was installed only in the x86/x64 flavor (`VC.14.44.17.14.x86.x64`), while the native `windows-11-vs2026-arm` image also ships the ARM64 flavor (`VC.14.44.17.14.ARM64`). As a result, ARM64 builds with PlatformToolset `v143` failed on `windows-2025-vs2026`. This adds the missing ARM64 component so cross-compilation matches the ARM image.

#### Related issue:
Fixes #14552

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
