### PR TITLE
[Ubuntu] Disable the DEP-11/AppStream apt index target

### DIFF
--- a/images/ubuntu-slim/scripts/build/configure-apt.sh
+++ b/images/ubuntu-slim/scripts/build/configure-apt.sh
@@ -27,6 +27,11 @@ echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 # apt-cache policy pkgname
 echo 'APT::Get::Always-Include-Phased-Updates "true";' > /etc/apt/apt.conf.d/99-phased-updates
 
+# DEP-11/AppStream is desktop software-catalog metadata with no CI use. Skipping it drops 15 of the 51
+# index items and 7.6 MB from every apt-get update.
+# Sorts after appstream's own /etc/apt/apt.conf.d/50appstream, so it wins.
+echo 'Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";' > /etc/apt/apt.conf.d/90-index-targets
+
 # Fix bad proxy and http headers settings
 cat <<EOF >> /etc/apt/apt.conf.d/99bad_proxy
 Acquire::http::Pipeline-Depth 0;

--- a/images/ubuntu-slim/test.sh
+++ b/images/ubuntu-slim/test.sh
@@ -99,3 +99,6 @@ run_test "docker buildx is installed" docker buildx version
 
 # Quick check: ensure the imagedata JSON file was created during image build
 run_test "imagedata JSON file exists" test -f /imagegeneration/imagedata.json
+
+# Assert the effective value, since a setting written under a key apt does not read is silently ignored.
+run_test "apt DEP-11 index target is disabled" bash -c 'apt-config dump Acquire::IndexTargets::deb::DEP-11::DefaultEnabled | grep -Fxq "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled \"false\";"'

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -27,6 +27,11 @@ echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 # apt-cache policy pkgname
 echo 'APT::Get::Always-Include-Phased-Updates "true";' > /etc/apt/apt.conf.d/99-phased-updates
 
+# DEP-11/AppStream is desktop software-catalog metadata with no CI use. Skipping it drops 15 of the 51
+# index items and 7.6 MB from every apt-get update.
+# Sorts after appstream's own /etc/apt/apt.conf.d/50appstream, so it wins.
+echo 'Acquire::IndexTargets::deb::DEP-11::DefaultEnabled "false";' > /etc/apt/apt.conf.d/90-index-targets
+
 # Fix bad proxy and http headers settings
 cat <<EOF >> /etc/apt/apt.conf.d/99bad_proxy
 Acquire::http::Pipeline-Depth 0;

--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -24,3 +24,12 @@ Describe "Apt" {
         (Get-Command -Name $toolName).CommandType | Should -BeExactly "Application"
     }
 }
+
+Describe "Apt index targets" {
+    # Asserts the effective value, because a setting written under a key apt does not read is silently
+    # ignored and leaves the image on apt's defaults.
+    It "DEP-11 is disabled" {
+        $setting = "Acquire::IndexTargets::deb::DEP-11::DefaultEnabled"
+        (Get-CommandResult "apt-config dump $setting").Output | Should -BeExactly "$setting `"false`";"
+    }
+}


### PR DESCRIPTION
# Description
- Disable the DEP-11/AppStream apt index target on `ubuntu` and `ubuntu-slim`.
- Assert the effective value in `Apt.Tests.ps1` and `ubuntu-slim/test.sh`.

Split out of #14643 so it can be validated separately from the retry and timeout work.

### Reasoning:
DEP-11 is metadata for graphical software centres. A CI runner never reads it, but we download it on every `apt-get update`, where it is 15 of the roughly 51 index items and 7.6 MB. It is enabled only because `appstream` registers the target without `DefaultEnabled`, unlike its own icon targets.

It also helps with the stalls in #14594. Time-to-failover scales with the number of index items, since the mirror method restarts from `priority:1` for every one of them, so this takes the worst case from about 26 minutes to about 19 on top of #14643. It is also the only part of this work that helps when a mirror is slow rather than dead, since timeouts cannot bound that case and fetching less is the only lever left.

The setting lives in `/etc/apt/apt.conf.d/90-index-targets`, which sorts after `50appstream` so it wins.

#### Related issue:
https://github.com/actions/runner-images/issues/14594

#### Split from:
- https://github.com/actions/runner-images/pull/14643

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated