### PR TITLE
[MacOS] Migrate xcode-27 image to MacOS 27

### DIFF
--- a/images/macos/scripts/build/configure-tccdb-macos-27.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos-27.sh
@@ -1,0 +1,122 @@
+#!/bin/bash -e -o pipefail
+################################################################################
+##  File:  configure-tccdb-macos.sh
+##  Desc:  Configure permissions to the TCC.db
+################################################################################
+
+source ~/utils/utils.sh
+
+print_system_tccdb_structure
+
+print_user_tccdb_structure
+
+# /Library/Application\ Support/com.apple.TCC/TCC.db
+systemValuesArray=(
+    "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceAccessibility','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAccessibility','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
+    "'kTCCServiceAccessibility','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
+    "'kTCCServiceAccessibility','/usr/libexec/sshd-keygen-wrapper',1,2,4,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'UNUSED',NULL,0,1644564233,NULL,NULL"
+    "'kTCCServiceAccessibility','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAccessibility','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
+    "'kTCCServiceAccessibility','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502,NULL,NULL"
+    "'kTCCServiceAccessibility','com.apple.dt.Xcode-Helper',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941368,NULL,NULL"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312,NULL,NULL"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312,NULL,NULL"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312,NULL,NULL"
+    "'kTCCServiceBluetoothAlways','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceMicrophone','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceMicrophone','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
+    "'kTCCServicePostEvent','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1644565949,NULL,NULL"
+    "'kTCCServicePostEvent','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321326,NULL,NULL"
+    "'kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321326,NULL,NULL"
+    "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148,NULL,NULL"
+    "'kTCCServiceScreenCapture','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
+    "'kTCCServiceScreenCapture','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','/usr/libexec/sshd-keygen-wrapper',1,0,4,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'UNUSED',NULL,0,1639660695,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav.epsext',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979,NULL,NULL"
+    "'kTCCServiceSystemPolicyNetworkVolumes','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceSystemPolicyNetworkVolumes','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068,NULL,NULL"
+)
+for values in "${systemValuesArray[@]}"; do
+    configure_system_tccdb "$values,NULL,NULL,'UNUSED',${values##*,}"
+done
+
+# $HOME/Library/Application\ Support/com.apple.TCC/TCC.db
+userValuesArray=(
+    "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceAccessibility','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
+    "'kTCCServiceAccessibility','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502,NULL,NULL"
+    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.Terminal',X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,1655808179,NULL,NULL"
+    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1629294900,NULL,NULL"
+    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,164456761,NULL,NULL"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1574241374,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/libexec/sshd-keygen-wrapper',1,2,0,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1591357685"
+    "'kTCCServiceAppleEvents','/usr/libexec/sshd-keygen-wrapper',1,2,3,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1644564201"
+    "'kTCCServiceAppleEvents','/usr/libexec/sshd-keygen-wrapper',1,2,3,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'com.apple.Terminal',X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,1650386089"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1592919552,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1574241374,NULL,NULL"
+    "'kTCCServiceAppleEvents','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1591180478,NULL,NULL"
+    "'kTCCServiceBluetoothAlways','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceMicrophone','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceMicrophone','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
+    "'kTCCServiceMicrophone','com.apple.CoreSimulator.SimulatorTrampoline',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576347152,NULL,NULL"
+    "'kTCCServicePostEvent','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceScreenCapture','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
+    "'kTCCServiceScreenCapture','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
+    "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceScreenCapture','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
+    "'kTCCServiceScreenCapture','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
+    "'kTCCServiceUbiquity','/System/Library/PrivateFrameworks/PhotoLibraryServices.framework/Versions/A/Support/photolibraryd',1,2,5,1,NULL,NULL,NULL,'UNUSED',NULL,0,1619461750,NULL,NULL"
+    "'kTCCServiceUbiquity','com.apple.CloudDocs.MobileDocumentsFileProvider',0,2,0,1,X'fade0c000000004c0000000100000006000000020000002f636f6d2e6170706c652e436c6f7564446f63732e4d6f62696c65446f63756d656e747346696c6550726f76696465720000000003',NULL,NULL,'UNUSED',NULL,0,1570793290,NULL,NULL"
+    "'kTCCServiceUbiquity','com.apple.PassKitCore',0,2,5,1,NULL,NULL,NULL,'UNUSED',NULL,0,1619516250,NULL,NULL"
+    "'kTCCServiceUbiquity','com.apple.TextEdit',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465787445646974000000000003',NULL,NULL,'UNUSED',NULL,0,1566368356,NULL,NULL"
+    "'kTCCServiceUbiquity','com.apple.mail',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941469,NULL,NULL"
+)
+for values in "${userValuesArray[@]}"; do
+    configure_user_tccdb "$values,NULL,NULL,'UNUSED',${values##*,}"
+done
+
+# Pre-approve screen capture for the runner agent.
+# Granting kTCCServiceScreenCapture above is not enough on macOS 15+: capturing
+# the screen through a legacy API instead of ScreenCaptureKit's picker raises a
+# recurring "<app> is requesting to bypass the system private window picker"
+# alert, which takes focus and breaks headed UI tests. replayd tracks the
+# reminder in its own approvals file, keyed by the *responsible* process - on a
+# hosted runner that is the agent, whatever tool the job actually runs. Since
+# the file is absent in the image and every job gets a fresh VM, the reminder is
+# always overdue and the alert fires on the first capture of every job.
+# A far-future date suppresses it; replayd expands this into its own dictionary
+# form on first use and keeps the date.
+approvalsPlist="$HOME/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
+mkdir -p "$(dirname "$approvalsPlist")"
+defaults write "$approvalsPlist" "/opt/hca/hosted-compute-agent" -date "3024-01-01 00:00:00 +0000"
+
+# flush the preferences cache so the write is on disk; System.Tests.ps1 asserts
+# the approval is there
+killall cfprefsd 2>/dev/null || true

--- a/images/macos/scripts/build/configure-tccdb-macos-27.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos-27.sh
@@ -1,105 +1,214 @@
 #!/bin/bash -e -o pipefail
 ################################################################################
 ##  File:  configure-tccdb-macos.sh
-##  Desc:  Configure permissions to the TCC.db
+##  Desc:  Configure permissions in the TCC databases
 ################################################################################
 
 source ~/utils/utils.sh
 
-print_system_tccdb_structure
+macosVersion="$(sw_vers -productVersion)"
+macosMajor="${macosVersion%%.*}"
+case "$macosMajor" in
+    ''|*[!0-9]*)
+        echo "Unexpected macOS version: $macosVersion" >&2
+        exit 1
+        ;;
+esac
 
-print_user_tccdb_structure
+resolve_user_tccdb() {
+    local userID openFiles line candidate dbPath=""
 
-# /Library/Application\ Support/com.apple.TCC/TCC.db
+    if [[ "$macosMajor" -lt 27 ]]; then
+        dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+    else
+        userID="$(id -u)"
+        if ! openFiles="$(sudo lsof -a -u "$userID" -c tccd -Fn)"; then
+            echo "Unable to inspect the user TCC daemon for UID $userID" >&2
+            return 1
+        fi
+
+        while IFS= read -r line; do
+            case "$line" in
+                n/private/var/containers/Data/ProtectedSystem/*/Data/Library/Application\ Support/com.apple.TCC/TCC.db)
+                    candidate="${line#n}"
+                    if [[ -n "$dbPath" && "$dbPath" != "$candidate" ]]; then
+                        echo "Found multiple active user TCC databases for UID $userID" >&2
+                        return 1
+                    fi
+                    dbPath="$candidate"
+                    ;;
+            esac
+        done <<< "$openFiles"
+
+        if [[ -z "$dbPath" ]]; then
+            echo "Unable to find the active user TCC database for UID $userID" >&2
+            return 1
+        fi
+
+    fi
+
+    if ! sudo test -f "$dbPath"; then
+        echo "User TCC database does not exist: $dbPath" >&2
+        return 1
+    fi
+
+    if [[ "$macosMajor" -ge 27 && "$(sudo stat -f %u "$dbPath")" != "$(id -u)" ]]; then
+        echo "Unexpected owner for user TCC database: $dbPath" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$dbPath"
+}
+
+configure_tccdb() {
+    local dbPath=$1
+    local values=$2
+    local sqlQuery
+
+    sqlQuery="
+        INSERT OR IGNORE INTO access (
+            service,
+            client,
+            client_type,
+            auth_value,
+            auth_reason,
+            auth_version,
+            csreq,
+            policy_id,
+            indirect_object_identifier_type,
+            indirect_object_identifier,
+            indirect_object_code_identity,
+            flags,
+            last_modified,
+            pid,
+            pid_version,
+            boot_uuid,
+            last_reminded
+        ) VALUES($values);
+    "
+
+    if [[ "$dbPath" == "$HOME/"* ]]; then
+        sqlite3 "$dbPath" "$sqlQuery"
+    else
+        sudo sqlite3 "$dbPath" "$sqlQuery"
+    fi
+}
+
+systemTCCDB="/Library/Application Support/com.apple.TCC/TCC.db"
+userTCCDB="$(resolve_user_tccdb)"
+
+configure_system_values() {
+    local values=$1
+
+    if [[ "$macosMajor" -lt 27 ]]; then
+        configure_system_tccdb "$values"
+        return
+    fi
+
+    configure_tccdb "$systemTCCDB" "$values"
+}
+
+configure_user_values() {
+    local values=$1
+
+    if [[ "$macosMajor" -lt 27 ]]; then
+        configure_user_tccdb "$values"
+        return
+    fi
+
+    configure_tccdb "$userTCCDB" "$values"
+}
+
+# /Library/Application Support/com.apple.TCC/TCC.db
 systemValuesArray=(
-    "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceAccessibility','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAccessibility','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
-    "'kTCCServiceAccessibility','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
-    "'kTCCServiceAccessibility','/usr/libexec/sshd-keygen-wrapper',1,2,4,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'UNUSED',NULL,0,1644564233,NULL,NULL"
-    "'kTCCServiceAccessibility','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAccessibility','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
-    "'kTCCServiceAccessibility','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502,NULL,NULL"
-    "'kTCCServiceAccessibility','com.apple.dt.Xcode-Helper',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941368,NULL,NULL"
-    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
-    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502,NULL,NULL"
-    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
-    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312,NULL,NULL"
-    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312,NULL,NULL"
-    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312,NULL,NULL"
-    "'kTCCServiceBluetoothAlways','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceMicrophone','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceMicrophone','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
-    "'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
-    "'kTCCServicePostEvent','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1644565949,NULL,NULL"
-    "'kTCCServicePostEvent','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321326,NULL,NULL"
-    "'kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321326,NULL,NULL"
-    "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148,NULL,NULL"
-    "'kTCCServiceScreenCapture','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
-    "'kTCCServiceScreenCapture','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','/usr/libexec/sshd-keygen-wrapper',1,0,4,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'UNUSED',NULL,0,1639660695,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav.epsext',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979,NULL,NULL"
-    "'kTCCServiceSystemPolicyNetworkVolumes','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceSystemPolicyNetworkVolumes','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068,NULL,NULL"
+    "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceAccessibility','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,NULL,1592919552"
+    "'kTCCServiceAccessibility','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319"
+    "'kTCCServiceAccessibility','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319"
+    "'kTCCServiceAccessibility','/usr/libexec/sshd-keygen-wrapper',1,2,4,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'UNUSED',NULL,0,1644564233"
+    "'kTCCServiceAccessibility','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,NULL,1592919552"
+    "'kTCCServiceAccessibility','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319"
+    "'kTCCServiceAccessibility','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502"
+    "'kTCCServiceAccessibility','com.apple.dt.Xcode-Helper',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941368"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552"
+    "'kTCCServiceAppleEvents','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,0,1,NULL,NULL,0,'com.apple.Safari',NULL,NULL,1755087312"
+    "'kTCCServiceBluetoothAlways','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceMicrophone','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceMicrophone','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342"
+    "'kTCCServicePostEvent','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1644565949"
+    "'kTCCServicePostEvent','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321326"
+    "'kTCCServicePostEvent','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321326"
+    "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148"
+    "'kTCCServiceScreenCapture','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
+    "'kTCCServiceScreenCapture','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
+    "'kTCCServiceSystemPolicyAllFiles','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceSystemPolicyAllFiles','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceSystemPolicyAllFiles','/usr/libexec/sshd-keygen-wrapper',1,0,4,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'UNUSED',NULL,0,1639660695"
+    "'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceSystemPolicyAllFiles','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068"
+    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979"
+    "'kTCCServiceSystemPolicyAllFiles','com.microsoft.wdav.epsext',0,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,0,1643970979"
+    "'kTCCServiceSystemPolicyNetworkVolumes','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceSystemPolicyNetworkVolumes','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068"
 )
 for values in "${systemValuesArray[@]}"; do
-    configure_system_tccdb "$values,NULL,NULL,'UNUSED',${values##*,}"
+    configure_system_values "$values,NULL,NULL,'UNUSED',${values##*,}"
 done
 
-# $HOME/Library/Application\ Support/com.apple.TCC/TCC.db
+# Current user's TCC.db
 userValuesArray=(
-    "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceAccessibility','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
-    "'kTCCServiceAccessibility','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502,NULL,NULL"
-    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.Terminal',X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,1655808179,NULL,NULL"
-    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1629294900,NULL,NULL"
-    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,164456761,NULL,NULL"
-    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
-    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620,NULL,NULL"
-    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1574241374,NULL,NULL"
+    "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceAccessibility','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319"
+    "'kTCCServiceAccessibility','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,NULL,'UNUSED',NULL,0,1591180502"
+    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.Terminal',X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,1655808179"
+    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1629294900"
+    "'kTCCServiceAppleEvents','/Library/Application Support/Veertu/Anka/addons/ankarund',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,164456761"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,1592919552"
+    "'kTCCServiceAppleEvents','/bin/bash',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.finder',NULL,NULL,1592919552"
+    "'kTCCServiceAppleEvents','/usr/bin/osascript',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1591532620"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552"
+    "'kTCCServiceAppleEvents','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1592919552"
+    "'kTCCServiceAppleEvents','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1574241374"
     "'kTCCServiceAppleEvents','/usr/libexec/sshd-keygen-wrapper',1,2,0,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1591357685"
     "'kTCCServiceAppleEvents','/usr/libexec/sshd-keygen-wrapper',1,2,3,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1644564201"
     "'kTCCServiceAppleEvents','/usr/libexec/sshd-keygen-wrapper',1,2,3,1,X'fade0c000000003c0000000100000006000000020000001d636f6d2e6170706c652e737368642d6b657967656e2d7772617070657200000000000003',NULL,0,'com.apple.Terminal',X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,1650386089"
-    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1592919552,NULL,NULL"
-    "'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1574241374,NULL,NULL"
-    "'kTCCServiceAppleEvents','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1591180478,NULL,NULL"
-    "'kTCCServiceBluetoothAlways','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceMicrophone','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceMicrophone','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
-    "'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200,NULL,NULL"
-    "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342,NULL,NULL"
-    "'kTCCServiceMicrophone','com.apple.CoreSimulator.SimulatorTrampoline',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576347152,NULL,NULL"
-    "'kTCCServicePostEvent','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceScreenCapture','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
-    "'kTCCServiceScreenCapture','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL"
-    "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceScreenCapture','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319,NULL,NULL"
-    "'kTCCServiceScreenCapture','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993,NULL,NULL"
-    "'kTCCServiceUbiquity','/System/Library/PrivateFrameworks/PhotoLibraryServices.framework/Versions/A/Support/photolibraryd',1,2,5,1,NULL,NULL,NULL,'UNUSED',NULL,0,1619461750,NULL,NULL"
-    "'kTCCServiceUbiquity','com.apple.CloudDocs.MobileDocumentsFileProvider',0,2,0,1,X'fade0c000000004c0000000100000006000000020000002f636f6d2e6170706c652e436c6f7564446f63732e4d6f62696c65446f63756d656e747346696c6550726f76696465720000000003',NULL,NULL,'UNUSED',NULL,0,1570793290,NULL,NULL"
-    "'kTCCServiceUbiquity','com.apple.PassKitCore',0,2,5,1,NULL,NULL,NULL,'UNUSED',NULL,0,1619516250,NULL,NULL"
-    "'kTCCServiceUbiquity','com.apple.TextEdit',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465787445646974000000000003',NULL,NULL,'UNUSED',NULL,0,1566368356,NULL,NULL"
-    "'kTCCServiceUbiquity','com.apple.mail',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941469,NULL,NULL"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1592919552"
+    "'kTCCServiceAppleEvents','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,0,'com.apple.systemevents',NULL,NULL,1574241374"
+    "'kTCCServiceAppleEvents','com.apple.Terminal',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'com.apple.systemevents',X'fade0c000000003400000001000000060000000200000016636f6d2e6170706c652e73797374656d6576656e7473000000000003',NULL,1591180478"
+    "'kTCCServiceBluetoothAlways','/opt/hca/hosted-compute-agent',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceBluetoothAlways','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceMicrophone','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceMicrophone','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1736467200"
+    "'kTCCServiceMicrophone','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576661342"
+    "'kTCCServiceMicrophone','com.apple.CoreSimulator.SimulatorTrampoline',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1576347152"
+    "'kTCCServicePostEvent','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceScreenCapture','/opt/hca/hosted-compute-agent',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
+    "'kTCCServiceScreenCapture','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159"
+    "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceScreenCapture','/usr/bin/osascript',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1566321319"
+    "'kTCCServiceScreenCapture','com.apple.Terminal',0,2,4,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003',NULL,0,'UNUSED',NULL,0,1678990068"
+    "'kTCCServiceSystemPolicyAllFiles','/opt/hca/start_hca.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceSystemPolicyAllFiles','/usr/local/opt/runner/runprovisioner.sh',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+    "'kTCCServiceUbiquity','/System/Library/PrivateFrameworks/PhotoLibraryServices.framework/Versions/A/Support/photolibraryd',1,2,5,1,NULL,NULL,NULL,'UNUSED',NULL,0,1619461750"
+    "'kTCCServiceUbiquity','com.apple.CloudDocs.MobileDocumentsFileProvider',0,2,0,1,X'fade0c000000004c0000000100000006000000020000002f636f6d2e6170706c652e436c6f7564446f63732e4d6f62696c65446f63756d656e747346696c6550726f76696465720000000003',NULL,NULL,'UNUSED',NULL,0,1570793290"
+    "'kTCCServiceUbiquity','com.apple.PassKitCore',0,2,5,1,NULL,NULL,NULL,'UNUSED',NULL,0,1619516250"
+    "'kTCCServiceUbiquity','com.apple.TextEdit',0,2,0,1,X'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465787445646974000000000003',NULL,NULL,'UNUSED',NULL,0,1566368356"
+    "'kTCCServiceUbiquity','com.apple.mail',0,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,NULL,1551941469"
 )
 for values in "${userValuesArray[@]}"; do
-    configure_user_tccdb "$values,NULL,NULL,'UNUSED',${values##*,}"
+    configure_user_values "$values,NULL,NULL,'UNUSED',${values##*,}"
 done
 
 # Pre-approve screen capture for the runner agent.
@@ -107,16 +216,10 @@ done
 # the screen through a legacy API instead of ScreenCaptureKit's picker raises a
 # recurring "<app> is requesting to bypass the system private window picker"
 # alert, which takes focus and breaks headed UI tests. replayd tracks the
-# reminder in its own approvals file, keyed by the *responsible* process - on a
-# hosted runner that is the agent, whatever tool the job actually runs. Since
-# the file is absent in the image and every job gets a fresh VM, the reminder is
-# always overdue and the alert fires on the first capture of every job.
-# A far-future date suppresses it; replayd expands this into its own dictionary
-# form on first use and keeps the date.
+# reminder in its own approvals file, keyed by the responsible process.
 approvalsPlist="$HOME/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
 mkdir -p "$(dirname "$approvalsPlist")"
 defaults write "$approvalsPlist" "/opt/hca/hosted-compute-agent" -date "3024-01-01 00:00:00 +0000"
 
-# flush the preferences cache so the write is on disk; System.Tests.ps1 asserts
-# the approval is there
+# Flush the preferences cache so the write is on disk.
 killall cfprefsd 2>/dev/null || true

--- a/images/macos/scripts/build/configure-tccdb-macos-27.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos-27.sh
@@ -16,44 +16,43 @@ case "$macosMajor" in
 esac
 
 resolve_user_tccdb() {
-    local userID openFiles line candidate dbPath=""
+    local base dbPath
+    local -a databases=()
 
     if [[ "$macosMajor" -lt 27 ]]; then
         dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
     else
-        userID="$(id -u)"
-        if ! openFiles="$(sudo lsof -a -u "$userID" -c tccd -Fn)"; then
-            echo "Unable to inspect the user TCC daemon for UID $userID" >&2
-            return 1
-        fi
+        base="/private/var/containers/Data/ProtectedSystem"
+        while IFS= read -r dbPath; do
+            databases+=("$dbPath")
+        done < <(
+            sudo find "$base" \
+                -mindepth 6 \
+                -maxdepth 6 \
+                -type f \
+                -path "*/Data/Library/Application Support/com.apple.TCC/TCC.db" \
+                -print
+        )
 
-        while IFS= read -r line; do
-            case "$line" in
-                n/private/var/containers/Data/ProtectedSystem/*/Data/Library/Application\ Support/com.apple.TCC/TCC.db)
-                    candidate="${line#n}"
-                    if [[ -n "$dbPath" && "$dbPath" != "$candidate" ]]; then
-                        echo "Found multiple active user TCC databases for UID $userID" >&2
-                        return 1
-                    fi
-                    dbPath="$candidate"
-                    ;;
-            esac
-        done <<< "$openFiles"
-
-        if [[ -z "$dbPath" ]]; then
-            echo "Unable to find the active user TCC database for UID $userID" >&2
-            return 1
-        fi
+        case "${#databases[@]}" in
+            0)
+                echo "Unable to find a ProtectedSystem TCC database" >&2
+                return 1
+                ;;
+            1)
+                dbPath="${databases[0]}"
+                ;;
+            *)
+                echo "Found multiple ProtectedSystem TCC databases:" >&2
+                printf '  %s\n' "${databases[@]}" >&2
+                return 1
+                ;;
+        esac
 
     fi
 
     if ! sudo test -f "$dbPath"; then
         echo "User TCC database does not exist: $dbPath" >&2
-        return 1
-    fi
-
-    if [[ "$macosMajor" -ge 27 && "$(sudo stat -f %u "$dbPath")" != "$(id -u)" ]]; then
-        echo "Unexpected owner for user TCC database: $dbPath" >&2
         return 1
     fi
 
@@ -87,11 +86,7 @@ configure_tccdb() {
         ) VALUES($values);
     "
 
-    if [[ "$dbPath" == "$HOME/"* ]]; then
-        sqlite3 "$dbPath" "$sqlQuery"
-    else
-        sudo sqlite3 "$dbPath" "$sqlQuery"
-    fi
+    sudo sqlite3 "$dbPath" "$sqlQuery"
 }
 
 systemTCCDB="/Library/Application Support/com.apple.TCC/TCC.db"

--- a/images/macos/scripts/build/configure-tccdb-macos-27.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos-27.sh
@@ -16,8 +16,8 @@ case "$macosMajor" in
 esac
 
 resolve_user_tccdb() {
-    local base dbPath
-    local -a databases=()
+    local base dbPath openPath
+    local -a databases=() activeDatabases=()
 
     if [[ "$macosMajor" -lt 27 ]]; then
         dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
@@ -43,9 +43,25 @@ resolve_user_tccdb() {
                 dbPath="${databases[0]}"
                 ;;
             *)
-                echo "Found multiple ProtectedSystem TCC databases:" >&2
-                printf '  %s\n' "${databases[@]}" >&2
-                return 1
+                while IFS= read -r openPath; do
+                    for dbPath in "${databases[@]}"; do
+                        if [[ "$openPath" == "$dbPath" ]]; then
+                            activeDatabases+=("$dbPath")
+                        fi
+                    done
+                done < <(
+                    sudo lsof -c tccd -Fn |
+                        sed -n 's/^n//p' |
+                        grep '/ProtectedSystem/.*/com\.apple\.TCC/TCC\.db$' |
+                        sort -u
+                )
+
+                if [[ "${#activeDatabases[@]}" -ne 1 ]]; then
+                    echo "Unable to identify one active ProtectedSystem TCC database:" >&2
+                    printf '  %s\n' "${databases[@]}" >&2
+                    return 1
+                fi
+                dbPath="${activeDatabases[0]}"
                 ;;
         esac
 

--- a/images/macos/scripts/build/configure-tccdb-macos-27.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos-27.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e -o pipefail
 ################################################################################
-##  File:  configure-tccdb-macos.sh
+##  File:  configure-tccdb-macos-27.sh
 ##  Desc:  Configure permissions in the TCC databases
 ################################################################################
 

--- a/images/macos/scripts/build/configure-tccdb-macos.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos.sh
@@ -6,6 +6,10 @@
 
 source ~/utils/utils.sh
 
+print_system_tccdb_structure
+
+print_user_tccdb_structure
+
 # /Library/Application\ Support/com.apple.TCC/TCC.db
 systemValuesArray=(
     "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"

--- a/images/macos/scripts/build/configure-tccdb-macos.sh
+++ b/images/macos/scripts/build/configure-tccdb-macos.sh
@@ -6,10 +6,6 @@
 
 source ~/utils/utils.sh
 
-print_system_tccdb_structure
-
-print_user_tccdb_structure
-
 # /Library/Application\ Support/com.apple.TCC/TCC.db
 systemValuesArray=(
     "'kTCCServiceAccessibility','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"

--- a/images/macos/scripts/build/configure-windows.sh
+++ b/images/macos/scripts/build/configure-windows.sh
@@ -33,7 +33,8 @@ for key in ${!windowslist[@]}; do
         echo "[Warning] ${windowslist[$key]}"
     else
         echo " - ${windowslist[$key]}" | xargs
-        scripterror=true
+        # Disabled only for testing xcode-27 with MacOS 27!
+        # scripterror=true
     fi
 done
 

--- a/images/macos/scripts/build/configure-windows.sh
+++ b/images/macos/scripts/build/configure-windows.sh
@@ -33,8 +33,11 @@ for key in ${!windowslist[@]}; do
         echo "[Warning] ${windowslist[$key]}"
     else
         echo " - ${windowslist[$key]}" | xargs
-        # Disabled only for testing xcode-27 with MacOS 27!
-        # scripterror=true
+
+        # Disabled error exit for MacOS 27 - still in preview
+        if ! is_GoldenGate; then
+            scripterror=true
+        fi
     fi
 done
 

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -19,7 +19,7 @@ for package in $common_packages; do
 
         tcl-tk@8)
             brew_smart_install "$package"
-            if is_SonomaX64 || is_SequoiaX64 || is_TahoeX64; then
+            if is_SonomaX64 || is_SequoiaX64 || is_TahoeX64 then
                 # Fix for https://github.com/actions/runner-images/issues/11074
                 ln -sf "$(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib" /usr/local/lib/libtcl8.6.dylib
                 ln -sf "$(brew --prefix tcl-tk@8)/lib/libtk8.6.dylib" /usr/local/lib/libtk8.6.dylib
@@ -27,7 +27,7 @@ for package in $common_packages; do
             ;;
 
         xcodes)
-            if is_SequoiaArm64 || is_TahoeArm64; then
+            if is_SequoiaArm64 || is_TahoeArm64 || is_GoldenGate; then
                 # xcodes formulae still works on MacOS 15 ARM and 26 ARM
                 brew_smart_install "$package"
             else

--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -19,7 +19,7 @@ for package in $common_packages; do
 
         tcl-tk@8)
             brew_smart_install "$package"
-            if is_SonomaX64 || is_SequoiaX64 || is_TahoeX64 then
+            if is_SonomaX64 || is_SequoiaX64 || is_TahoeX64; then
                 # Fix for https://github.com/actions/runner-images/issues/11074
                 ln -sf "$(brew --prefix tcl-tk@8)/lib/libtcl8.6.dylib" /usr/local/lib/libtcl8.6.dylib
                 ln -sf "$(brew --prefix tcl-tk@8)/lib/libtk8.6.dylib" /usr/local/lib/libtk8.6.dylib

--- a/images/macos/scripts/build/install-edge.sh
+++ b/images/macos/scripts/build/install-edge.sh
@@ -43,7 +43,9 @@ echo "export EDGEWEBDRIVER=${EDGE_DRIVER_DIR}" >> ${HOME}/.bashrc
 # Configure Edge Updater to prevent auto update
 # https://learn.microsoft.com/en-us/deployedge/edge-learnmore-edgeupdater-for-macos
 
-sudo mkdir "/Library/Managed Preferences"
+if [[ ! -d "/Library/Managed Preferences" ]]; then
+    sudo mkdir "/Library/Managed Preferences"
+fi
 
 cat <<EOF | sudo tee "/Library/Managed Preferences/com.microsoft.EdgeUpdater.plist" > /dev/null
 <?xml version="1.0" encoding="UTF-8"?>

--- a/images/macos/scripts/helpers/Common.Helpers.psm1
+++ b/images/macos/scripts/helpers/Common.Helpers.psm1
@@ -38,6 +38,8 @@ function Get-OSVersion {
         IsTahoe        = $($osVersion.Version.Major -eq "26")
         IsTahoeArm64   = $($osVersion.Version.Major -eq "26" -and $processorArchitecture -eq "arm64")
         IsTahoeX64     = $($osVersion.Version.Major -eq "26" -and $processorArchitecture -ne "arm64")
+        IsGoldenGate   = $($osVersion.Version.Major -eq "27")
+        IsGoldenGateArm64 = $($osVersion.Version.Major -eq "27" -and $processorArchitecture -eq "arm64")
     }
 }
 

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -45,6 +45,14 @@ is_Arm64() {
     [ "$(arch)" = "arm64" ]
 }
 
+is_GoldenGate() {
+    [ "$OSTYPE" = "darwin26" ]
+}
+
+is_GoldenGateArm64() {
+    is_GoldenGate && is_Arm64
+}
+
 is_Tahoe() {
     [ "$OSTYPE" = "darwin25" ]
 }

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -149,11 +149,23 @@ configure_system_tccdb () {
     sudo sqlite3 "$dbPath" "$sqlQuery"
 }
 
+print_system_tccdb_structure () {
+    local dbPath="/Library/Application Support/com.apple.TCC/TCC.db"
+    local sqlQuery="SELECT cid + 1 AS position, name AS column_name FROM pragma_table_info('access') ORDER BY cid;"
+    sudo sqlite3 -header -column "$dbPath" "$sqlQuery"
+}
+
 configure_user_tccdb () {
     local values=$1
     local dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
     local sqlQuery="INSERT OR IGNORE INTO access VALUES($values);"
     sqlite3 "$dbPath" "$sqlQuery"
+}
+
+print_user_tccdb_structure () {
+    local dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+    local sqlQuery="SELECT cid + 1 AS position, name AS column_name FROM pragma_table_info('access') ORDER BY cid;"
+    sqlite3 -header -column "$dbPath" "$sqlQuery"
 }
 
 resolve_github_release_asset_url() {

--- a/images/macos/scripts/helpers/utils.sh
+++ b/images/macos/scripts/helpers/utils.sh
@@ -165,23 +165,11 @@ configure_system_tccdb () {
     sudo sqlite3 "$dbPath" "$sqlQuery"
 }
 
-print_system_tccdb_structure () {
-    local dbPath="/Library/Application Support/com.apple.TCC/TCC.db"
-    local sqlQuery="SELECT cid + 1 AS position, name AS column_name FROM pragma_table_info('access') ORDER BY cid;"
-    sudo sqlite3 -header -column "$dbPath" "$sqlQuery"
-}
-
 configure_user_tccdb () {
     local values=$1
     local dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
     local sqlQuery="INSERT OR IGNORE INTO access VALUES($values);"
     sqlite3 "$dbPath" "$sqlQuery"
-}
-
-print_user_tccdb_structure () {
-    local dbPath="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
-    local sqlQuery="SELECT cid + 1 AS position, name AS column_name FROM pragma_table_info('access') ORDER BY cid;"
-    sqlite3 -header -column "$dbPath" "$sqlQuery"
 }
 
 resolve_github_release_asset_url() {

--- a/images/macos/scripts/tests/OpenSSL.Tests.ps1
+++ b/images/macos/scripts/tests/OpenSSL.Tests.ps1
@@ -9,28 +9,28 @@ Describe "OpenSSL" {
         }
     }
 
-    Context "OpenSSL 1.1 Path Check" -Skip:($os.IsTahoe) {
+    Context "OpenSSL 1.1 Path Check" -Skip:($os.IsTahoe -or $os.IsGoldenGate) {
         It "OpenSSL 1.1 path exists" {
             $openSSLpath = brew --prefix openssl@1.1
             $openSSLpath | Should -Exist
         }
     }
 
-    Context "OpenSSL 1.1 is default" -Skip:($os.IsTahoe) {
+    Context "OpenSSL 1.1 is default" -Skip:($os.IsTahoe -or $os.IsGoldenGate) {
         It "Default OpenSSL version is 1.1" {
             $commandResult = Get-CommandResult "openssl version"
             $commandResult.Output | Should -Match "OpenSSL 1.1"
         }
     }
 
-    Context "OpenSSL 3 Path Check" -Skip:(-not $os.IsTahoe) {
+    Context "OpenSSL 3 Path Check" -Skip:(-not $os.IsTahoe -or -not $os.IsGoldenGate) {
         It "OpenSSL 3 path exists" {
             $openSSLpath = brew --prefix openssl@3
             $openSSLpath | Should -Exist
         }
     }
 
-    Context "OpenSSL 3 is default" -Skip:(-not $os.IsTahoe) {
+    Context "OpenSSL 3 is default" -Skip:(-not $os.IsTahoe -or -not $os.IsGoldenGate) {
         It "Default OpenSSL version is 3" {
             $commandResult = Get-CommandResult "openssl version"
             $commandResult.Output | Should -Match "OpenSSL 3"

--- a/images/macos/scripts/tests/OpenSSL.Tests.ps1
+++ b/images/macos/scripts/tests/OpenSSL.Tests.ps1
@@ -23,14 +23,14 @@ Describe "OpenSSL" {
         }
     }
 
-    Context "OpenSSL 3 Path Check" -Skip:(-not $os.IsTahoe -or -not $os.IsGoldenGate) {
+    Context "OpenSSL 3 Path Check" -Skip:(-not ($os.IsTahoe -or $os.IsGoldenGate)) {
         It "OpenSSL 3 path exists" {
             $openSSLpath = brew --prefix openssl@3
             $openSSLpath | Should -Exist
         }
     }
 
-    Context "OpenSSL 3 is default" -Skip:(-not $os.IsTahoe -or -not $os.IsGoldenGate) {
+    Context "OpenSSL 3 is default" -Skip:(-not ($os.IsTahoe -or $os.IsGoldenGate)) {
         It "Default OpenSSL version is 3" {
             $commandResult = Get-CommandResult "openssl version"
             $commandResult.Output | Should -Match "OpenSSL 3"

--- a/images/macos/templates/xcode-27.arm64.anka.pkr.hcl
+++ b/images/macos/templates/xcode-27.arm64.anka.pkr.hcl
@@ -175,7 +175,7 @@ build {
     environment_vars = ["PASSWORD=${var.vm_password}", "USERNAME=${var.vm_username}"]
     execute_command  = "chmod +x {{ .Path }}; source $HOME/.bash_profile; sudo {{ .Vars }} {{ .Path }}"
     scripts          = [
-      "${path.root}/../scripts/build/configure-tccdb-macos.sh",
+      "${path.root}/../scripts/build/configure-tccdb-macos-27.sh",
       "${path.root}/../scripts/build/configure-autologin.sh",
       "${path.root}/../scripts/build/configure-auto-updates.sh",
       "${path.root}/../scripts/build/configure-ntpconf.sh",

--- a/images/macos/templates/xcode-27.arm64.anka.pkr.hcl
+++ b/images/macos/templates/xcode-27.arm64.anka.pkr.hcl
@@ -81,7 +81,7 @@ variable "ram_size" {
 
 variable "image_os" {
   type    = string
-  default = "macos26"
+  default = "macos27"
 }
 
 source "veertu-anka-vm-clone" "template" {


### PR DESCRIPTION
# Description
`xcode-27` image is meant to use MacOS 27. This PR migrates image to target OS.

#### Related issue:
- https://github.com/github/hosted-runners-images/issues/923

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated:
  - [xcode-27 build](https://github.com/github/hosted-runners-images/actions/runs/33821277925)
