### PR TITLE
[MacOS] Pin gmp to the last bottled revision on Intel macOS images

### DIFF
--- a/images/macos/scripts/build/install-common-utils.sh
+++ b/images/macos/scripts/build/install-common-utils.sh
@@ -6,6 +6,16 @@
 
 source ~/utils/utils.sh
 
+# homebrew-core dropped the Intel bottles for gmp on 2026-09-02, and gmplib.org blocks
+# GitHub server IPs so the source build cannot fetch the tarball. Install the last bottled
+# revision before gnupg pulls gmp in as a dependency.
+if ! is_Arm64; then
+    COMMIT=f97a5a6fd3dee66c7f015608b82ad047a29e2c9b
+    FILE_NAME="g/gmp.rb"
+    FORMULA_NAME="gmp"
+    brew_install_pinned_formula "$FORMULA_NAME" "$FILE_NAME" "$COMMIT"
+fi
+
 common_packages=$(get_toolset_value '.brew.common_packages[]')
 for package in $common_packages; do
     echo "Installing $package..."


### PR DESCRIPTION
# Description

This is a bug fix. 

macOS x64 builds have been failing since homebrew-core stopped publishing Intel bottles for gmp on 2026-09-02. Homebrew then tries to build gmp from source, which fails because gmplib.org blocks GitHub server IPs. gnupg depends on gmp, so the build retries for hours and then dies.

This pins gmp to a homebrew-core commit that still has the Intel bottles, so the image pours a prebuilt binary instead. It is the same approach already used for gnu-tar and swiftformat. Arm64 is unaffected.

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated