### PR TITLE
[Ubuntu] Stop apt-get update stalling on a degraded mirror

### DIFF
--- a/images/ubuntu-slim/scripts/build/configure-apt.sh
+++ b/images/ubuntu-slim/scripts/build/configure-apt.sh
@@ -14,8 +14,15 @@ source $HELPER_SCRIPTS/os.sh
 # systemctl disable apt-daily-upgrade.timer
 # systemctl disable apt-daily-upgrade.service
 
-# Enable retry logic for apt up to 10 times
-echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
+# Bound apt's acquire behaviour so a stalled mirror fails over in seconds instead of minutes.
+# apt reads Acquire::Retries (default 3), not APT::Acquire::Retries, and spends every retry on the
+# same URI before trying the next mirror in /etc/apt/apt-mirrors.txt, so a high count delays failover.
+# https://github.com/actions/runner-images/issues/14594
+cat <<EOF > /etc/apt/apt.conf.d/80-retries
+Acquire::Retries "1";
+Acquire::http::Timeout "15";
+Acquire::https::Timeout "15";
+EOF
 
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes

--- a/images/ubuntu-slim/scripts/build/configure-apt.sh
+++ b/images/ubuntu-slim/scripts/build/configure-apt.sh
@@ -52,6 +52,9 @@ else
     cat /etc/apt/sources.list.d/ubuntu.sources
 fi
 
+echo 'APT mirrors'
+cat /etc/apt/apt-mirrors.txt
+
 apt-get update
 
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/images/ubuntu-slim/scripts/build/configure-apt.sh
+++ b/images/ubuntu-slim/scripts/build/configure-apt.sh
@@ -24,6 +24,8 @@ Acquire::http::Timeout "15";
 Acquire::https::Timeout "15";
 EOF
 
+echo 'Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";' > /etc/apt/apt.conf.d/90-index-targets
+
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 

--- a/images/ubuntu-slim/scripts/build/configure-apt.sh
+++ b/images/ubuntu-slim/scripts/build/configure-apt.sh
@@ -14,7 +14,7 @@ source $HELPER_SCRIPTS/os.sh
 # systemctl disable apt-daily-upgrade.timer
 # systemctl disable apt-daily-upgrade.service
 
-# Bound apt's acquire behaviour so a stalled mirror fails over in seconds instead of minutes.
+# Bound apt's acquire behavior so a stalled mirror fails over in seconds instead of minutes.
 # apt reads Acquire::Retries (default 3), not APT::Acquire::Retries, and spends every retry on the
 # same URI before trying the next mirror in /etc/apt/apt-mirrors.txt, so a high count delays failover.
 # https://github.com/actions/runner-images/issues/14594

--- a/images/ubuntu-slim/scripts/build/configure-apt.sh
+++ b/images/ubuntu-slim/scripts/build/configure-apt.sh
@@ -24,8 +24,6 @@ Acquire::http::Timeout "15";
 Acquire::https::Timeout "15";
 EOF
 
-echo 'Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";' > /etc/apt/apt.conf.d/90-index-targets
-
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 

--- a/images/ubuntu-slim/test.sh
+++ b/images/ubuntu-slim/test.sh
@@ -99,3 +99,10 @@ run_test "docker buildx is installed" docker buildx version
 
 # Quick check: ensure the imagedata JSON file was created during image build
 run_test "imagedata JSON file exists" test -f /imagegeneration/imagedata.json
+
+# Assert the effective apt acquire bounds, since a setting written under a key apt does not read is
+# silently ignored: https://github.com/actions/runner-images/issues/14594
+run_test "apt acquire retries are bounded" bash -c 'apt-config dump Acquire::Retries | grep -Fxq "Acquire::Retries \"1\";"'
+run_test "apt http timeout is bounded" bash -c 'apt-config dump Acquire::http::Timeout | grep -Fxq "Acquire::http::Timeout \"15\";"'
+run_test "apt https timeout is bounded" bash -c 'apt-config dump Acquire::https::Timeout | grep -Fxq "Acquire::https::Timeout \"15\";"'
+run_test "apt sources resolve through the mirror list" bash -c 'grep -Rq "mirror+file:/etc/apt/apt-mirrors.txt" /etc/apt/'

--- a/images/ubuntu-slim/test.sh
+++ b/images/ubuntu-slim/test.sh
@@ -105,4 +105,5 @@ run_test "imagedata JSON file exists" test -f /imagegeneration/imagedata.json
 run_test "apt acquire retries are bounded" bash -c 'apt-config dump Acquire::Retries | grep -Fxq "Acquire::Retries \"1\";"'
 run_test "apt http timeout is bounded" bash -c 'apt-config dump Acquire::http::Timeout | grep -Fxq "Acquire::http::Timeout \"15\";"'
 run_test "apt https timeout is bounded" bash -c 'apt-config dump Acquire::https::Timeout | grep -Fxq "Acquire::https::Timeout \"15\";"'
+run_test "apt DEP-11 index target is disabled" bash -c 'apt-config dump Acquire::IndexTargets::deb::DEP-11::DefaultEnabled | grep -Fxq "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled \"false\";"'
 run_test "apt sources resolve through the mirror list" bash -c 'grep -Rq "mirror+file:/etc/apt/apt-mirrors.txt" /etc/apt/'

--- a/images/ubuntu-slim/test.sh
+++ b/images/ubuntu-slim/test.sh
@@ -105,5 +105,4 @@ run_test "imagedata JSON file exists" test -f /imagegeneration/imagedata.json
 run_test "apt acquire retries are bounded" bash -c 'apt-config dump Acquire::Retries | grep -Fxq "Acquire::Retries \"1\";"'
 run_test "apt http timeout is bounded" bash -c 'apt-config dump Acquire::http::Timeout | grep -Fxq "Acquire::http::Timeout \"15\";"'
 run_test "apt https timeout is bounded" bash -c 'apt-config dump Acquire::https::Timeout | grep -Fxq "Acquire::https::Timeout \"15\";"'
-run_test "apt DEP-11 index target is disabled" bash -c 'apt-config dump Acquire::IndexTargets::deb::DEP-11::DefaultEnabled | grep -Fxq "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled \"false\";"'
 run_test "apt sources resolve through the mirror list" bash -c 'grep -Rq "mirror+file:/etc/apt/apt-mirrors.txt" /etc/apt/'

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -17,10 +17,11 @@ systemctl disable apt-daily-upgrade.service
 # Bound apt's acquire behavior so a stalled mirror fails over in seconds instead of minutes.
 # apt reads Acquire::Retries (default 3), not APT::Acquire::Retries, and spends every retry on the
 # same URI before trying the next mirror in /etc/apt/apt-mirrors.txt, so a high count delays failover.
-# arm64 sources come from ports.ubuntu.com, which the mirror list does not cover, leaving retries as
-# the only failover apt has, so the count stays at apt's default.
+# 22.04 and 24.04 arm64 are served by ports.ubuntu.com, which the mirror list does not cover, leaving
+# retries as the only failover apt has there, so the count stays at apt's default. 26.04 merged arm64
+# into the main archive, so it uses the mirror list like x64 does.
 # https://github.com/actions/runner-images/issues/14594
-if is_arm64; then
+if is_ubuntu22_arm64 || is_ubuntu24_arm64; then
     apt_retries=3
 else
     apt_retries=1

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -67,6 +67,9 @@ else
     cat /etc/apt/sources.list.d/ubuntu.sources
 fi
 
+echo 'APT mirrors'
+cat /etc/apt/apt-mirrors.txt
+
 apt-get update
 apt-get upgrade -y
 # Install jq

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -14,8 +14,20 @@ systemctl stop apt-daily-upgrade.timer
 systemctl disable apt-daily-upgrade.timer
 systemctl disable apt-daily-upgrade.service
 
-# Enable retry logic for apt up to 10 times
-echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
+# Bound apt's acquire behaviour so a stalled mirror fails over in seconds instead of minutes.
+# apt reads Acquire::Retries (default 3), not APT::Acquire::Retries, and spends every retry on the
+# same URI before trying the next mirror in /etc/apt/apt-mirrors.txt, so a high count delays failover.
+# https://github.com/actions/runner-images/issues/14594
+cat <<EOF > /etc/apt/apt.conf.d/80-retries
+Acquire::Retries "1";
+Acquire::http::Timeout "15";
+Acquire::https::Timeout "15";
+EOF
+
+# DEP-11/AppStream is desktop software-catalog metadata with no CI use. Skipping it drops 15 of the 51
+# index items and 7.6 MB from every apt-get update, which is also 15 fewer chances to hit a sick mirror.
+# Sorts after appstream's own /etc/apt/apt.conf.d/50appstream, so it wins.
+echo 'Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";' > /etc/apt/apt.conf.d/90-index-targets
 
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -14,11 +14,11 @@ systemctl stop apt-daily-upgrade.timer
 systemctl disable apt-daily-upgrade.timer
 systemctl disable apt-daily-upgrade.service
 
-# Bound apt's acquire behaviour so a stalled mirror fails over in seconds instead of minutes.
+# Bound apt's acquire behavior so a stalled mirror fails over in seconds instead of minutes.
 # apt reads Acquire::Retries (default 3), not APT::Acquire::Retries, and spends every retry on the
 # same URI before trying the next mirror in /etc/apt/apt-mirrors.txt, so a high count delays failover.
-# arm64 sources come from ports.ubuntu.com, which the mirror list does not cover, so there retries are
-# the only failover apt has and the count stays at apt's default.
+# arm64 sources come from ports.ubuntu.com, which the mirror list does not cover, leaving retries as
+# the only failover apt has, so the count stays at apt's default.
 # https://github.com/actions/runner-images/issues/14594
 if is_arm64; then
     apt_retries=3

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -17,9 +17,17 @@ systemctl disable apt-daily-upgrade.service
 # Bound apt's acquire behaviour so a stalled mirror fails over in seconds instead of minutes.
 # apt reads Acquire::Retries (default 3), not APT::Acquire::Retries, and spends every retry on the
 # same URI before trying the next mirror in /etc/apt/apt-mirrors.txt, so a high count delays failover.
+# arm64 sources come from ports.ubuntu.com, which the mirror list does not cover, so there retries are
+# the only failover apt has and the count stays at apt's default.
 # https://github.com/actions/runner-images/issues/14594
+if is_arm64; then
+    apt_retries=3
+else
+    apt_retries=1
+fi
+
 cat <<EOF > /etc/apt/apt.conf.d/80-retries
-Acquire::Retries "1";
+Acquire::Retries "$apt_retries";
 Acquire::http::Timeout "15";
 Acquire::https::Timeout "15";
 EOF

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -33,11 +33,6 @@ Acquire::http::Timeout "15";
 Acquire::https::Timeout "15";
 EOF
 
-# DEP-11/AppStream is desktop software-catalog metadata with no CI use. Skipping it drops 15 of the 51
-# index items and 7.6 MB from every apt-get update, which is also 15 fewer chances to hit a sick mirror.
-# Sorts after appstream's own /etc/apt/apt.conf.d/50appstream, so it wins.
-echo 'Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";' > /etc/apt/apt.conf.d/90-index-targets
-
 # Configure apt to always assume Y
 echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -17,20 +17,22 @@ systemctl disable apt-daily-upgrade.service
 # Bound apt's acquire behavior so a stalled mirror fails over in seconds instead of minutes.
 # apt reads Acquire::Retries (default 3), not APT::Acquire::Retries, and spends every retry on the
 # same URI before trying the next mirror in /etc/apt/apt-mirrors.txt, so a high count delays failover.
-# 22.04 and 24.04 arm64 are served by ports.ubuntu.com, which the mirror list does not cover, leaving
-# retries as the only failover apt has there, so the count stays at apt's default. 26.04 merged arm64
-# into the main archive, so it uses the mirror list like x64 does.
+# 22.04 and 24.04 arm64 keep apt's defaults: they are served by ports.ubuntu.com, which the mirror
+# list does not cover, so retries are their only failover and a timeout is a hard failure rather than
+# a fallback. 26.04 merged arm64 into the main archive, so it uses the mirror list like x64 does.
 # https://github.com/actions/runner-images/issues/14594
 if is_ubuntu22_arm64 || is_ubuntu24_arm64; then
     apt_retries=3
+    apt_timeout=30
 else
     apt_retries=1
+    apt_timeout=15
 fi
 
 cat <<EOF > /etc/apt/apt.conf.d/80-retries
 Acquire::Retries "$apt_retries";
-Acquire::http::Timeout "15";
-Acquire::https::Timeout "15";
+Acquire::http::Timeout "$apt_timeout";
+Acquire::https::Timeout "$apt_timeout";
 EOF
 
 # Configure apt to always assume Y

--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Apt acquire configuration" {
     # ignored and leaves the image on apt's defaults.
     # https://github.com/actions/runner-images/issues/14594
     $settingsTestCases = @(
-        @{ setting = "Acquire::Retries"; expectedValue = "1" }
+        @{ setting = "Acquire::Retries"; expectedValue = if (Test-IsArm64) { "3" } else { "1" } }
         @{ setting = "Acquire::http::Timeout"; expectedValue = "15" }
         @{ setting = "Acquire::https::Timeout"; expectedValue = "15" }
         @{ setting = "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled"; expectedValue = "false" }
@@ -44,12 +44,21 @@ Describe "Apt acquire configuration" {
         (Get-CommandResult "apt-config dump APT::Acquire::Retries").Output | Should -BeNullOrEmpty
     }
 
-    It "Apt sources resolve through the mirror list" {
+    # arm64 sources come from ports.ubuntu.com, which /etc/apt/apt-mirrors.txt does not cover.
+    It "Apt sources resolve through the mirror list" -Skip:(Test-IsArm64) {
         $sourcesFile = if (Test-IsUbuntu22) { "/etc/apt/sources.list" } else { "/etc/apt/sources.list.d/ubuntu.sources" }
         Get-Content $sourcesFile -Raw | Should -Match ([regex]::Escape("mirror+file:/etc/apt/apt-mirrors.txt"))
     }
 
-    It "Mirror list defines a failover chain with unique priorities" {
+    # The mirror list holds x86-only archives, so pointing arm64 at it would 404 every fetch.
+    It "Apt sources use the ports archive on arm64" -Skip:(Test-IsX64) {
+        $sourcesFile = if (Test-IsUbuntu22) { "/etc/apt/sources.list" } else { "/etc/apt/sources.list.d/ubuntu.sources" }
+        $aptSources = Get-Content $sourcesFile -Raw
+        $aptSources | Should -Match ([regex]::Escape("ports.ubuntu.com/ubuntu-ports"))
+        $aptSources | Should -Not -Match ([regex]::Escape("mirror+file:/etc/apt/apt-mirrors.txt"))
+    }
+
+    It "Mirror list entries have unique priorities" {
         $priorities = Get-Content "/etc/apt/apt-mirrors.txt" | ForEach-Object { ($_ -split "priority:")[1] }
         $priorities.Count | Should -BeGreaterThan 1
         ($priorities | Select-Object -Unique).Count | Should -BeExactly $priorities.Count

--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -24,3 +24,34 @@ Describe "Apt" {
         (Get-Command -Name $toolName).CommandType | Should -BeExactly "Application"
     }
 }
+
+Describe "Apt acquire configuration" {
+    # Asserts the effective values, because a setting written under a key apt does not read is silently
+    # ignored and leaves the image on apt's defaults.
+    # https://github.com/actions/runner-images/issues/14594
+    $settingsTestCases = @(
+        @{ setting = "Acquire::Retries"; expectedValue = "1" }
+        @{ setting = "Acquire::http::Timeout"; expectedValue = "15" }
+        @{ setting = "Acquire::https::Timeout"; expectedValue = "15" }
+        @{ setting = "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled"; expectedValue = "false" }
+    )
+
+    It "<setting> is set to <expectedValue>" -TestCases $settingsTestCases {
+        (Get-CommandResult "apt-config dump $setting").Output | Should -BeExactly "$setting `"$expectedValue`";"
+    }
+
+    It "APT::Acquire::Retries is not set" {
+        (Get-CommandResult "apt-config dump APT::Acquire::Retries").Output | Should -BeNullOrEmpty
+    }
+
+    It "Apt sources resolve through the mirror list" {
+        $sourcesFile = if (Test-IsUbuntu22) { "/etc/apt/sources.list" } else { "/etc/apt/sources.list.d/ubuntu.sources" }
+        Get-Content $sourcesFile -Raw | Should -Match ([regex]::Escape("mirror+file:/etc/apt/apt-mirrors.txt"))
+    }
+
+    It "Mirror list defines a failover chain with unique priorities" {
+        $priorities = Get-Content "/etc/apt/apt-mirrors.txt" | ForEach-Object { ($_ -split "priority:")[1] }
+        $priorities.Count | Should -BeGreaterThan 1
+        ($priorities | Select-Object -Unique).Count | Should -BeExactly $priorities.Count
+    }
+}

--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -29,8 +29,11 @@ Describe "Apt acquire configuration" {
     # Asserts the effective values, because a setting written under a key apt does not read is silently
     # ignored and leaves the image on apt's defaults.
     # https://github.com/actions/runner-images/issues/14594
+    # 22.04 and 24.04 arm64 are served by ports.ubuntu.com; 26.04 merged arm64 into the main archive.
+    $usesPortsArchive = (Test-IsUbuntu22-Arm64) -or (Test-IsUbuntu24-Arm64)
+
     $settingsTestCases = @(
-        @{ setting = "Acquire::Retries"; expectedValue = if (Test-IsArm64) { "3" } else { "1" } }
+        @{ setting = "Acquire::Retries"; expectedValue = if ($usesPortsArchive) { "3" } else { "1" } }
         @{ setting = "Acquire::http::Timeout"; expectedValue = "15" }
         @{ setting = "Acquire::https::Timeout"; expectedValue = "15" }
         @{ setting = "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled"; expectedValue = "false" }
@@ -44,14 +47,13 @@ Describe "Apt acquire configuration" {
         (Get-CommandResult "apt-config dump APT::Acquire::Retries").Output | Should -BeNullOrEmpty
     }
 
-    # arm64 sources come from ports.ubuntu.com, which /etc/apt/apt-mirrors.txt does not cover.
-    It "Apt sources resolve through the mirror list" -Skip:(Test-IsArm64) {
+    It "Apt sources resolve through the mirror list" -Skip:$usesPortsArchive {
         $sourcesFile = if (Test-IsUbuntu22) { "/etc/apt/sources.list" } else { "/etc/apt/sources.list.d/ubuntu.sources" }
         Get-Content $sourcesFile -Raw | Should -Match ([regex]::Escape("mirror+file:/etc/apt/apt-mirrors.txt"))
     }
 
-    # The mirror list holds x86-only archives, so pointing arm64 at it would 404 every fetch.
-    It "Apt sources use the ports archive on arm64" -Skip:(Test-IsX64) {
+    # The mirror list carries no arm64 packages for these releases, so pointing them at it would 404.
+    It "Apt sources use the ports archive" -Skip:(-not $usesPortsArchive) {
         $sourcesFile = if (Test-IsUbuntu22) { "/etc/apt/sources.list" } else { "/etc/apt/sources.list.d/ubuntu.sources" }
         $aptSources = Get-Content $sourcesFile -Raw
         $aptSources | Should -Match ([regex]::Escape("ports.ubuntu.com/ubuntu-ports"))

--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -31,11 +31,12 @@ Describe "Apt acquire configuration" {
     # https://github.com/actions/runner-images/issues/14594
     # 22.04 and 24.04 arm64 are served by ports.ubuntu.com; 26.04 merged arm64 into the main archive.
     $usesPortsArchive = (Test-IsUbuntu22-Arm64) -or (Test-IsUbuntu24-Arm64)
+    $expectedTimeout = if ($usesPortsArchive) { "30" } else { "15" }
 
     $settingsTestCases = @(
         @{ setting = "Acquire::Retries"; expectedValue = if ($usesPortsArchive) { "3" } else { "1" } }
-        @{ setting = "Acquire::http::Timeout"; expectedValue = "15" }
-        @{ setting = "Acquire::https::Timeout"; expectedValue = "15" }
+        @{ setting = "Acquire::http::Timeout"; expectedValue = $expectedTimeout }
+        @{ setting = "Acquire::https::Timeout"; expectedValue = $expectedTimeout }
     )
 
     It "<setting> is set to <expectedValue>" -TestCases $settingsTestCases {

--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -36,7 +36,6 @@ Describe "Apt acquire configuration" {
         @{ setting = "Acquire::Retries"; expectedValue = if ($usesPortsArchive) { "3" } else { "1" } }
         @{ setting = "Acquire::http::Timeout"; expectedValue = "15" }
         @{ setting = "Acquire::https::Timeout"; expectedValue = "15" }
-        @{ setting = "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled"; expectedValue = "false" }
     )
 
     It "<setting> is set to <expectedValue>" -TestCases $settingsTestCases {


### PR DESCRIPTION
# Description
- Replace `APT::Acquire::Retries "10"` with `Acquire::Retries "1"`.
- Set `Acquire::http::Timeout` / `Acquire::https::Timeout` to `15`.
- Assert the effective values in `Apt.Tests.ps1` and `ubuntu-slim/test.sh`.

### Reasoning:
When a mirror degrades, `apt-get update` stalls for 20-80 minutes instead of failing over. Three things caused that.

apt reads `Acquire::Retries`, not `APT::Acquire::Retries`. the latter appears nowhere in apt's source, so these images have always run on apt's default of 3. Correcting the key alone would have made things worse: retries are spent on the same*URI before apt moves to the next mirror in `/etc/apt/apt-mirrors.txt`, so a value of 10 pushes time-to-failover from ~2 minutes to ~8.5 minutes per index item. 

`Acquire::http::Timeout` was never set, but apt's built-in default is already 30s (unchanged across every apt in 22.04/24.04/26.04), so setting it to 30 explicitly is a no-op. 15s is safe because it is a connect/inactivity timeout, not a transfer budget. It does not abort slow-but-progressing downloads.

Time-to-failover also scales with the number of index items, because the mirror method re-sorts from priority:1 for every item and keeps no failure state. Reducing that item count is split into a separate PR so it can be validated on its own.

Mirror order is unchanged. The Azure mirror runs in the same datacentres as the runners, so it is fast and its traffic stays inside the network. The two fallbacks behind it, `archive.ubuntu.com` and `security.ubuntu.com`, are two names for the same servers. Putting them first would send every runner's apt traffic to servers Canonical owns and we don't, and would leave one thing to fail instead of two. 

Tests assert `apt-config dump` output rather than file contents, so a wrong key name or a later override fails the build instead of silently reverting to apt's defaults.

#### Related issue:
https://github.com/actions/runner-images/issues/14594

#### Past PRs: 
- https://github.com/actions/runner-images/pull/14596
- https://github.com/actions/runner-images/pull/14584

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated