### PR TITLE
[MacOS] Pin Homebrew formulas for Intel images

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -43,18 +43,26 @@ for package in $common_packages; do
             ;;
 
         gnu-tar)
-            # For the Intel images gnu-tar stopped to work, using pinned commit
-            COMMIT=f80d41dc9db047924348b69d03f398e9e8b19598
-            FILE_NAME="g/gnu-tar.rb"
-            FORMULA_NAME="gnu-tar"
-            brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+            if ! is_Arm64; then
+                # For the Intel images gnu-tar stopped to work, using pinned commit
+                COMMIT=f80d41dc9db047924348b69d03f398e9e8b19598
+                FILE_NAME="g/gnu-tar.rb"
+                FORMULA_NAME="gnu-tar"
+                brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+            else
+                brew_smart_install "$package"
+            fi
             ;;
 
         swiftformat)
-            COMMIT=cb845e90e905cb254daaf82a721ac972c3307b03
-            FILE_NAME="s/swiftformat.rb"
-            FORMULA_NAME="swiftformat"
-            brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+            if ! is_Arm64; then
+                COMMIT=cb845e90e905cb254daaf82a721ac972c3307b03
+                FILE_NAME="s/swiftformat.rb"
+                FORMULA_NAME="swiftformat"
+                brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+            else
+                brew_smart_install "$package"
+            fi
             ;;
 
         # Default behaviour for all other packages

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -50,6 +50,13 @@ for package in $common_packages; do
             brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
             ;;
 
+        swiftformat)
+            COMMIT=cb845e90e905cb254daaf82a721ac972c3307b03
+            FILE_NAME="s/swiftformat.rb"
+            FORMULA_NAME="swiftformat"
+            brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+            ;;
+
         # Default behaviour for all other packages
         *)
             brew_smart_install "$package"

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -42,6 +42,14 @@ for package in $common_packages; do
             fi
             ;;
 
+        gnu-tar)
+            # For the Intel images gnu-tar stopped to work, using pinned commit
+            COMMIT=f80d41dc9db047924348b69d03f398e9e8b19598
+            FILE_NAME="g/gnu-tar.rb"
+            FORMULA_NAME="gnu-tar"
+            brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+            ;;
+
         # Default behaviour for all other packages
         *)
             brew_smart_install "$package"

--- a/images/macos/scripts/build/install-git.sh
+++ b/images/macos/scripts/build/install-git.sh
@@ -17,13 +17,10 @@ if is_Arm64; then
     brew_smart_install "git-lfs"
 else
     # For the Intel images git-lfs stopped to work, using pinned commit
-    echo "Installing pinned git-lfs formulae..."
     COMMIT=70cbd7e455267402af156a5b733a774b15ef9949
-    FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/g/git-lfs.rb"
-    FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/g/git-lfs.rb"
-    mkdir -p "$(dirname $FORMULA_PATH)"
-    curl -fsSL $FORMULA_URL -o $FORMULA_PATH
-    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install git-lfs
+    FILE_NAME="g/git-lfs.rb"
+    FORMULA_NAME="git-lfs"
+    brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
 fi
 
 # Update global git config

--- a/images/macos/scripts/build/install-git.sh
+++ b/images/macos/scripts/build/install-git.sh
@@ -12,7 +12,19 @@ brew_smart_install "git"
 git config --global --add safe.directory "*"
 
 echo "Installing Git LFS"
-brew_smart_install "git-lfs"
+if is_Arm64; then
+    # git-lfs works fine on ARM64 images
+    brew_smart_install "git-lfs"
+else
+    # For the Intel images git-lfs stopped to work, using pinned commit
+    echo "Installing pinned git-lfs formulae..."
+    COMMIT=70cbd7e455267402af156a5b733a774b15ef9949
+    FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$COMMIT/Formula/g/git-lfs.rb"
+    FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/g/git-lfs.rb"
+    mkdir -p "$(dirname $FORMULA_PATH)"
+    curl -fsSL $FORMULA_URL -o $FORMULA_PATH
+    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install git-lfs
+fi
 
 # Update global git config
 git lfs install

--- a/images/macos/scripts/build/install-homebrew.sh
+++ b/images/macos/scripts/build/install-homebrew.sh
@@ -34,6 +34,13 @@ echo "Installing jq..."
 brew_smart_install jq
 
 echo "Installing curl..."
+if ! is_Arm64; then
+    # For the Intel images curl dependency openssl@3 stopped to work, using pinned commit
+    COMMIT=ac0bc95fef0e5aed25b3662f6271020410cfbc3d
+    FILE_NAME="o/openssl@3.rb"
+    FORMULA_NAME="openssl@3"
+    brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+fi
 brew_smart_install curl
 
 echo "Installing wget..."

--- a/images/macos/scripts/build/install-node.sh
+++ b/images/macos/scripts/build/install-node.sh
@@ -8,6 +8,14 @@ source ~/utils/utils.sh
 
 defaultVersion=$(get_toolset_value '.node.default')
 
+if ! is_Arm64; then
+    # Node dependency simdjson is not available for Intel macOS images since 2026.08.31
+    COMMIT=e13ded35d324fe5e3eb9ac4d3c2be05cab13cf72
+    FILE_NAME="s/simdjson.rb"
+    FORMULA_NAME="simdjson"
+    brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+fi
+
 echo "Installing Node.js $defaultVersion"
 brew_smart_install "node@$defaultVersion"
 brew link node@$defaultVersion --force --overwrite

--- a/images/macos/scripts/build/install-python.sh
+++ b/images/macos/scripts/build/install-python.sh
@@ -11,6 +11,14 @@ echo "Installing Python Tooling"
 # Close Finder window
 close_finder_window
 
+if ! is_SonomaArm64; then
+    # For the MacOS 14 Intel python dependency expat stopped to work, using pinned commit
+    COMMIT=808c33c0f058f5898ef0556a343a5599f801f942
+    FILE_NAME="e/expat.rb"
+    FORMULA_NAME="expat"
+    brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+fi
+
 # Installing latest Homebrew Python 3 to handle python3 and pip3 symlinks
 echo "Brew Installing default Python 3"
 brew_smart_install "python3"

--- a/images/macos/scripts/build/install-python.sh
+++ b/images/macos/scripts/build/install-python.sh
@@ -11,7 +11,7 @@ echo "Installing Python Tooling"
 # Close Finder window
 close_finder_window
 
-if ! is_SonomaArm64; then
+if is_SonomaX64; then
     # For the MacOS 14 Intel python dependency expat stopped to work, using pinned commit
     COMMIT=808c33c0f058f5898ef0556a343a5599f801f942
     FILE_NAME="e/expat.rb"

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -99,7 +99,7 @@ brew_smart_install() {
 
     failed=true
     for i in {1..10}; do
-        brew deps --missing $tool_name > /tmp/$tool_name && failed=false || sleep 60
+        brew deps $tool_name > /tmp/$tool_name && failed=false || sleep 60
         [ "$failed" = false ] && break
     done
 
@@ -148,6 +148,7 @@ brew_install_pinned_formula() {
     curl -fsSL "$FORMULA_URL" -o "$FORMULA_PATH"
 
     HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install "$formula_name"
+    brew pin "$formula_name"
 }
 
 configure_system_tccdb () {

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -148,7 +148,6 @@ brew_install_pinned_formula() {
     curl -fsSL "$FORMULA_URL" -o "$FORMULA_PATH"
 
     HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install "$formula_name"
-    brew pin "$formula_name"
 }
 
 configure_system_tccdb () {

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -124,7 +124,7 @@ brew_smart_install() {
 
     failed=true
     for i in {1..10}; do
-        brew install $tool_name && failed=false || sleep 60
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install $tool_name && failed=false || sleep 60
         [ "$failed" = false ] && break
     done
 

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -124,7 +124,7 @@ brew_smart_install() {
 
     failed=true
     for i in {1..10}; do
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install $tool_name && failed=false || sleep 60
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install "$tool_name" && failed=false || sleep 60
         [ "$failed" = false ] && break
     done
 

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -134,6 +134,22 @@ brew_smart_install() {
     fi
 }
 
+brew_install_pinned_formula() {
+    local formula_name=$1
+    local formula_file=$2
+    local commit_hash=$3
+
+    echo "Installing pinned formula: $formula_name"
+
+    local FORMULA_URL="https://raw.githubusercontent.com/Homebrew/homebrew-core/$commit_hash/Formula/$formula_file"
+    local FORMULA_PATH
+    FORMULA_PATH="$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/$formula_file"
+    mkdir -p "$(dirname "$FORMULA_PATH")"
+    curl -fsSL "$FORMULA_URL" -o "$FORMULA_PATH"
+
+    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install "$formula_name"
+}
+
 configure_system_tccdb () {
     local values=$1
     local dbPath="/Library/Application Support/com.apple.TCC/TCC.db"

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -99,7 +99,7 @@ brew_smart_install() {
 
     failed=true
     for i in {1..10}; do
-        brew deps $tool_name > /tmp/$tool_name && failed=false || sleep 60
+        brew deps --missing $tool_name > /tmp/$tool_name && failed=false || sleep 60
         [ "$failed" = false ] && break
     done
 

--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -291,6 +291,7 @@ build {
   }
 
   provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline = ["rm -rf \"$(brew --cache)\""]
   }
 

--- a/images/macos/templates/macOS-15.anka.pkr.hcl
+++ b/images/macos/templates/macOS-15.anka.pkr.hcl
@@ -290,6 +290,7 @@ build {
   }
 
   provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline = ["rm -rf \"$(brew --cache)\""]
   }
 


### PR DESCRIPTION
# Description
Recent updates in some Homebrew formulas made them unsupported on MacOS Intel images. Workaround is to pin older formula versions. Affected software:
- gnu-tar
- swiftformat
- git-lfs
- simdjson
- expat
- openssl@3

Additional changes:
- Added helper function to make Homebrew formula pinning easier.
- Added `HOMEBREW_NO_AUTO_UPDATE=1` flag to `brew_smart_install()` to prevent default Homebrew behavior of updating all dependencies for formula being installed, resulting in failure if dependency is not supported for Intel images in newer dependency's formula version.
- Added `sudo` to homebrew cache cleanup step to fix access issues.

#### Related issue:
- https://github.com/github/hosted-runners-images/issues/945

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated:
  - [MacOS 14 ARM](https://github.com/github/hosted-runners-images/actions/runs/33669236166)
  - [MacOS 14 Intel](https://github.com/github/hosted-runners-images/actions/runs/33669244382)
  - [MacOS 15 ARM](https://github.com/github/hosted-runners-images/actions/runs/33669255618)
  - [MacOS 15 Intel](https://github.com/github/hosted-runners-images/actions/runs/33669270333)
  - [MacOS 26 Intel](https://github.com/github/hosted-runners-images/actions/runs/33669291682)
  - [xcode-27](https://github.com/github/hosted-runners-images/actions/runs/33669305890)

