### PR TITLE
[Ubuntu] Roll back Podman static bundle

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -2,103 +2,37 @@
 ################################################################################
 ##  File:  install-container-tools.sh
 ##  Desc:  Install container tools: podman, buildah and skopeo onto the image
-##  Supply chain security: podman static bundle - pinned version + SHA256 validation
 ################################################################################
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/os.sh
-source $HELPER_SCRIPTS/install.sh
 
-# Ubuntu 22.04/24.04 only ship an outdated podman via apt (3.4.4 / 4.9.3) whose
-# Docker-compatible API is too old for the current Docker daemon and breaks
-# `podman push docker-daemon:` (actions/runner-images#13691, #549). There is no
-# maintained podman apt repository for Ubuntu (Kubic/OBS was discontinued), so a
-# current self-contained static bundle (podman + crun/runc + conmon + netavark +
-# aardvark-dns + pasta) is installed instead. Ubuntu 26.04 already ships podman 5.x.
-podman_static_tag="v5.8.4"
-podman_static_sha256_amd64="a58765fe8be6ab3fb79f892f1a027b4ce4a7e8eb589df1ef960c167cbde08d69"
-podman_static_sha256_arm64="a2f6b73cc0f7018e2e8518338a4ec27db70148e1af86e16719235605aefd1df3"
+# Pin podman due to https://github.com/actions/runner-images/issues/7753
+#                   https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394
+if is_ubuntu22; then
+    install_packages=(podman=3.4.4+ds1-1ubuntu1 buildah skopeo)
+else
+    install_packages=(podman buildah skopeo)
+fi
 
-install_podman_static() {
-    local arch checksum
-    if is_x64; then
-        arch="amd64"
-        checksum="$podman_static_sha256_amd64"
-    else
-        arch="arm64"
-        checksum="$podman_static_sha256_arm64"
-    fi
-
-    local archive_url="https://github.com/mgoltzsche/podman-static/releases/download/${podman_static_tag}/podman-linux-${arch}.tar.gz"
-    local archive_path
-    archive_path=$(download_with_retry "$archive_url")
-    use_checksum_comparison "$archive_path" "$checksum"
-
-    # The bundle ships ./usr and ./etc under a single top-level directory.
-    # Every archive entry is stored as uid/gid 1001 (`runner`) because the bundle is
-    # built on a GitHub Actions runner, and the archive also carries the `usr` and
-    # `etc` directory entries themselves. As root, tar restores that ownership by
-    # default and hands /usr and /etc to the unprivileged user, so keep the metadata
-    # of the existing system directories untouched.
-    # https://github.com/actions/runner-images/issues/14477
-    tar -xzf "$archive_path" -C / --strip-components=1 --no-same-owner --no-overwrite-dir \
-        "podman-linux-${arch}/usr" "podman-linux-${arch}/etc"
-    rm -f "$archive_path"
-
-    # podman resolves its OCI runtime from a built-in list of absolute paths in which
-    # /usr/bin/crun precedes /usr/local/bin/crun, and the bundle does not pin the path
-    # either, so podman picks the outdated crun that buildah pulls in from apt (1.14.1
-    # on 24.04) instead of the one shipped with the bundle. That crun rejects the
-    # ociVersion written by podman 5.x with "unknown version specified". Only the path
-    # is corrected, and the drop-in is named to load first so user drop-ins still win.
-    # https://github.com/actions/runner-images/issues/14473
-    mkdir -p /etc/containers/containers.conf.d
-    printf '[engine.runtimes]\ncrun = ["/usr/local/bin/crun"]\n' \
-        | tee /etc/containers/containers.conf.d/00-fix-runtime.conf
-
-    # The bundle's non-setuid fusermount3 shadows the distro's setuid
-    # /usr/bin/fusermount3 (PATH order) and breaks unprivileged FUSE mounts.
-    # https://github.com/actions/runner-images/issues/14516
-    rm -f /usr/local/bin/fusermount3
-
-    # Ubuntu >= 23.10 restricts unprivileged user namespaces via AppArmor
-    # (kernel.apparmor_restrict_unprivileged_userns=1). The distro podman package
-    # ships an /etc/apparmor.d/podman profile that grants the `userns` permission,
-    # but the static binary in /usr/local/bin has none, so rootless podman fails
-    # with "failed to reexec: Permission denied". Provide the same profile for it.
-    if [[ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null)" == "1" ]]; then
-        cat > /etc/apparmor.d/podman <<'EOF'
-abi <abi/4.0>,
-include <tunables/global>
-
-profile podman /usr/{bin,local/bin}/podman flags=(unconfined) {
-  userns,
-
-  include if exists <local/podman>
-}
-EOF
-        apparmor_parser -r -W /etc/apparmor.d/podman
-    fi
-}
+if is_ubuntu22_x64; then
+    # Install containernetworking-plugins for Ubuntu 22 x64
+    curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
+    dpkg -i containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
+fi
 
 apt-get update
-if is_ubuntu26; then
-    # apt already provides a current podman on 26.04
-    apt-get install podman buildah skopeo
-else
-    # buildah and skopeo from apt (podman is not a dependency of either);
-    # uidmap keeps rootless podman working; podman itself comes from the bundle
-    apt-get install buildah skopeo uidmap
-    install_podman_static
-fi
+apt-get install ${install_packages[@]}
 
 mkdir -p /etc/containers
 printf 'unqualified-search-registries = ["docker.io", "quay.io"]\n' | tee /etc/containers/registries.conf
 
-# netavark (used by podman 5.x) can default to nftables on Ubuntu and then fails
-# name resolution; force iptables. https://github.com/actions/runner-images/issues/14230
-mkdir -p /etc/containers/containers.conf.d
-printf '[network]\nfirewall_driver = "iptables"\n' | tee /etc/containers/containers.conf.d/99-fix-firewall.conf
-podman network reload --all 2>/dev/null || true
+# https://github.com/actions/runner-images/issues/14230
+# netavark on Ubuntu 26.04 defaults to nftables and fails name resolution
+if is_ubuntu26; then
+    mkdir -p /etc/containers/containers.conf.d
+    printf '[network]\nfirewall_driver = "iptables"\n' | tee /etc/containers/containers.conf.d/99-fix-firewall.conf
+    podman network reload --all 2>/dev/null
+fi
 
 invoke_tests "Tools" "Containers"

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -27,6 +27,20 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o $GPG_
 echo "deb [arch=$docker_arch signed-by=$GPG_KEY] $REPO_URL ${os_codename} stable" > $REPO_PATH
 apt-get update
 
+# Ubuntu 22.04 and 24.04 ship Podman clients whose docker-daemon transport uses
+# API 1.41. Keep that transport compatible with Docker 28 and later.
+# https://github.com/actions/runner-images/issues/13691
+if ! is_ubuntu26; then
+    daemon_config_temp=$(mktemp)
+    if [[ -f /etc/docker/daemon.json ]]; then
+        jq '.["min-api-version"] = "1.41"' /etc/docker/daemon.json > "$daemon_config_temp"
+    else
+        jq -n '{"min-api-version": "1.41"}' > "$daemon_config_temp"
+    fi
+    install -D -m 0644 "$daemon_config_temp" /etc/docker/daemon.json
+    rm -f "$daemon_config_temp"
+fi
+
 # Install docker components which available via apt-get
 # Using toolsets keep installation order to install dependencies before the package in order to control versions
 

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -27,20 +27,6 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o $GPG_
 echo "deb [arch=$docker_arch signed-by=$GPG_KEY] $REPO_URL ${os_codename} stable" > $REPO_PATH
 apt-get update
 
-# Ubuntu 22.04 and 24.04 ship Podman clients whose docker-daemon transport uses
-# API 1.41. Keep that transport compatible with Docker 28 and later.
-# https://github.com/actions/runner-images/issues/13691
-if ! is_ubuntu26; then
-    daemon_config_temp=$(mktemp)
-    if [[ -f /etc/docker/daemon.json ]]; then
-        jq '.["min-api-version"] = "1.41"' /etc/docker/daemon.json > "$daemon_config_temp"
-    else
-        jq -n '{"min-api-version": "1.41"}' > "$daemon_config_temp"
-    fi
-    install -D -m 0644 "$daemon_config_temp" /etc/docker/daemon.json
-    rm -f "$daemon_config_temp"
-fi
-
 # Install docker components which available via apt-get
 # Using toolsets keep installation order to install dependencies before the package in order to control versions
 

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -90,27 +90,6 @@ Describe "Docker" {
         $clientVersion | Should -Be $serverVersion
     }
 
-    It "podman pushes images to the docker daemon" -Skip:(Test-IsUbuntu26) {
-        $command = @'
-set -e
-test_dir=$(mktemp -d)
-source_image=localhost/podman-docker-daemon-test:latest
-destination_image=podman-docker-daemon-test:latest
-cleanup() {
-    sudo podman image rm -f "$source_image" >/dev/null 2>&1 || true
-    sudo docker image rm -f "$destination_image" >/dev/null 2>&1 || true
-    rm -rf "$test_dir"
-}
-trap cleanup EXIT
-printf 'runner-images podman test\n' > "$test_dir/marker"
-tar -C "$test_dir" -cf "$test_dir/rootfs.tar" marker
-sudo podman import "$test_dir/rootfs.tar" "$source_image"
-sudo podman push "$source_image" "docker-daemon:$destination_image"
-sudo docker image inspect "$destination_image"
-'@
-        $command | Should -ReturnZeroExitCode
-    }
-
     It "docker buildx" {
         $version=(Get-ToolsetContent).docker.plugins | Where-Object { $_.plugin -eq 'buildx' } | Select-Object -ExpandProperty version
         If ($version -ne "latest") {

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -90,6 +90,32 @@ Describe "Docker" {
         $clientVersion | Should -Be $serverVersion
     }
 
+    # https://github.com/actions/runner-images/issues/13691
+    It "docker accepts API 1.41 clients" -Skip:(Test-IsUbuntu26) {
+        "sudo env DOCKER_API_VERSION=1.41 docker version --format '{{.Server.APIVersion}}'" | Should -ReturnZeroExitCode
+    }
+
+    It "podman pushes images to the docker daemon" -Skip:(Test-IsUbuntu26) {
+        $command = @'
+set -e
+test_dir=$(mktemp -d)
+source_image=localhost/podman-docker-daemon-test:latest
+destination_image=podman-docker-daemon-test:latest
+cleanup() {
+    sudo podman image rm -f "$source_image" >/dev/null 2>&1 || true
+    sudo docker image rm -f "$destination_image" >/dev/null 2>&1 || true
+    rm -rf "$test_dir"
+}
+trap cleanup EXIT
+printf 'runner-images podman test\n' > "$test_dir/marker"
+tar -C "$test_dir" -cf "$test_dir/rootfs.tar" marker
+sudo podman import "$test_dir/rootfs.tar" "$source_image"
+sudo podman push "$source_image" "docker-daemon:$destination_image"
+sudo docker image inspect "$destination_image"
+'@
+        $command | Should -ReturnZeroExitCode
+    }
+
     It "docker buildx" {
         $version=(Get-ToolsetContent).docker.plugins | Where-Object { $_.plugin -eq 'buildx' } | Select-Object -ExpandProperty version
         If ($version -ne "latest") {
@@ -328,9 +354,10 @@ Describe "Containers" {
         "podman network rm test-net" | Should -ReturnZeroExitCode
     }
 
-    # https://github.com/actions/runner-images/issues/14473
-    It "podman uses the crun shipped with the podman bundle" -Skip:(Test-IsUbuntu26) {
-        "podman info --format '{{.Host.OCIRuntime.Path}}'" | Should -OutputTextMatchingRegex "/usr/local/bin/crun"
+    # https://github.com/actions/runner-images/issues/14611
+    It "podman is installed from the Ubuntu package" {
+        (Get-Command podman).Source | Should -Be "/usr/bin/podman"
+        "dpkg-query --show podman" | Should -ReturnZeroExitCode
     }
 
     # https://github.com/actions/runner-images/issues/14406

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -90,11 +90,6 @@ Describe "Docker" {
         $clientVersion | Should -Be $serverVersion
     }
 
-    # https://github.com/actions/runner-images/issues/13691
-    It "docker accepts API 1.41 clients" -Skip:(Test-IsUbuntu26) {
-        "sudo env DOCKER_API_VERSION=1.41 docker version --format '{{.Server.APIVersion}}'" | Should -ReturnZeroExitCode
-    }
-
     It "podman pushes images to the docker daemon" -Skip:(Test-IsUbuntu26) {
         $command = @'
 set -e


### PR DESCRIPTION
# Description

**Bug fix / rollback**

Roll back the `mgoltzsche/podman-static` v5.8.4 bundle from the Ubuntu 22.04 and 24.04 images and restore the distro-managed Podman packages.

The bundle introduced in #14412 resolved the Docker daemon API incompatibility reported in #13691, but production use has since exposed several severe binary/build-level regressions:

- container health checks never run because the binary was built without the `systemd` build tag (#14569);
- the bundled `fuse-overlayfs` 1.16 silently changes the Buildah storage backend and correlates with image corruption (#14597);
- `podman exec` can hang indefinitely on a futex (#14604);
- the unmanaged `/usr/local/bin/podman` can coexist with an APT-installed Podman and produce an incompatible `/dev/shm/libpod_lock` on Arm64 (#14611).

These issues cannot be reliably addressed with extraction or configuration workarounds.

This change:

- restores the known-working Ubuntu package path: Podman 3.4.4 on Ubuntu 22.04 and Podman 4.9.3 on Ubuntu 24.04;
- leaves Ubuntu 26.04 unchanged on its distro-provided Podman 5.x;
- configures Docker on Ubuntu 22.04/24.04 with `min-api-version: 1.41`, preserving `podman push docker-daemon:` compatibility that originally motivated #14412;
- removes the static archive download, checksum pins, bundled runtime overrides, and bundle-specific AppArmor handling;
- retains the v2 `registries.conf` format and scopes the netavark `iptables` workaround back to Ubuntu 26.04.

Regression coverage now verifies that:

- `podman` resolves to the package-managed `/usr/bin/podman` and is registered with `dpkg`;
- Docker accepts API 1.41 clients on Ubuntu 22.04/24.04;
- a locally created image can be transferred through `podman push docker-daemon:` and inspected by Docker without relying on an external registry.

#### Related issues:

- Fixes #14569
- Fixes #14597
- Fixes #14604
- Fixes #14611
- Original compatibility issue: #13691

## Check list

- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable) - n/a; image readmes are generated during image builds
- [ ] Changes are tested and related VM images are successfully generated

### Validation

Local validation completed:

| Image | Status | Link |
|---|---|---|
| Ubuntu 22.04 X64 | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/32845785158 |
| Ubuntu 22.04 Arm64 | IN PROGRESS - build and specialization successful, canary provisioning running | https://github.com/github/hosted-runners-images/actions/runs/33053609627 |
| Ubuntu 24.04 X64 | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/32831380782 |
| Ubuntu 24.04 Arm64 | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/32831384658 |
| Ubuntu 26.04 X64 | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/32947545040 |
| Ubuntu 26.04 Arm64 | SUCCESS | https://github.com/github/hosted-runners-images/actions/runs/32947548340 |

The replacement `actions/runner-images-ci` matrix against
`v-GeorgyPuzakov/runner-images@d22f589f32e58a6ce9a2ed1fe80ed4de2488633a`:

| Image | Status | Link |
|---|---|---|
| Ubuntu 22.04 X64 | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/32945988229 |
| Ubuntu 22.04 Arm64 | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/32945991197 |
| Ubuntu 24.04 X64 | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/32945994247 |
| Ubuntu 24.04 Arm64 | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/32945997200 |
| Ubuntu 26.04 X64 | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/32946000041 |
| Ubuntu 26.04 Arm64 | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/32946002987 |
