### PR TITLE
[Windows][Ubuntu] Resolve version pinning review (#14607)

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2204-arm64.json
@@ -345,7 +345,7 @@
         "pinnedDetails": {
             "reason": "Pinned to avoid CMake 4.0 compatibility issues",
             "link": "https://github.com/actions/runner-images/issues/11926",
-            "review-at": "2026-09-01"
+            "review-at": "2026-12-01"
         }
     },
     "vcpkg": {
@@ -353,7 +353,7 @@
         "pinnedDetails": {
             "reason": "Pinned to a version compatible with CMake 3.31.6",
             "link": "https://github.com/microsoft/vcpkg/commit/827a2e1203bc19941126c657166da44f2623acc4",
-            "review-at": "2026-09-01"
+            "review-at": "2026-12-01"
         }
     },
     "pwsh": {

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -355,7 +355,7 @@
         "pinnedDetails": {
             "reason": "Pinned to avoid CMake 4.0 compatibility issues",
             "link": "https://github.com/actions/runner-images/issues/11926",
-            "review-at": "2026-09-01"
+            "review-at": "2026-12-01"
         }
     },
     "pwsh": {

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -322,7 +322,7 @@
         "pinnedDetails": {
             "reason": "Pinned to avoid CMake 4.0 compatibility issues",
             "link": "https://github.com/actions/runner-images/issues/11926",
-            "review-at": "2026-09-01"
+            "review-at": "2026-12-01"
         }
     },
     "vcpkg": {
@@ -330,7 +330,7 @@
         "pinnedDetails": {
             "reason": "Pinned to a version compatible with CMake 3.31.6",
             "link": "https://github.com/microsoft/vcpkg/commit/827a2e1203bc19941126c657166da44f2623acc4",
-            "review-at": "2026-09-01"
+            "review-at": "2026-12-01"
         }
     },
     "pwsh": {

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -325,7 +325,7 @@
         "pinnedDetails": {
             "reason": "Pinned to avoid CMake 4.0 compatibility issues",
             "link": "https://github.com/actions/runner-images/issues/11926",
-            "review-at": "2026-09-01"
+            "review-at": "2026-12-01"
         }
     },
     "pwsh": {

--- a/images/windows/toolsets/toolset-win-11-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-arm64.json
@@ -284,12 +284,7 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "20.1.6",
-        "pinnedDetails": {
-            "reason": "Pinned to a specific version for Windows 11 ARM64 initial image support",
-            "link": "https://github.com/actions/runner-images/pull/13879",
-            "review-at": "2026-09-01"
-        }
+        "version": "22.1.8"
     },
     "php": {
         "version": "8.4"

--- a/images/windows/toolsets/toolset-win-11-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-arm64.json
@@ -284,7 +284,12 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "22.1.8"
+        "version": "22.1.8",
+        "pinnedDetails": {
+            "reason": "Pinned to a specific validated version for the Windows 11 ARM64 image",
+            "link": "https://github.com/actions/runner-images/pull/14640",
+            "review-at": "2026-12-01"
+        }
     },
     "php": {
         "version": "8.4"

--- a/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
@@ -275,12 +275,7 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "20.1.6",
-        "pinnedDetails": {
-            "reason": "Pinned to a specific version for Windows 11 ARM64 initial image support",
-            "link": "https://github.com/actions/runner-images/pull/13879",
-            "review-at": "2026-09-01"
-        }
+        "version": "22.1.8"
     },
     "php": {
         "version": "8.4"

--- a/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
@@ -275,7 +275,12 @@
         "version": "3.10"
     },
     "llvm": {
-        "version": "22.1.8"
+        "version": "22.1.8",
+        "pinnedDetails": {
+            "reason": "Pinned to a specific validated version for the Windows 11 ARM64 image",
+            "link": "https://github.com/actions/runner-images/pull/14640",
+            "review-at": "2026-12-01"
+        }
     },
     "php": {
         "version": "8.4"


### PR DESCRIPTION
# Description
Resolves the version pinning review in #14607.

- **LLVM (windows-11-arm64 + vs2026-arm64):** bumped the pin from `20.1.6` to `22.1.8` and refreshed its `pinnedDetails` (the old "initial image support" reason no longer applied). Kept pinned to an exact version for full control of the ARM64 toolchain — the toolset schema also requires `pinnedDetails` for any exact `X.Y.Z` version. Validated on a hosted `windows-11-arm` runner ([validation run](https://github.com/v-davit-ioramashvili/runner-images/actions/runs/32945995332)): the real `Install-LLVM.ps1` installs `22.1.8`, the version test passes, and `clang`/`clang++` compile and run native ARM64 binaries.
- **CMake (22.04 / 24.04) + vcpkg (arm64):** kept pinned and `review-at` extended to `2026-12-01`. CMake 4.0 still breaks projects using older `cmake_minimum_required` (#11926), and 4.x is already available opt-in via `additional_tools`; vcpkg stays pinned to track that compatibility.

#### Related issue:
#14607

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
