### PR TITLE
Fix Git not updating from git-core PPA on Ubuntu 26.04 x64

### DIFF
--- a/images/ubuntu/scripts/build/install-git.sh
+++ b/images/ubuntu/scripts/build/install-git.sh
@@ -21,12 +21,6 @@ fi
 apt-get update
 apt-get install git
 
-installed_version=$(dpkg-query -W -f='${Version}' git)
-if [[ "$installed_version" != *ppa* ]]; then
-    echo "git was installed from the distro archive ($installed_version) instead of $GIT_REPO"
-    exit 1
-fi
-
 # Git version 2.35.2 introduces security fix that breaks action\checkout https://github.com/actions/checkout/issues/760
 cat <<EOF >> /etc/gitconfig
 [safe]

--- a/images/ubuntu/scripts/build/install-git.sh
+++ b/images/ubuntu/scripts/build/install-git.sh
@@ -6,13 +6,26 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/os.sh
 
 GIT_REPO="ppa:git-core/ppa"
 
 ## Install git
 add-apt-repository $GIT_REPO -y
+
+# Launchpad advertises an amd64v3 index for this PPA that contains no git (LP#2127888)
+if is_ubuntu26_x64; then
+    sed -i '/^URIs:.*git-core/a Architectures: amd64' /etc/apt/sources.list.d/*.sources
+fi
+
 apt-get update
 apt-get install git
+
+installed_version=$(dpkg-query -W -f='${Version}' git)
+if [[ "$installed_version" != *ppa* ]]; then
+    echo "git was installed from the distro archive ($installed_version) instead of $GIT_REPO"
+    exit 1
+fi
 
 # Git version 2.35.2 introduces security fix that breaks action\checkout https://github.com/actions/checkout/issues/760
 cat <<EOF >> /etc/gitconfig
@@ -22,6 +35,11 @@ EOF
 
 # Install git-ftp
 apt-get install git-ftp
+
+# Restore the entry to what add-apt-repository wrote so --remove still matches it
+if is_ubuntu26_x64; then
+    sed -i '/^URIs:.*git-core/{n;/^Architectures: amd64$/d}' /etc/apt/sources.list.d/*.sources
+fi
 
 # Remove source repo's
 add-apt-repository --remove $GIT_REPO

--- a/images/ubuntu/scripts/build/install-git.sh
+++ b/images/ubuntu/scripts/build/install-git.sh
@@ -10,12 +10,24 @@ source $HELPER_SCRIPTS/os.sh
 
 GIT_REPO="ppa:git-core/ppa"
 
+# Applies a sed script to the git-core PPA stanza, wherever add-apt-repository wrote it
+update_git_ppa_sources() {
+    local sed_script=$1
+    local sources_file
+
+    for sources_file in /etc/apt/sources.list.d/*.sources; do
+        if grep -q '^URIs:.*git-core' "$sources_file"; then
+            sed -i "$sed_script" "$sources_file"
+        fi
+    done
+}
+
 ## Install git
 add-apt-repository $GIT_REPO -y
 
 # Launchpad advertises an amd64v3 index for this PPA that contains no git (LP#2127888)
 if is_ubuntu26_x64; then
-    sed -i '/^URIs:.*git-core/a Architectures: amd64' /etc/apt/sources.list.d/*.sources
+    update_git_ppa_sources '/^URIs:.*git-core/a Architectures: amd64'
 fi
 
 apt-get update
@@ -32,7 +44,7 @@ apt-get install git-ftp
 
 # Restore the entry to what add-apt-repository wrote so --remove still matches it
 if is_ubuntu26_x64; then
-    sed -i '/^URIs:.*git-core/{n;/^Architectures: amd64$/d}' /etc/apt/sources.list.d/*.sources
+    update_git_ppa_sources '/^URIs:.*git-core/{n;/^Architectures: amd64$/d}'
 fi
 
 # Remove source repo's

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -234,6 +234,11 @@ Describe "Git" {
         "git --version" | Should -ReturnZeroExitCode
     }
 
+    # https://github.com/actions/runner-images/issues/14583
+    It "git comes from the git-core PPA" {
+        $(dpkg-query -W -f '${Version}' git) | Should -BeLike "*ppa*"
+    }
+
     It "git-ftp" {
         "git-ftp --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description
This is a bug fix. Ubuntu 26.04 is the first of our images with the `amd64v3` architecture variant, and apt reads that index instead of `amd64` when a repo advertises one. Due to a Launchpad bug (which appears to be [LP#2127888](https://bugs.launchpad.net/launchpad/+bug/2127888)) the git-core PPA advertises an `amd64v3` index it never opted into building, so the index contains only the arch-independent packages and no git at all. Apt concludes the PPA has no Git and silently falls back to the archive version, leaving ubuntu-26.04 stuck on `2.53.0` for nine deployments while every other image tracks the PPA.

This pins the git-core repo to the `amd64` index on 26.04 x64 only, reverting the pin before the repo is removed so the shipped image is unchanged. It also adds a test that fails the build if Git didn't come from the PPA, since `configure-apt-mock.sh` swallows apt exit codes, making this hidden for some time. 

The pin should be reverted once Launchpad is fixed, but it has been stalled since November and deprioritized.

#### Related issues:
[#14583](https://github.com/actions/runner-images/issues/14583)
[#14560](https://github.com/actions/runner-images/issues/14560)

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
