### PR TITLE
[Windows] Update Service Fabric SDK, runtime, and VS functionality

### DIFF
--- a/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/windows/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -114,6 +114,7 @@ if (Test-IsArm64) {
     $tools.AddToolVersion("R", $(Get-RVersion))
 }
 if (Test-IsX64) {
+    $tools.AddToolVersion("Service Fabric Runtime", $(Get-ServiceFabricRuntimeVersion))
     $tools.AddToolVersion("Service Fabric SDK", $(Get-ServiceFabricSDKVersion))
 }
 $tools.AddToolVersion("Stack", $(Get-StackVersion))

--- a/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
+++ b/images/windows/scripts/docs-gen/SoftwareReport.Tools.psm1
@@ -252,8 +252,13 @@ function Get-StackVersion {
     return $stackVersion
 }
 
+function Get-ServiceFabricRuntimeVersion {
+    $serviceFabricRuntimeVersion = Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion
+    return $serviceFabricRuntimeVersion
+}
+
 function Get-ServiceFabricSDKVersion {
-    $serviceFabricSDKVersion = Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion
+    $serviceFabricSDKVersion = Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric SDK\' -Name FabricSDKVersion
     return $serviceFabricSDKVersion
 }
 

--- a/images/windows/scripts/tests/Tools.Tests.ps1
+++ b/images/windows/scripts/tests/Tools.Tests.ps1
@@ -129,8 +129,13 @@ Describe "ServiceFabricSDK" -Skip:(Test-IsWin11-Arm64) {
         }
     }
 
+    It "Service Fabric runtime version" {
+        $runtimeVersion = (Get-ToolsetContent).serviceFabric.runtime.version
+        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion | Should -Be $runtimeVersion
+    }
+
     It "ServiceFabricSDK version" {
-        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric\' -Name FabricVersion | Should -Not -BeNullOrEmpty
+        Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Service Fabric SDK\' -Name FabricSDKVersion | Should -Not -BeNullOrEmpty
     }
 }
 

--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -273,12 +273,12 @@
     },
     "serviceFabric": {
         "runtime": {
-            "version": "10.1.2493.9590",
-            "checksum": "09C63A971BACDE338282C73B3C9174BED9AAD53E1D3A1B73D44515852C9C00CF"
+            "version": "11.7.157.1",
+            "checksum": "BBD4531D80ED5FA8D2704C9267F701684FC58306987184BE9CAF35153F358C7B"
         },
         "sdk": {
-            "version": "7.1.2493",
-            "checksum": "0CB1084156C75CF5075EA91ABA330CF10B58648B8E036C9C2F286805263C497F"
+            "version": "8.7.157",
+            "checksum": "32ECB92CA3C9369A0BEA688737F9714E93EC1F8022D1708ABF5084E5B1F9EFBA"
         }
     },
     "dotnet": {

--- a/images/windows/toolsets/toolset-2025-vs2026.json
+++ b/images/windows/toolsets/toolset-2025-vs2026.json
@@ -201,7 +201,8 @@
             "VisualStudioClient.MicrosoftVisualStudio2022InstallerProjects",
             "WixToolset.WixToolsetVisualStudio2022Extension",
             "ProBITools.MicrosoftReportProjectsforVisualStudio2022",
-            "ProBITools.MicrosoftAnalysisServicesModelingProjects2022"
+            "ProBITools.MicrosoftAnalysisServicesModelingProjects2022",
+            "ms-azuretools.MicrosoftVisualStudioAzureFabricVsix"
         ]
     },
     "docker": {
@@ -231,12 +232,12 @@
     },
     "serviceFabric": {
         "runtime": {
-            "version": "10.1.2493.9590",
-            "checksum": "09C63A971BACDE338282C73B3C9174BED9AAD53E1D3A1B73D44515852C9C00CF"
+            "version": "11.7.157.1",
+            "checksum": "BBD4531D80ED5FA8D2704C9267F701684FC58306987184BE9CAF35153F358C7B"
         },
         "sdk": {
-            "version": "7.1.2493",
-            "checksum": "0CB1084156C75CF5075EA91ABA330CF10B58648B8E036C9C2F286805263C497F"
+            "version": "8.7.157",
+            "checksum": "32ECB92CA3C9369A0BEA688737F9714E93EC1F8022D1708ABF5084E5B1F9EFBA"
         }
     },
     "dotnet": {

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -244,12 +244,12 @@
     },
     "serviceFabric": {
         "runtime": {
-            "version": "10.1.2493.9590",
-            "checksum": "09C63A971BACDE338282C73B3C9174BED9AAD53E1D3A1B73D44515852C9C00CF"
+            "version": "11.7.157.1",
+            "checksum": "BBD4531D80ED5FA8D2704C9267F701684FC58306987184BE9CAF35153F358C7B"
         },
         "sdk": {
-            "version": "7.1.2493",
-            "checksum": "0CB1084156C75CF5075EA91ABA330CF10B58648B8E036C9C2F286805263C497F"
+            "version": "8.7.157",
+            "checksum": "32ECB92CA3C9369A0BEA688737F9714E93EC1F8022D1708ABF5084E5B1F9EFBA"
         }
     },
     "dotnet": {

--- a/images/windows/toolsets/toolset-win-11-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-arm64.json
@@ -211,12 +211,12 @@
     },
     "serviceFabric": {
         "runtime": {
-            "version": "10.1.2493.9590",
-            "checksum": "09C63A971BACDE338282C73B3C9174BED9AAD53E1D3A1B73D44515852C9C00CF"
+            "version": "11.7.157.1",
+            "checksum": "BBD4531D80ED5FA8D2704C9267F701684FC58306987184BE9CAF35153F358C7B"
         },
         "sdk": {
-            "version": "7.1.2493",
-            "checksum": "0CB1084156C75CF5075EA91ABA330CF10B58648B8E036C9C2F286805263C497F"
+            "version": "8.7.157",
+            "checksum": "32ECB92CA3C9369A0BEA688737F9714E93EC1F8022D1708ABF5084E5B1F9EFBA"
         }
     },
     "dotnet": {

--- a/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
+++ b/images/windows/toolsets/toolset-win-11-vs2026-arm64.json
@@ -202,12 +202,12 @@
     },
     "serviceFabric": {
         "runtime": {
-            "version": "10.1.2493.9590",
-            "checksum": "09C63A971BACDE338282C73B3C9174BED9AAD53E1D3A1B73D44515852C9C00CF"
+            "version": "11.7.157.1",
+            "checksum": "BBD4531D80ED5FA8D2704C9267F701684FC58306987184BE9CAF35153F358C7B"
         },
         "sdk": {
-            "version": "7.1.2493",
-            "checksum": "0CB1084156C75CF5075EA91ABA330CF10B58648B8E036C9C2F286805263C497F"
+            "version": "8.7.157",
+            "checksum": "32ECB92CA3C9369A0BEA688737F9714E93EC1F8022D1708ABF5084E5B1F9EFBA"
         }
     },
     "dotnet": {


### PR DESCRIPTION
# Description
This is an Improvement / version update.

Service Fabric runtime `10.1.2493.9590` and SDK `7.1.2493` went out of support on June 30, 2026, so this bumps them to the currently supported runtime `11.7.157.1` and SDK `8.7.157`. Both checksums were verified by downloading the installers and hashing them.

The VS 2026 image also gets the `ms-azuretools.MicrosoftVisualStudioAzureFabricVsix` extension, because Visual Studio 2026 has no built-in Service Fabric component and the SDK no longer ships the VS tooling, so `.sfproj` builds have nothing to import without it. The VS 2022 toolsets are left unchanged since they still get that tooling from the built-in component.

While here, the software report was reporting the runtime version under the "Service Fabric SDK" label. It now reports the runtime and the SDK separately, and the Pester test asserts the installed runtime matches the pinned version instead of only checking it is not empty.

No breaking changes are expected for users on supported cluster versions, but anyone still targeting a 10.1 or older cluster may need to pin the SDK themselves.

#### Related issue:
#14612

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated