### PR TITLE
Add Dokany and macFUSE filesystem drivers

### DIFF
--- a/images/macos/scripts/build/install-macfuse.sh
+++ b/images/macos/scripts/build/install-macfuse.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e -o pipefail
+################################################################################
+##  File:  install-macfuse.sh
+##  Desc:  Install and approve macFUSE for lazy user-mode filesystems
+################################################################################
+
+source ~/utils/utils.sh
+
+MACFUSE_VERSION="5.3.3"
+MACFUSE_SHA256="7a0b7b66c0e7f8932707d1215dc9cf486e178d097ae0a2dcdf17d8530566aa15"
+MACFUSE_DMG="${RUNNER_TEMP:-/tmp}/macfuse-${MACFUSE_VERSION}.dmg"
+MACFUSE_URL="https://github.com/macfuse/macfuse/releases/download/macfuse-${MACFUSE_VERSION}/macfuse-${MACFUSE_VERSION}.dmg"
+
+download_with_retry "$MACFUSE_URL" "$MACFUSE_DMG"
+use_checksum_comparison "$MACFUSE_DMG" "$MACFUSE_SHA256"
+
+mount_point=$(hdiutil attach "$MACFUSE_DMG" -nobrowse -readonly | awk '/\/Volumes\// { sub(/^.*\/Volumes\//, "/Volumes/"); print; exit }')
+if [[ -z "$mount_point" ]]; then
+    echo "Unable to mount macFUSE installer image"
+    exit 1
+fi
+trap 'hdiutil detach "$mount_point" >/dev/null 2>&1 || true' EXIT
+
+sudo installer -pkg "$mount_point/Extras/macFUSE ${MACFUSE_VERSION}.pkg" -target /
+
+# Trigger the approval request. The image builder already provisions UI
+# automation for the Security & Privacy approval used by Parallels.
+sudo /Library/Filesystems/macfuse.fs/Contents/Resources/load_macfuse || true
+osascript "$HOME/utils/confirm-identified-developers-macos15.scpt" "$USER_PASSWORD"
+killall "System Settings" || true
+
+invoke_tests "MacFUSE" "macFUSE installation"

--- a/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/macos/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -89,6 +89,9 @@ $utilities.AddToolVersion("GNU Tar", $(Get-GnuTarVersion))
 $utilities.AddToolVersion("GNU Wget", $(Get-WgetVersion))
 $utilities.AddToolVersion("gpg (GnuPG)", $(Get-GPGVersion))
 $utilities.AddToolVersion("jq", $(Get-JqVersion))
+if ($os.IsSequoiaX64) {
+    $utilities.AddToolVersion("macFUSE", $(Get-MacFUSEVersion))
+}
 $utilities.AddToolVersion("OpenSSL", $(Get-OpenSSLVersion))
 $utilities.AddToolVersion("Packer", $(Get-PackerVersion))
 $utilities.AddToolVersion("pkgconf", $(Get-PKGConfVersion))

--- a/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
+++ b/images/macos/scripts/docs-gen/SoftwareReport.Common.psm1
@@ -5,6 +5,11 @@ function Get-BashVersion {
     return $version
 }
 
+function Get-MacFUSEVersion {
+    $packageInfo = Run-Command "pkgutil --pkg-info io.macfuse.installer.components.core"
+    return ($packageInfo | Select-String "^version:").Line.Split(":", 2)[1].Trim()
+}
+
 function Get-DotnetVersionList {
     $sdkRawList = Run-Command "dotnet --list-sdks"
     return $sdkRawList | ForEach-Object { Take-Part $_ -Part 0 }

--- a/images/macos/scripts/tests/MacFUSE.Tests.ps1
+++ b/images/macos/scripts/tests/MacFUSE.Tests.ps1
@@ -1,0 +1,29 @@
+Import-Module "$PSScriptRoot/../helpers/Common.Helpers.psm1"
+
+$os = Get-OSVersion
+
+Describe "macFUSE installation" -Skip:(-not $os.IsSequoiaX64) {
+    It "Installs the package and filesystem bundle" {
+        "pkgutil --pkg-info io.macfuse.installer.components.core" | Should -ReturnZeroExitCode
+        "/Library/Filesystems/macfuse.fs" | Should -Exist
+    }
+
+    It "Uses the expected Developer ID" {
+        $output = bash -c "codesign -dv --verbose=4 /Library/Filesystems/macfuse.fs 2>&1"
+        $output | Should -Match "TeamIdentifier=3T5GSNBU6W"
+    }
+
+}
+
+Describe "macFUSE runtime" -Skip:(-not $os.IsSequoiaX64) {
+    It "Records kernel extension approval" {
+        $approved = bash -c "sudo sqlite3 /var/db/SystemPolicyConfiguration/KextPolicy `"SELECT allowed FROM kext_policy WHERE team_id = '3T5GSNBU6W' LIMIT 1;`""
+        $approved.Trim() | Should -Be "1"
+    }
+
+    It "Loads the filesystem extension after reboot" {
+        $loaded = bash -c "sudo /Library/Filesystems/macfuse.fs/Contents/Resources/load_macfuse && kmutil showloaded | grep -E 'io\.macfuse\.filesystems\.macfuse|io\.macfuse\.filesystems\.osxfuse'"
+        $LASTEXITCODE | Should -Be 0
+        $loaded | Should -Not -BeNullOrEmpty
+    }
+}

--- a/images/macos/templates/macOS-15.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.anka.pkr.hcl
@@ -213,6 +213,7 @@ build {
       "${path.root}/../scripts/build/install-rubygems.sh",
       "${path.root}/../scripts/build/install-git.sh",
       "${path.root}/../scripts/build/install-node.sh",
+      "${path.root}/../scripts/build/install-macfuse.sh",
       "${path.root}/../scripts/build/install-common-utils.sh"
     ]
   }

--- a/images/windows/scripts/build/Install-Dokany.ps1
+++ b/images/windows/scripts/build/Install-Dokany.ps1
@@ -1,0 +1,13 @@
+################################################################################
+##  File:  Install-Dokany.ps1
+##  Desc:  Install the Dokany user-mode filesystem kernel driver
+################################################################################
+
+$version = "2.3.1.1000"
+$downloadUrl = "https://github.com/dokan-dev/dokany/releases/download/v${version}/Dokan_x64.msi"
+
+Install-Binary `
+    -Url $downloadUrl `
+    -ExpectedSHA256Sum "69ff8cb37bfec3a75921c85ffd1c6370b50a9ec4ecef2cf3a009d488dcbf5465"
+
+Invoke-PesterTests -TestFile "Dokany"

--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -85,6 +85,7 @@ if (Test-IsX64) {
     $tools.AddToolVersion("Docker", $(Get-DockerVersion))
     $tools.AddToolVersion("Docker Compose", $(Get-DockerComposeVersion))
     $tools.AddToolVersion("Docker-wincred", $(Get-DockerWincredVersion))
+    $tools.AddToolVersion("Dokany", $(Get-DokanyVersion))
     $tools.AddToolVersion("ghc", $(Get-GHCVersion))
 }
 $tools.AddToolVersion("Git", $(Get-GitVersion))

--- a/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
@@ -179,6 +179,11 @@ function Get-WinAppDriver {
     return $winAppDriverVersion
 }
 
+function Get-DokanyVersion {
+    $driver = Get-Item (Join-Path $env:SystemRoot "System32\drivers\dokan2.sys")
+    return $driver.VersionInfo.FileVersion
+}
+
 function Get-WixVersion {
     $regKey = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
     $installedApplications = Get-ItemProperty -Path $regKey

--- a/images/windows/scripts/tests/Dokany.Tests.ps1
+++ b/images/windows/scripts/tests/Dokany.Tests.ps1
@@ -1,0 +1,19 @@
+Describe "Dokany" -Skip:(Test-IsArm64) {
+    It "Registers the Dokany filesystem driver" {
+        $driver = Get-CimInstance Win32_SystemDriver -Filter "Name = 'dokan2'"
+        $driver | Should -Not -BeNullOrEmpty
+        $driver.PathName | Should -Match "dokan2.sys"
+    }
+
+    It "Installs a signed kernel driver" {
+        $driverPath = Join-Path $env:SystemRoot "System32\drivers\dokan2.sys"
+        $driverPath | Should -Exist
+        (Get-AuthenticodeSignature $driverPath).Status | Should -Be "Valid"
+    }
+
+    It "Installs the x64 user-mode library" {
+        $library = Get-ChildItem "${env:ProgramFiles}\Dokan" -Filter "dokan2.dll" -Recurse | Select-Object -First 1
+        $library | Should -Not -BeNullOrEmpty
+        $library.VersionInfo.FileVersion | Should -Match "^2\.3\.1"
+    }
+}

--- a/images/windows/templates/build.windows-2022.pkr.hcl
+++ b/images/windows/templates/build.windows-2022.pkr.hcl
@@ -171,6 +171,7 @@ build {
       "${path.root}/../scripts/build/Install-Nginx.ps1",
       "${path.root}/../scripts/build/Install-Msys2.ps1",
       "${path.root}/../scripts/build/Install-WinAppDriver.ps1",
+      "${path.root}/../scripts/build/Install-Dokany.ps1",
       "${path.root}/../scripts/build/Install-R.ps1",
       "${path.root}/../scripts/build/Install-AWSTools.ps1",
       "${path.root}/../scripts/build/Install-DACFx.ps1",

--- a/images/windows/templates/build.windows-2025-vs2026.pkr.hcl
+++ b/images/windows/templates/build.windows-2025-vs2026.pkr.hcl
@@ -166,6 +166,7 @@ build {
       "${path.root}/../scripts/build/Install-Nginx.ps1",
       "${path.root}/../scripts/build/Install-Msys2.ps1",
       "${path.root}/../scripts/build/Install-WinAppDriver.ps1",
+      "${path.root}/../scripts/build/Install-Dokany.ps1",
       "${path.root}/../scripts/build/Install-R.ps1",
       "${path.root}/../scripts/build/Install-AWSTools.ps1",
       "${path.root}/../scripts/build/Install-DACFx.ps1",

--- a/images/windows/templates/build.windows-2025.pkr.hcl
+++ b/images/windows/templates/build.windows-2025.pkr.hcl
@@ -166,6 +166,7 @@ build {
       "${path.root}/../scripts/build/Install-Nginx.ps1",
       "${path.root}/../scripts/build/Install-Msys2.ps1",
       "${path.root}/../scripts/build/Install-WinAppDriver.ps1",
+      "${path.root}/../scripts/build/Install-Dokany.ps1",
       "${path.root}/../scripts/build/Install-R.ps1",
       "${path.root}/../scripts/build/Install-AWSTools.ps1",
       "${path.root}/../scripts/build/Install-DACFx.ps1",


### PR DESCRIPTION
## Summary
- install checksum-pinned Dokany 2.3.1.1000 on Windows Server 2022/2025 x64 images
- install checksum-pinned macFUSE 5.3.3 on macOS 15 Intel and reuse the image builder's existing system-software approval automation
- validate package presence, signing identity, kernel driver registration, approval, and runtime loading
- include both drivers in generated software reports

## Motivation

User-mode filesystem drivers let Actions expose virtual disk images lazily instead of downloading a complete image before attaching it. The immediate consumer is GitHub Drives:

- Dokany projects a VHD file which Windows can attach with `Mount-VHD`.
- macFUSE projects a raw disk image which macOS can attach with `hdiutil`.

This enables on-demand block hydration and dirty-block tracking for large persisted build volumes.

Closes/depends on #14638.

## Hosted smoke evidence

https://github.com/0b01/runner-images/actions/runs/33017792054

- **Windows 2025:** PASS. Dokany installed silently in seconds; signed `dokan2.sys` registered and reached `Running` without reboot.
- **macOS 15 Intel:** PARTIAL. macFUSE package 5.3.3 installed and Developer ID team `3T5GSNBU6W` validated. Runtime loading failed without system-software approval, confirming that workflow-time installation is insufficient and image-time approval/security configuration is required.

## Scope

- Windows Server 2022 x64
- Windows Server 2025 x64
- Windows Server 2025 with Visual Studio 2026 x64
- macOS 15 Intel

macOS ARM and macOS 26 are intentionally excluded from this first POC because they need additional Reduced Security/system-extension work.

## Validation

- upstream release SHA-256 values independently verified:
  - Dokany MSI: `69ff8cb37bfec3a75921c85ffd1c6370b50a9ec4ecef2cf3a009d488dcbf5465`
  - macFUSE DMG: `7a0b7b66c0e7f8932707d1215dc9cf486e178d097ae0a2dcdf17d8530566aa15`
- hosted Dokany install/driver registration test passes
- hosted macFUSE package/signature test passes; load test documents the approval requirement
- shell syntax and ShellCheck pass for the new macOS installer
- Pester validation is added for image builds

## Blockers / review needed

- runner-images policy requires approval of the tool request before adding software
- the repository currently says external macOS image implementation PRs cannot be accepted
- macFUSE's binary license restricts commercial bundling/automated installation without prior written permission; this POC must not merge until GitHub confirms permission
- macOS 15 image build must prove the existing Security Settings automation records approval and that macFUSE loads after reboot

This is intentionally a draft proof-of-concept for feasibility and policy/security review.