### PR TITLE
[Ubuntu] Improve Ubuntu image performance

### DIFF
--- a/images/ubuntu/scripts/build/configure-dpkg.sh
+++ b/images/ubuntu/scripts/build/configure-dpkg.sh
@@ -18,10 +18,13 @@ set_etc_environment_variable "DEBIAN_FRONTEND" "noninteractive"
 
 # dpkg can be instructed not to ask for confirmation
 # when replacing a configuration file (with the --force-confdef --force-confold options)
+# --force-unsafe-io drops the fsync calls dpkg makes while unpacking packages. Runner VMs are
+# ephemeral, so trading crash consistency for faster package installation is acceptable here
 cat <<EOF >> /etc/apt/apt.conf.d/10dpkg-options
 Dpkg::Options {
   "--force-confdef";
   "--force-confold";
+  "--force-unsafe-io";
 }
 EOF
 

--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -63,6 +63,21 @@ if ! is_ubuntu22; then
     echo 'ACTION=="add|change", KERNEL=="sd*|nvme*n*", ATTR{queue/read_ahead_kb}="128"' | tee "$readahead_rule"
 fi
 
+# Relax root filesystem durability guarantees to speed up I/O heavy workloads. Runner VMs are
+# ephemeral, so losing recent writes on an unclean shutdown is acceptable.
+# data= and journal_async_commit can only be set on the initial mount performed by the initramfs,
+# so they have to be passed through rootflags on the kernel command line rather than through fstab.
+root_fs_type=$(findmnt --noheadings --first-only --output FSTYPE --target /)
+if [[ "$root_fs_type" != "ext4" ]]; then
+    echo "Expected an ext4 root filesystem but found '${root_fs_type}', refusing to set ext4 rootflags"
+    exit 1
+fi
+
+grub_dropin='/etc/default/grub.d/99-runner-performance.cfg'
+mkdir -p "$(dirname "$grub_dropin")"
+echo 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT rootflags=nobarrier,data=writeback,journal_async_commit,commit=30"' | tee "$grub_dropin"
+update-grub
+
 # Create symlink for tests running
 chmod +x $HELPER_SCRIPTS/invoke-tests.sh
 ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -45,3 +45,28 @@ Describe "ReadAhead udev rule" -Skip:(Test-IsUbuntu22) {
         }
     }
 }
+
+Describe "Root filesystem performance options" {
+    It "GRUB drop-in sets the root filesystem mount options" {
+        $content = Get-Content "/etc/default/grub.d/99-runner-performance.cfg" -Raw
+        $content | Should -Match "rootflags=nobarrier,data=writeback,journal_async_commit,commit=30"
+    }
+
+    It "Kernel command line contains the root filesystem mount options" {
+        $cmdline = & cat /proc/cmdline
+        $cmdline | Should -Match "rootflags=nobarrier,data=writeback,journal_async_commit,commit=30"
+    }
+
+    It "Root filesystem is mounted with the relaxed durability options" {
+        $mountOptions = (findmnt --noheadings --first-only --output OPTIONS --target /) -split ","
+        $mountOptions | Should -Contain "data=writeback"
+        $mountOptions | Should -Contain "commit=30"
+    }
+}
+
+Describe "Dpkg options" {
+    It "Package unpacking is configured with --force-unsafe-io" {
+        $dpkgOptions = (apt-config dump "Dpkg::Options") -join "`n"
+        $dpkgOptions | Should -Match "--force-unsafe-io"
+    }
+}


### PR DESCRIPTION
# Description

This is an improvement. It applies two performance tweaks to the Ubuntu images.

- Tell apt to pass `--force-unsafe-io` to dpkg, so dpkg skips the fsync calls it normally makes while unpacking packages 
- Mount the root filesystem with `rootflags=nobarrier,data=writeback,journal_async_commit,commit=30`, which is added to the kernel command line through a drop-in file in `/etc/default/grub.d`. It has to go on the kernel command line rather than in fstab, because `data=` and `journal_async_commit` can only be set on the very first mount, and that mount is done by the initramfs

Both changes trade some crash consistency for speed, which is a reasonable deal here since runner VMs are ephemeral and are thrown away after the job finishes.

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated