### PR TITLE
[Ubuntu 24] Pin pipx to 1.16.7

### DIFF
--- a/images/ubuntu/scripts/build/install-python.sh
+++ b/images/ubuntu/scripts/build/install-python.sh
@@ -25,7 +25,13 @@ fi
 export PIPX_BIN_DIR=/opt/pipx_bin
 export PIPX_HOME=/opt/pipx
 
-python3 -m pip install pipx
+if is_ubuntu24; then
+    # Noble ships Debian-managed packaging 24.0, which pip cannot replace for pipx 1.17.1.
+    # Keep this pin for the Ubuntu 24.04 lifetime unless the distro package is upgraded.
+    python3 -m pip install "pipx==1.16.7"
+else
+    python3 -m pip install pipx
+fi
 python3 -m pipx ensurepath
 
 # Update /etc/environment


### PR DESCRIPTION
# Description

**Bug fixing**

Pin `pipx` to version `1.16.7` on Ubuntu 24.04.

Ubuntu 24.04 x64 and Arm64 image builds started failing after `pipx 1.17.1` was released. This version requires `packaging>=26`, while the Ubuntu 24.04 base cloud image contains the Debian-managed `python3-packaging 24.0-1` package.

During `python3 -m pip install pipx`, pip resolves `packaging 26.3` and attempts to replace the distro package, but cannot uninstall it because Debian packages do not include a pip `RECORD` file:

```text
Found existing installation: packaging 24.0
ERROR: Cannot uninstall packaging 24.0, RECORD file not found.
Hint: The package was installed by debian.
```

The pin is limited to Ubuntu 24.04. Other Ubuntu versions continue installing the latest available `pipx`. Version `1.16.7` requires `packaging>=20`, is compatible with Noble's system package, and matches the version included in the latest successful Ubuntu 24.04 images.

The pin is expected to remain for the Ubuntu 24.04 image lifetime unless Canonical updates the distro-managed `python3-packaging` package. This avoids replacing files owned by `dpkg` in the system Python environment.

Affected builds:

- Ubuntu 24.04 x64: https://github.com/github/hosted-runners-images/actions/runs/33335347170
- Ubuntu 24.04 Arm64: https://github.com/github/hosted-runners-images/actions/runs/33335249089

#### Related issue:

- https://github.com/github/hosted-runners-images/issues/946

## Check list

- [x] Related issue / work item is attached
- [x] Tests are written (if applicable; covered by the installer command check and existing pipx package tests)
- [x] Documentation is updated (not applicable; the reported pipx version remains `1.16.7`)
- [ ] Changes are tested and related VM images are successfully generated

### Validation

| Image | Status | Link |
|---|---|---|
| Ubuntu 24.04 x64 | In progress(build done) | https://github.com/github/hosted-runners-images/actions/runs/33395163076 |
| Ubuntu 24.04 Arm64 | In progress(build done) | https://github.com/github/hosted-runners-images/actions/runs/33395168710 |
