### PR TITLE
[All OSs] Fix SBOM release asset upload and duplicate scan runs

### DIFF
--- a/.github/workflows/create_sbom_report.yml
+++ b/.github/workflows/create_sbom_report.yml
@@ -1,10 +1,15 @@
 name: Create SBOM for the release
 
-run-name: Collecting SBOM for ${{ github.event.client_payload.agentSpec || 'unknown image' }} - ${{ github.event.client_payload.imageVersion || 'unknown version' }}
+run-name: Collecting SBOM for ${{ github.event.client_payload.agentSpec || 'unknown image' }} - ${{ github.event.client_payload.imageVersion || 'unknown version' }} (dispatch ${{ github.event.client_payload.DispatchId || 'unknown' }})
 
 on:
   repository_dispatch:
     types: [generate-sbom]
+
+# Serialize runs per release so a retry waits for the in-flight scan instead of duplicating it.
+concurrency:
+  group: sbom-${{ github.event.client_payload.ReleaseID || github.run_id }}
+  cancel-in-progress: false
 
 defaults:
   run:
@@ -102,11 +107,19 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: "https://uploads.github.com/repos/actions/runner-images/releases/${{ env.RELEASE_ID }}/assets{?name,label}"
-          asset_path: ./sbom.json.zip
-          asset_name: sbom.${{ env.AGENT_SPEC }}.json.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $releaseTag = gh api "repos/${{ github.repository }}/releases/$($env:RELEASE_ID)" --jq ".tag_name"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to resolve the tag name of release $($env:RELEASE_ID)"
+          }
+
+          $assetName = "sbom.$($env:AGENT_SPEC).json.zip"
+          Copy-Item sbom.json.zip $assetName
+
+          # --clobber keeps the upload idempotent when a duplicate scan reaches this step.
+          gh release upload $releaseTag $assetName --repo "${{ github.repository }}" --clobber
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to upload $assetName to release $releaseTag"
+          }

--- a/.github/workflows/create_sbom_report.yml
+++ b/.github/workflows/create_sbom_report.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Compress SBOM file
         run: Compress-Archive sbom.json sbom.json.zip
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: sbom-${{ env.AGENT_SPEC }}-${{ env.IMAGE_VERSION }}
           path: sbom.json.zip


### PR DESCRIPTION
# Description
- Replace `actions/upload-release-asset@v1` with `gh release upload --clobber`.
- Bump `actions/upload-artifact` from v4 to v6.
- Add a `concurrency` group keyed on the release ID.
- Include the dispatch id in `run-name`.

### Reasoning:
When more than one run is dispatched for the same release, both scan concurrently and the second upload fails with a bare `Validation Failed`. That is all the archived action reports. It drops the API error details, so the actual cause (`already_exists`) never appears in the log.

`--clobber` makes the upload idempotent, and the concurrency group stops a second run from repeating a multi-hour scan that has already been done. The archived action was last updated in 2021, targets Node 20, and uses the deprecated `set-output`.

`actions/upload-artifact@v4` was named in the same Node 20 deprecation warning. v6 is the first major to run on Node 24; its inputs are unchanged from v4, and it requires runner 2.327.1 or newer, which these runners already exceed.

#### Related issue:
Tracked privately

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
