### PR TITLE
[Ubuntu] Resolve azure-cli apt suite by package availability

### DIFF
--- a/images/ubuntu/scripts/build/install-azure-cli.sh
+++ b/images/ubuntu/scripts/build/install-azure-cli.sh
@@ -4,12 +4,48 @@
 ##  Desc:  Install Azure CLI (az)
 ################################################################################
 
+AZURE_CLI_REPO_URL="https://packages.microsoft.com/repos/azure-cli"
+
+suite_has_azure_cli() {
+    local suite=$1
+    local url="$AZURE_CLI_REPO_URL/dists/$suite/main/binary-$(dpkg --print-architecture)/Packages"
+    local packages
+
+    packages=$(curl -fsL "$url") || return 1
+    grep -q '^Package: azure-cli$' <<< "$packages"
+}
+
+# packages.microsoft.com publishes an empty suite for a new Ubuntu release before azure-cli is
+# built for it, which defeats the codename fallback in the upstream installer
+# https://github.com/actions/runner-images/issues/14647
+os_codename=$(lsb_release -cs)
+dist_code=""
+
+for suite in "$os_codename" jammy; do
+    if suite_has_azure_cli "$suite"; then
+        dist_code=$suite
+        break
+    fi
+done
+
+if [[ -z $dist_code ]]; then
+    echo "No azure-cli packages published for '$os_codename' or the 'jammy' fallback in $AZURE_CLI_REPO_URL" >&2
+    exit 1
+fi
+
+echo "Installing azure-cli from the '$dist_code' suite"
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
+curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE="$dist_code" bash
+
+# The apt mock swallows apt-get exit codes, so we confirm if the package really landed
+if ! command -v az > /dev/null; then
+    echo "Failed to install azure-cli from the '$dist_code' suite: 'az' is not on PATH" >&2
+    exit 1
+fi
 
 echo "azure-cli https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt" >> $HELPER_SCRIPTS/apt-sources.txt
 
-rm -f /etc/apt/sources.list.d/azure-cli.list
-rm -f /etc/apt/sources.list.d/azure-cli.list.save
+rm -f /etc/apt/sources.list.d/azure-cli.*
 
 invoke_tests "CLI.Tools" "Azure CLI"

--- a/images/ubuntu/scripts/build/install-azure-cli.sh
+++ b/images/ubuntu/scripts/build/install-azure-cli.sh
@@ -11,7 +11,8 @@ suite_has_azure_cli() {
     local url="$AZURE_CLI_REPO_URL/dists/$suite/main/binary-$(dpkg --print-architecture)/Packages"
     local packages
 
-    packages=$(curl -fsL "$url") || return 1
+    # Without a retry a transient failure here would silently downgrade the image to the fallback suite
+    packages=$(curl -fsL --retry 3 "$url") || return 1
     grep -q '^Package: azure-cli$' <<< "$packages"
 }
 


### PR DESCRIPTION
# Description
This is a hotfix and an improvement. 

`packages.microsoft.com` created an empty resolute suite in the `azure-cli` repo on 2026-08-26, which satisfies the codename check in the upstream installer and stops it falling back to jammy. apt then points at a suite with a zero-byte Packages index and Ubuntu 26.04 builds fail with `E: Unable to locate package azure-cli`.

We now probe the suite for an azure-cli instance before installing and pass the resolved codename via `DIST_CODE`, falling back to jammy (as intended before). 22.04 and 24.04 keep resolving to their own suites, and 26.04 returns to the jammy packages it used until the placeholder appeared. Once azure-cli is published for resolute the primary candidate wins again with no further change.

Fail fast when no suite has packages and verify az is on PATH after the install, since the apt mock swallows apt-get exit codes and the failure would otherwise only surface in the Pester test.

The PR also drops the dead `azure-cli.list` cleanup. The installer writes deb822 `azure-cli.sources` now, so the repo was being left in the built image.


#### Related issue:
https://github.com/actions/runner-images/issues/14647

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
