### PR TITLE
[Ubuntu] Remove Google Chrome deb822 apt source from the image

### DIFF
--- a/images/ubuntu/scripts/build/install-google-chrome.sh
+++ b/images/ubuntu/scripts/build/install-google-chrome.sh
@@ -40,8 +40,9 @@ chrome_deb_path=$(download_with_retry "$CHROME_DEB_URL")
 apt-get install "$chrome_deb_path" -f
 set_etc_environment_variable "CHROME_BIN" "/usr/bin/google-chrome"
 
-# Remove Google Chrome repo
-rm -f /etc/cron.daily/google-chrome /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.list.save
+# Remove Google Chrome repo. The glob covers the legacy .list and the deb822 .sources layouts.
+# Keep /etc/default/google-chrome: its repo_add_once="false" is what stops the repo coming back.
+rm -f /etc/cron.daily/google-chrome /etc/apt/sources.list.d/google-chrome*
 
 # Parse Google Chrome version
 full_chrome_version=$(google-chrome --product-version)

--- a/images/ubuntu/scripts/tests/Browsers.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Browsers.Tests.ps1
@@ -22,6 +22,10 @@ Describe "Chrome" -Skip:(Test-IsArm64) {
         $chromeDriverMajor = (chromedriver --version).Trim("ChromeDriver ").Split(".")[0]
         $chromeMajor | Should -BeExactly $chromeDriverMajor
     }
+
+    It "Google Chrome apt repository is not configured" {
+        "/etc/apt/sources.list.d/google-chrome*" | Should -Not -Exist
+    }
 }
 
 Describe "Edge" -Skip:(Test-IsArm64) {


### PR DESCRIPTION
# Description
This is a bug fix. 

The Ubuntu x64 images ship with Google's Chrome apt repository still enabled, so `apt-get update` on a runner fails whenever Google's published index is briefly inconsistent. That happened on 2026-09-09 and broke workflows that run `apt-get update`, directly or through something like `playwright install --with-deps`.

The Chrome `.deb` used to register the repo as `google-chrome.list`, which this script removed. It now writes `google-chrome.sources` instead, and the old `rm -f` no longer matched it. The removal now uses a `google-chrome*` glob, so it covers both layouts and any future rename, matching what the Microsoft Edge and Azure CLI scripts already do. `/etc/default/google-chrome` is left in place on purpose, since the `repo_add_once="false"` marker it holds is what stops the file being recreated.

A test in `Browsers.Tests.ps1` asserts no `google-chrome*` source file survives, so this cannot regress silently again.

No breaking changes. Chrome, chromedriver and Chromium do not come from that repo, and Arm64 images do not install Chrome at all.

#### Related issue:
https://github.com/actions/runner-images/issues/14708

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
