### PR TITLE
[Ubuntu][Windows] Update Android command-line tools to 22.0

### DIFF
--- a/images/ubuntu/scripts/build/install-android-sdk.sh
+++ b/images/ubuntu/scripts/build/install-android-sdk.sh
@@ -47,12 +47,12 @@ mkdir -p ${ANDROID_SDK_ROOT}
 # Download the latest command line tools so that we can accept all of the licenses.
 # See https://developer.android.com/studio/#command-tools
 cmdline_tools_package=$(get_toolset_value '.android."cmdline-tools"')
-if [[ $cmdline_tools_version == "latest" ]]; then
+if [[ $cmdline_tools_package == "latest" ]]; then
     REPOSITORY_XML_URL="https://dl.google.com/android/repository/repository2-1.xml"
     repository_xml_file=$(download_with_retry "$REPOSITORY_XML_URL")
     cmdline_tools_package=$(
         yq -p=xml \
-        '.sdk-repository.remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
+        '.["sdk:sdk-repository"].remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' \
         "${repository_xml_file}"
     )
 

--- a/images/ubuntu/scripts/tests/Android.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Android.Tests.ps1
@@ -97,6 +97,14 @@ Describe "Android" -Skip:(Test-IsArm64) {
         }
     }
 
+    # The Android CLI ships with command-line tools 22.0 and later, the first revision that also writes
+    # valid AVD targets for Major.Minor packages; ubuntu-22.04 stays behind because 22.0 requires Java 17
+    Context "Command-line tools" -Skip:(Test-IsUbuntu22) {
+        It "Android CLI is available" {
+            "$env:ANDROID_HOME/cmdline-tools/latest/bin/android" | Should -Exist
+        }
+    }
+
     Context "Packages" {
         $testCases = $androidPackages | ForEach-Object { @{ PackageName = $_ } }
 

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -68,7 +68,7 @@
         "maven": "3.9.12"
     },
     "android": {
-        "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",
+        "cmdline-tools": "commandlinetools-linux-15859902_latest.zip",
         "platform_min_version": "34",
         "build_tools_min_version": "34.0.0",
         "extra_list": [

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -72,7 +72,7 @@
         "maven": "3"
     },
     "android": {
-        "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",
+        "cmdline-tools": "commandlinetools-linux-15859902_latest.zip",
         "platform_min_version": "34",
         "build_tools_min_version": "34.0.0",
         "extra_list": [

--- a/images/ubuntu/toolsets/toolset-2604-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2604-arm64.json
@@ -68,7 +68,7 @@
         "maven": "3.9.15"
     },
     "android": {
-        "cmdline-tools": "commandlinetools-linux-14742923_latest.zip",
+        "cmdline-tools": "commandlinetools-linux-15859902_latest.zip",
         "platform_min_version": "34",
         "build_tools_min_version": "34.0.0",
         "extra_list": [

--- a/images/ubuntu/toolsets/toolset-2604.json
+++ b/images/ubuntu/toolsets/toolset-2604.json
@@ -72,7 +72,7 @@
         "maven": "3.9.15"
     },
     "android": {
-        "cmdline-tools": "commandlinetools-linux-14742923_latest.zip",
+        "cmdline-tools": "commandlinetools-linux-15859902_latest.zip",
         "platform_min_version": "34",
         "build_tools_min_version": "34.0.0",
         "extra_list": [

--- a/images/windows/scripts/tests/Android.Tests.ps1
+++ b/images/windows/scripts/tests/Android.Tests.ps1
@@ -47,6 +47,14 @@ Describe "Android SDK" -Skip:(Test-IsArm64) {
         }
     }
 
+    # The Android CLI ships with command-line tools 22.0 and later, the first revision that also writes
+    # valid AVD targets for Major.Minor packages; windows-2022 stays behind because 22.0 requires Java 17
+    Context "Command-line tools" -Skip:(Test-IsWin22) {
+        It "Android CLI is available" {
+            "$env:ANDROID_HOME\cmdline-tools\latest\bin\android.exe" | Should -Exist
+        }
+    }
+
     Context "Packages" {
         if (-not (Test-IsArm64)) {
             It "Platform version <platformVersion> is installed" -TestCases $platformTestCases {

--- a/images/windows/toolsets/toolset-2025-vs2026.json
+++ b/images/windows/toolsets/toolset-2025-vs2026.json
@@ -83,8 +83,8 @@
         "versions": [ "8", "11", "17", "21", "25"]
     },
     "android": {
-        "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-13114758_latest.zip",
-        "hash": "98B565CB657B012DAE6794CEFC0F66AE1EFB4690C699B78A614B4A6A3505B003",
+        "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-15859902_latest.zip",
+        "hash": "E5885E2E59038C0778A85FC19F01DE7CE7C567C105553F7617B936B1E0E87B2B",
         "platform_min_version": "34",
         "build_tools_min_version": "34.0.0",
         "extras": [

--- a/images/windows/toolsets/toolset-2025.json
+++ b/images/windows/toolsets/toolset-2025.json
@@ -83,8 +83,8 @@
         "versions": [ "8", "11", "17", "21", "25"]
     },
     "android": {
-        "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-12266719_latest.zip",
-        "hash": "F9088C04A44F1F37A8A3A228A7663E11AE9445FA07529C96CEF38ACB985A88F3",
+        "commandline_tools_url": "https://dl.google.com/android/repository/commandlinetools-win-15859902_latest.zip",
+        "hash": "E5885E2E59038C0778A85FC19F01DE7CE7C567C105553F7617B936B1E0E87B2B",
         "platform_min_version": "34",
         "build_tools_min_version": "34.0.0",
         "extras": [


### PR DESCRIPTION
Addresses #14484 for the Ubuntu and Windows images: updates the preinstalled Android SDK Command-line Tools to **22.0** (build `15859902`).

## Why

`cmdline-tools` older than 20.0 cannot parse the `Major.Minor` package paths Android now publishes (`android-37.0`, `system-images;android-37.0;google_apis_ps16k;x86_64`). I confirmed the root cause directly against the `sdklib` shipped in each revision:

| cmdline-tools | `AndroidTargetHash.getPlatformVersion("android-37.0")` | `target=` written into the AVD `.ini` |
| --- | --- | --- |
| 12.0 (current on `ubuntu-24.04`) | `null` | `android-0` :x: |
| 22.0 | `API 37.0` | `android-37.0` :white_check_mark: |

`avdmanager create avd` still exits 0, so the AVD looks fine but records `target=android-0`. The emulator then treats it as a very old system image, skips the Vulkan / GLDirectMem auto-enable and renders blank or corrupted frames while every step of the workflow reports success — nothing points back at the SDK tools.

22.0 is also the first revision that ships the **Android CLI** (`cmdline-tools/latest/bin/android`, `android.exe` on Windows) — the replacement that `sdkmanager` now advertises on every invocation. One version bump therefore covers both requests in the issue, with no new tool to package.

## Images updated

| Image | Command-line tools before | After |
| --- | --- | --- |
| `ubuntu-24.04` | 12.0 | 22.0 |
| `ubuntu-26.04` | 20.0 | 22.0 |
| `windows-2025` | 16.0 | 22.0 |
| `windows-2025` (VS2026) | 19.0 | 22.0 |

The arm64 Ubuntu toolsets are kept in sync with their x64 counterparts, as they are today (no arm64 template runs `install-android-sdk.sh`).

### Left on the current revision on purpose

`ubuntu-22.04` (9.0) and `windows-2022` (8.0). cmdline-tools 22.0 is compiled for **Java 17** — class file version 61, against 55 in 12.0/20.0 and 52 in 8.0/9.0 — and those two images default to Java 11 and Java 8 respectively. Bumping them would break `sdkmanager` for every workflow that uses the image's default JDK, and the image build itself, which runs `sdkmanager` under that default. Glad to add them if you would prefer to pin the Android install step to `JAVA_HOME_17_X64` instead.

macOS is untouched, per CONTRIBUTING. The same one-line change applies to `toolset-14/15/26/xcode-27.json`, with one caveat worth recording: starting with 22.0 Google renamed the macOS archive, so the value becomes `commandlinetools-mac_x86_64-15859902_latest.zip` (the `contains("commandlinetools-mac")` filter in `install-android-sdk.sh` still matches it).

## Compatibility with the existing scripts

22.0 keeps the classic `sdkmanager` — a Java tool with the pipe-table `--list` output — so nothing in this repo needs to change. Verified against real 22.0 output:

- `sed -n '/Available Packages:/,/^$/p' | grep "platforms;android-[0-9]" | cut -d"|" -f 1` and the `build-tools;` / `ndk;<major>.` greps in `install-android-sdk.sh` still return the expected package paths
- `sdkmanager --version` prints exactly `22.0` on **stdout**; the new deprecation notice goes to stderr, so `Get-AndroidCommandLineToolsVersion` in the software report keeps matching
- the three deprecation lines that `Get-AndroidPackages` picks up through `2>&1` are dropped by its existing `-NotMatch "^[^;]*$"` filter, since none of them contains a `;`

:warning: One note for whoever bumps this next: **23.0 cannot be picked up as a drop-in.** There `sdkmanager` becomes a shell shim over `android sdk`, `--list` switches to `build-tools/17.0.0`-style paths with no `|` columns, and `--include_obsolete` / `--verbose` are accepted-but-ignored. That silently breaks the platform/build-tools/NDK selection in `install-android-sdk.sh`, `Get-AndroidPackages` on Windows and the software report parsing. That is why this PR pins 22.0 explicitly rather than switching the pin to `latest`.

## Second commit: `latest` resolution on Ubuntu

`install-android-sdk.sh` supports `"cmdline-tools": "latest"`, but two defects meant it could never work:

- the branch tests `$cmdline_tools_version`, which is never assigned — the toolset value is read into `$cmdline_tools_package`, so `latest` fell straight through and was used as a file name
- the `yq` query addresses `.sdk-repository`, while `repository2-1.xml` declares the namespaced root `sdk:sdk-repository`, so the query returns nothing and the script exits with "Failed to parse latest command-line tools version"

With both fixed, the query resolves against the current repository index:

```console
$ yq -p=xml '.["sdk:sdk-repository"].remotePackage[] | select(."+@path" == "cmdline-tools;latest" and .channelRef."+@ref" == "channel-0").archives.archive[].complete.url | select(contains("commandlinetools-linux"))' repository2-1.xml
commandlinetools-linux-16111833_latest.zip
```

The pins stay explicit; this only makes the documented `latest` option usable (and it now fails loudly rather than downloading a file called `latest`).

The macOS script carries a byte-identical copy of that block (`images/macos/scripts/build/install-android-sdk.sh`, differing only in `commandlinetools-mac`), with the same `.sdk-repository` root, so it needs the same one-line change. Left out of this PR per CONTRIBUTING, along with the toolset bump.

## Validation

A `Command-line tools` context in `images/ubuntu/scripts/tests/Android.Tests.ps1` and `images/windows/scripts/tests/Android.Tests.ps1` asserts that the `android` CLI is present, and is skipped on the images that stay on the older revision. That single check also covers the revision, since `android` only ships from 22.0 on.

What I checked locally against the 22.0 package (macOS host with JDK 25 — `sdkmanager` is the same Java tool on every platform):

```console
$ cmdline-tools/latest/bin/sdkmanager --version 2>/dev/null
22.0
$ cmdline-tools/latest/bin/android --version | tail -1
1.0.15985488
```

- `AndroidTargetHash.getPlatformVersion("android-37.0")` against the `sdklib` of each revision gives the table above (`null` on 12.0, `API 37.0` / `android-37.0` on 22.0)
- the SHA-1 of both archives I downloaded matches `repository2-1.xml`, and the Windows SHA-256 added to the toolsets is computed from that verified download
- the `--list` parsing checks listed under *Compatibility* were run against real 22.0 output

I cannot build a full runner image here, so the end-to-end AVD check from the issue is unverified on my side. The issue reports `target=android-37.0` from 20.0 onward, which is consistent with the parser results above.

I did not add the Android CLI to the software report: `android` self-updates from Google on first run, so its version is a property of when it is invoked rather than of the image. Happy to add a row if you would like it reported anyway.
