### PR TITLE
[Windows ]Removed Docker from Windows ARM images

### DIFF
--- a/images/windows/toolsets/toolset-win-11-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-arm64.json
@@ -191,19 +191,6 @@
             "VisualStudioClient.MicrosoftVisualStudio2022InstallerProjectsArm64"
         ]
     },
-    "docker": {
-        "images": [
-            "mcr.microsoft.com/windows/servercore:ltsc2022",
-            "mcr.microsoft.com/windows/nanoserver:ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
-        ],
-        "components": {
-            "docker": "26.1.3",
-            "compose": "2.27.1"
-        }
-    },
     "pipx": [
         {
             "package": "yamllint",

--- a/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
@@ -182,19 +182,6 @@
             "VisualStudioClient.MicrosoftVisualStudio2022InstallerProjectsArm64"
         ]
     },
-    "docker": {
-        "images": [
-            "mcr.microsoft.com/windows/servercore:ltsc2022",
-            "mcr.microsoft.com/windows/nanoserver:ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
-        ],
-        "components": {
-            "docker": "26.1.3",
-            "compose": "2.27.1"
-        }
-    },
     "pipx": [
         {
             "package": "yamllint",


### PR DESCRIPTION
# Description
- Windows ARM does not support nested virtualization making Docker non-functional so it should be removed to optimize image.

#### Related issue:
- https://github.com/actions/runner-images/issues/14554
- https://github.com/actions/runner-images/issues/14632

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
  - [Windows 11 ARM](https://github.com/actions/runner-images-ci/actions/runs/32494079435)
  - [Windows 11 ARM + VS2026](https://github.com/actions/runner-images-ci/actions/runs/32494112195)