### PR TITLE
[windows-11] Document that Defender is not disabled (Tamper Protection)

### DIFF
--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -254,6 +254,14 @@ if (Test-IsWin22-X64) {
     $installedSoftware.AddHeader("Cached Docker images").AddTable($(Get-CachedDockerImagesTableData))
 }
 
+# Notes (Windows 11 only): Defender can't be disabled here, Tamper Protection blocks it. See issue #14326
+if (Test-IsWin11-Arm64) {
+    $defenderNote = @'
+Microsoft Defender is not disabled on this image. Tamper Protection is enabled by default on Windows 11 and prevents the image build from disabling it. See https://github.com/actions/runner-images/issues/14326 for details.
+'@
+    $softwareReport.Root.AddHeader("Notes").AddNote($defenderNote)
+}
+
 # Generate reports
 $softwareReport.ToJson() | Out-File -FilePath "C:\software-report.json" -Encoding UTF8NoBOM
 $softwareReport.ToMarkdown() | Out-File -FilePath "C:\software-report.md" -Encoding UTF8NoBOM

--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -254,7 +254,7 @@ if (Test-IsWin22-X64) {
     $installedSoftware.AddHeader("Cached Docker images").AddTable($(Get-CachedDockerImagesTableData))
 }
 
-# Notes (Windows 11 only): Defender can't be disabled here, Tamper Protection blocks it. See issue #14326
+# Notes (Windows 11 Arm64 only): Defender can't be disabled here, Tamper Protection blocks it. See issue #14326
 if (Test-IsWin11-Arm64) {
     $defenderNote = @'
 Microsoft Defender is not disabled on this image. Tamper Protection is enabled by default on Windows 11 and prevents the image build from disabling it. See https://github.com/actions/runner-images/issues/14326 for details.


### PR DESCRIPTION
# Description
Improvement (documentation). Adds a "Notes" section at the end of the Windows 11 (Arm64) image READMEs stating that Microsoft Defender is not disabled, because Tamper Protection is enabled by default on Windows 11 and blocks the image build from disabling it. This is a Windows platform limitation (confirmed against Microsoft's docs) — Defender can't be disabled from the build. Follow-up to the investigation in #14326.

The note is added via the software-report generator (`Generate-SoftwareReport.ps1`), guarded by `Test-IsWin11-Arm64`, so it renders on both Win11 images (plain and VS2026) and survives README regeneration.

#### Related issue:
actions/runner-images#14326

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated