### PR TITLE
[Windows] Stage x64 dbghelp.dll for ARM64 Debugging Tools

### DIFF
--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -53,12 +53,32 @@ if (Test-IsWin25-X64) {
     $installerEntry = Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* `
         | Where-Object { $_.DisplayName -match "Windows Software Development Kit" } `
         | Sort-Object DisplayVersion -Descending | Select-Object -First 1
-    
+
     if ($installerEntry -and $installerEntry.BundleCachePath) {
         Install-Binary -Type EXE `
             -LocalPath $installerEntry.BundleCachePath `
             -InstallArgs @("/features", "OptionId.WindowsDesktopDebuggers", "/q", "/norestart") `
             -ExpectedSubject $(Get-MicrosoftPublisher)
+    }
+}
+
+# On ARM64 the Windows SDK installer never provides the x64 Debugging Tools, so
+# Debuggers\x64\dbghelp.dll is missing. Chromium's vs_toolchain.py copies that file for
+# its win_clang_x64 host toolchain even in a native arm64 build, so builds fail without it.
+# The x64 dbghelp.dll already ships under the SDK bin folder; stage it where it is expected.
+if (Test-IsWin11-Arm64) {
+    $kitsRoot = "${env:ProgramFiles(x86)}\Windows Kits\10"
+    $x64DbgHelp = Get-ChildItem "$kitsRoot\bin\*\x64\dbghelp.dll" -ErrorAction SilentlyContinue `
+        | Sort-Object { $_.VersionInfo.FileVersionRaw } -Descending | Select-Object -First 1
+    if (-not $x64DbgHelp) {
+        throw "x64 dbghelp.dll not found under $kitsRoot\bin - cannot stage x64 Debugging Tools"
+    }
+    $x64DebuggersDir = Join-Path $kitsRoot "Debuggers\x64"
+    New-Item -ItemType Directory -Force -Path $x64DebuggersDir | Out-Null
+    # Do not clobber an existing copy - if a future SDK ever ships its own x64 debuggers, keep it.
+    $destDbgHelp = Join-Path $x64DebuggersDir "dbghelp.dll"
+    if (-not (Test-Path $destDbgHelp)) {
+        Copy-Item -Path $x64DbgHelp.FullName -Destination $destDbgHelp -Force
     }
 }
 

--- a/images/windows/scripts/tests/VisualStudio.Tests.ps1
+++ b/images/windows/scripts/tests/VisualStudio.Tests.ps1
@@ -36,3 +36,9 @@ Describe "Windows 11 SDK" {
         "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.26100.0\UAP.props" | Should -Exist
     }
 }
+
+Describe "x64 Debugging Tools" -Skip:(-not (Test-IsWin11-Arm64)) {
+    It "Verifies x64 dbghelp.dll is staged for Chromium builds" {
+        "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\dbghelp.dll" | Should -Exist
+    }
+}


### PR DESCRIPTION
# Description
Fixes the Chromium `gn gen` "Debugging Tools for Windows" failure on the ARM64 images (`windows-11-arm`, `windows-11-vs2026-arm64`): `Debuggers\x64\dbghelp.dll` is missing there and the SDK installer won't provide it on ARM64. Copies the x64 `dbghelp.dll` that already ships under the SDK `bin\<ver>\x64` folder into the expected `Debuggers\x64` directory (arm64 only). ~2 MB, sub-second.

Validated on a hosted `windows-11-arm` runner against Chromium's real `vs_toolchain.py` — the x64 check raises the exact error before the change and passes after: [validation run](https://github.com/v-davit-ioramashvili/runner-images/actions/runs/32364498982).

#### Related issue:
Fixes #14061

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
