### PR TITLE
[Windows] Disable the first-logon privacy experience on ARM64 images

### DIFF
--- a/images/windows/scripts/build/Configure-BaseImage.ps1
+++ b/images/windows/scripts/build/Configure-BaseImage.ps1
@@ -49,6 +49,18 @@ Get-ScheduledTask -TaskName ServerManager -ErrorAction SilentlyContinue | Disabl
 Write-Host "Disable 'Allow your PC to be discoverable by other PCs' popup"
 New-Item -Path HKLM:\System\CurrentControlSet\Control\Network -Name NewNetworkWindowOff -Force
 
+if (Test-IsWin11-Arm64) {
+    Write-Host "Disable the privacy settings experience for new user logons"
+    # Apply the device policy before image capture so it covers newly created runner users.
+    # https://learn.microsoft.com/windows/client-management/mdm/policy-csp-privacy#disableprivacyexperience
+    $privacyPolicyPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\OOBE"
+    if (-not (Test-Path -Path $privacyPolicyPath)) {
+        New-Item -Path $privacyPolicyPath -Force -ErrorAction Stop | Out-Null
+    }
+    New-ItemProperty -Path $privacyPolicyPath -Name DisablePrivacyExperience -PropertyType DWORD -Value 1 -Force -ErrorAction Stop | Out-Null
+    Invoke-PesterTests -TestFile "WindowsFeatures" -TestName "PrivacyExperience"
+}
+
 Write-Host 'Disable Windows Update Medic Service'
 Set-ItemProperty -Path HKLM:\System\CurrentControlSet\Services\WaaSMedicSvc -Name Start -Value 4 -Force
 

--- a/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
+++ b/images/windows/scripts/tests/WindowsFeatures.Tests.ps1
@@ -62,6 +62,14 @@ Describe "Test Signed Drivers" {
     }
 }
 
+Describe "PrivacyExperience" -Skip:(-not (Test-IsWin11-Arm64)) {
+    It "The privacy settings experience is disabled for all users" {
+        $regPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\OOBE"
+        Get-ItemPropertyValue -Path $regPath -Name DisablePrivacyExperience | Should -BeExactly 1
+        (Get-Item -Path $regPath).GetValueKind("DisablePrivacyExperience") | Should -Be "DWord"
+    }
+}
+
 Describe "Windows Updates" {
     It "WindowsUpdateDone.txt should exist" {
         "$env:windir\WindowsUpdateDone.txt" | Should -Exist


### PR DESCRIPTION
> [!NOTE]  
> **Disclosure** : This PR have been created with the help of AI (GPT 5.6 Sol) but reviewed by HB (Human Brain 😄)

# Description
Bug fixing  
Windows 11 ARM64 runners can display the "Choose privacy settings for your device" experience during first logon, taking focus away from applications and breaking automated GUI tests.  
Sets the documented machine-wide `DisablePrivacyExperience` policy to DWORD `1` in `Configure-BaseImage.ps1`, guarded by `Test-IsWin11-Arm64`. Both Windows 11 ARM64 image variants already execute this script before image capture, so the policy applies to newly created runner accounts rather than only the image-build account.  
Add a read-only Pester assertion in `WindowsFeatures.Tests.ps1` that verifies the policy value and registry type. Run it immediately after configuration and through the existing full image test suite. The configuration and assertion are restricted to Windows 11 ARM64.  
Microsoft documents the policy here : https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-privacy#disableprivacyexperience  
This change prevents the privacy experience from launching on subsequent eligible logons. It does not dismiss an already-open window or address the separate OneDrive and WSL prompts discussed in the issue. No process termination, UI automation, or background watcher is added (which are current workarounds).

## Validation
- Tests has been ran and passes
- A complete Azure image build and first-logon GUI validation have not been run locally

#### Related issue :
Closes #14069

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated