### PR TITLE
[Windows] Stage ARM64 x64 dbghelp.dll after the WDK install

### DIFF
--- a/images/windows/scripts/build/Install-VisualStudio.ps1
+++ b/images/windows/scripts/build/Install-VisualStudio.ps1
@@ -62,24 +62,4 @@ if (Test-IsWin25-X64) {
     }
 }
 
-# On ARM64 the Windows SDK installer never provides the x64 Debugging Tools, so
-# Debuggers\x64\dbghelp.dll is missing. Chromium's vs_toolchain.py copies that file for
-# its win_clang_x64 host toolchain even in a native arm64 build, so builds fail without it.
-# The x64 dbghelp.dll already ships under the SDK bin folder; stage it where it is expected.
-if (Test-IsWin11-Arm64) {
-    $kitsRoot = "${env:ProgramFiles(x86)}\Windows Kits\10"
-    $x64DbgHelp = Get-ChildItem "$kitsRoot\bin\*\x64\dbghelp.dll" -ErrorAction SilentlyContinue `
-        | Sort-Object { $_.VersionInfo.FileVersionRaw } -Descending | Select-Object -First 1
-    if (-not $x64DbgHelp) {
-        throw "x64 dbghelp.dll not found under $kitsRoot\bin - cannot stage x64 Debugging Tools"
-    }
-    $x64DebuggersDir = Join-Path $kitsRoot "Debuggers\x64"
-    New-Item -ItemType Directory -Force -Path $x64DebuggersDir | Out-Null
-    # Do not clobber an existing copy - if a future SDK ever ships its own x64 debuggers, keep it.
-    $destDbgHelp = Join-Path $x64DebuggersDir "dbghelp.dll"
-    if (-not (Test-Path $destDbgHelp)) {
-        Copy-Item -Path $x64DbgHelp.FullName -Destination $destDbgHelp -Force
-    }
-}
-
 Invoke-PesterTests -TestFile "VisualStudio"

--- a/images/windows/scripts/build/Install-WDK.ps1
+++ b/images/windows/scripts/build/Install-WDK.ps1
@@ -20,4 +20,23 @@ Install-Binary -Type EXE `
     -InstallArgs @("/features", "+", "/quiet") `
     -ExpectedSubject $(Get-MicrosoftPublisher)
 
+# Chromium's vs_toolchain.py needs Debuggers\x64\dbghelp.dll for its win_clang_x64 host
+# toolchain even in a native arm64 build, and nothing creates that folder on ARM64.
+# The x64 dbghelp.dll comes from the WDK payload above, so this must stay after the install.
+if (Test-IsWin11-Arm64) {
+    $kitsRoot = "${env:ProgramFiles(x86)}\Windows Kits\10"
+    $x64DbgHelp = Get-ChildItem "$kitsRoot\bin\*\x64\dbghelp.dll" -ErrorAction SilentlyContinue `
+        | Sort-Object { $_.VersionInfo.FileVersionRaw } -Descending | Select-Object -First 1
+    if (-not $x64DbgHelp) {
+        throw "x64 dbghelp.dll not found under $kitsRoot\bin - cannot stage x64 Debugging Tools"
+    }
+    $x64DebuggersDir = Join-Path $kitsRoot "Debuggers\x64"
+    New-Item -ItemType Directory -Force -Path $x64DebuggersDir | Out-Null
+    # Do not clobber an existing copy - if a future SDK ever ships its own x64 debuggers, keep it.
+    $destDbgHelp = Join-Path $x64DebuggersDir "dbghelp.dll"
+    if (-not (Test-Path $destDbgHelp)) {
+        Copy-Item -Path $x64DbgHelp.FullName -Destination $destDbgHelp -Force
+    }
+}
+
 Invoke-PesterTests -TestFile "WDK"

--- a/images/windows/scripts/tests/VisualStudio.Tests.ps1
+++ b/images/windows/scripts/tests/VisualStudio.Tests.ps1
@@ -36,9 +36,3 @@ Describe "Windows 11 SDK" {
         "${env:ProgramFiles(x86)}\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP\10.0.26100.0\UAP.props" | Should -Exist
     }
 }
-
-Describe "x64 Debugging Tools" -Skip:(-not (Test-IsWin11-Arm64)) {
-    It "Verifies x64 dbghelp.dll is staged for Chromium builds" {
-        "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\dbghelp.dll" | Should -Exist
-    }
-}

--- a/images/windows/scripts/tests/WDK.Tests.ps1
+++ b/images/windows/scripts/tests/WDK.Tests.ps1
@@ -11,3 +11,9 @@ Describe "WDK" -Skip:(Test-IsWin25-X64) {
     $version | Should -Not -BeNullOrEmpty
   }
 }
+
+Describe "x64 Debugging Tools" -Skip:(-not (Test-IsWin11-Arm64)) {
+  It "Verifies x64 dbghelp.dll is staged for Chromium builds" {
+    "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\dbghelp.dll" | Should -Exist
+  }
+}


### PR DESCRIPTION
# Description
This is a bug fix. 

The staging step added in [#14599](https://github.com/actions/runner-images/pull/14599) ran in `Install-VisualStudio.ps1` and read `Windows Kits\10\bin\*\x64\dbghelp.dll`, but that file is provided by the WDK, which is installed later in both ARM64 templates. The source was always absent and the throw broke every windows-11-arm64 and windows-11-vs2026-arm64 image build.

The PR moves the block and its Pester assertion to `Install-WDK.ps1` / `WDK.Tests.ps1`, where the source file exists. The staging logic is unchanged and still gated on `Test-IsWin11-Arm64`, so x64 images are unaffected.

#### Related issue:
https://github.com/actions/runner-images/issues/14061

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
